### PR TITLE
Branch C — ASR 簡→繁 + Context Reset (issue 6 + 7)

### DIFF
--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -11,6 +11,7 @@ from typing import Any
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+from std_msgs.msg import Empty
 from std_msgs.msg import String
 
 from .pending_confirm import (
@@ -171,6 +172,9 @@ class BrainNode(Node):
             String, "/brain/skill_request", self._on_skill_request, _RELIABLE_10
         )
         self.create_subscription(String, "/brain/skill_result", self._on_skill_result, _RELIABLE_10)
+
+        # P1-2: context reset — cancel PendingConfirm on page refresh / new-conversation
+        self.create_subscription(Empty, "/brain/reset_context", self._on_reset_context, _RELIABLE_10)
 
         self._brain_state_timer = self.create_timer(0.5, self._publish_brain_state)
         self._dedup_gc_timer = self.create_timer(2.0, self._gc_dedup)
@@ -885,6 +889,17 @@ class BrainNode(Node):
                     if status == SkillResultStatus.BLOCKED_BY_SAFETY.value:
                         plan["accepted"] = False
                     break
+
+    def _on_reset_context(self, msg: Empty) -> None:  # noqa: ARG002
+        """P1-2: Cancel PendingConfirm when browser requests a context reset.
+
+        Active plans and attention state are preserved — we only cancel any
+        in-progress confirmation flow that the user is walking away from.
+        """
+        with self._lock:
+            if self._pending_confirm.state == ConfirmState.PENDING:
+                self._pending_confirm.cancel(reason="page_reset")
+                self.get_logger().info("PendingConfirm cancelled by /brain/reset_context")
 
     def _publish_brain_state(self) -> None:
         snap = self._world.snapshot()

--- a/pawai-studio/frontend/components/chat/chat-panel.tsx
+++ b/pawai-studio/frontend/components/chat/chat-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
-import { ArrowUp, Mic, PawPrint, Sparkles, Square } from "lucide-react";
+import { ArrowUp, Mic, PawPrint, RotateCcw, Sparkles, Square } from "lucide-react";
 import { useStateStore } from "@/stores/state-store";
 import { useAudioRecorder } from "@/hooks/use-audio-recorder";
 import { AudioVisualizer } from "@/components/chat/audio-visualizer";
@@ -182,6 +182,18 @@ export function ChatPanel() {
       }, 8000);
     }
   }, [voiceResult]);
+
+  // P1-2: New conversation — clear local messages + POST /api/reset to clear global context.
+  const handleNewConversation = useCallback(async () => {
+    const ok = window.confirm(
+      "將清除目前所有對話記憶，包括其他開啟的 Studio 視窗。確定？"
+    );
+    if (!ok) return;
+    await fetch(`${getGatewayHttpUrl()}/api/reset`, { method: "POST" });
+    setMessages([]);
+    useStateStore.setState({ ttsMessages: [] });
+    lastSeenTtsIdRef.current = null;
+  }, []);
 
   // Auto-resize textarea.
   const adjustTextareaHeight = useCallback(() => {
@@ -372,7 +384,19 @@ export function ChatPanel() {
   // Conversation view — bubble stream + bottom composer.
   return (
     <div className="flex h-full flex-col">
-      <BrainStatusPill />
+      <div className="flex items-center justify-between">
+        <BrainStatusPill />
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={handleNewConversation}
+          title="重置全局對話記憶（所有 device 共用）"
+          aria-label="新對話"
+          className="mr-2 h-8 w-8 text-muted-foreground hover:text-foreground"
+        >
+          <RotateCcw className="h-4 w-4" />
+        </Button>
+      </div>
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto flex max-w-[var(--chat-max-w)] flex-col gap-3 px-4 md:px-8 py-6">
           {messages.map((msg) => {

--- a/pawai-studio/frontend/hooks/use-event-stream.ts
+++ b/pawai-studio/frontend/hooks/use-event-stream.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useWebSocket } from "@/hooks/use-websocket";
 import { useEventStore } from "@/stores/event-store";
 import { useStateStore } from "@/stores/state-store";
@@ -148,6 +148,17 @@ export function useEventStream(): UseEventStreamResult {
   );
 
   const { isConnected } = useWebSocket({ onMessage });
+
+  // P1-2: F5 hybrid auto-reset (dev-only — off by default in production)
+  // beforeunload sets a sessionStorage flag so that when the page reconnects
+  // within 5s we know it was a refresh and can auto-reset context.
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      sessionStorage.setItem("paw_refresh_at", Date.now().toString());
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []);
 
   return { isConnected };
 }

--- a/pawai-studio/frontend/hooks/use-websocket.ts
+++ b/pawai-studio/frontend/hooks/use-websocket.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { PawAIEvent } from "@/contracts/types";
-import { getGatewayWsUrl } from "@/lib/gateway-url";
+import { getGatewayHttpUrl, getGatewayWsUrl } from "@/lib/gateway-url";
 
 // Runtime fallback: env → same-origin hostname:8080 → localhost:8080
 // Auto-select ws/wss based on page protocol
@@ -50,6 +50,19 @@ export function useWebSocket({ onMessage }: UseWebSocketOptions): UseWebSocketRe
         return;
       }
       setIsConnected(true);
+
+      // P1-2: F5 auto-reset (dev-only). Demo default: OFF.
+      // Recommended path is the manual 'new conversation' button in ChatPanel.
+      // Enable by setting NEXT_PUBLIC_AUTO_RESET_ON_REFRESH=true in .env.local.
+      if (process.env.NEXT_PUBLIC_AUTO_RESET_ON_REFRESH === "true") {
+        const refreshAt = sessionStorage.getItem("paw_refresh_at");
+        if (refreshAt && Date.now() - parseInt(refreshAt) < 5000) {
+          fetch(`${getGatewayHttpUrl()}/api/reset`, { method: "POST" }).catch(() => {
+            // Best-effort — ignore errors (gateway may not be ready yet)
+          });
+          sessionStorage.removeItem("paw_refresh_at");
+        }
+      }
     };
 
     ws.onmessage = (ev) => {

--- a/pawai-studio/frontend/stores/__tests__/reset-conversation.test.ts
+++ b/pawai-studio/frontend/stores/__tests__/reset-conversation.test.ts
@@ -1,0 +1,68 @@
+/**
+ * P1-2: Unit tests for new-conversation reset behavior.
+ *
+ * Tests the store-level state clearing that handleNewConversation performs
+ * after POST /api/reset succeeds. The fetch call itself is tested at the
+ * gateway integration level; here we only verify state transitions.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { useStateStore } from "../state-store";
+
+describe("P1-2 new-conversation reset", () => {
+  beforeEach(() => {
+    // Reset to clean state before each test
+    useStateStore.setState({ ttsMessages: [] });
+  });
+
+  it("clearing ttsMessages via setState removes all entries", () => {
+    // Populate some messages first (10s apart to bypass rate-limit dedup window)
+    useStateStore.getState().appendTtsMessage({
+      id: "tts-1",
+      text: "你好",
+      timestamp: 1000,
+      origin: "tts",
+    });
+    useStateStore.getState().appendTtsMessage({
+      id: "tts-2",
+      text: "我是 PawAI",
+      timestamp: 12000,
+      origin: "tts",
+    });
+    expect(useStateStore.getState().ttsMessages).toHaveLength(2);
+
+    // Simulate what handleNewConversation does
+    useStateStore.setState({ ttsMessages: [] });
+
+    expect(useStateStore.getState().ttsMessages).toHaveLength(0);
+  });
+
+  it("clearing ttsMessages is idempotent when already empty", () => {
+    useStateStore.setState({ ttsMessages: [] });
+    useStateStore.setState({ ttsMessages: [] });
+    expect(useStateStore.getState().ttsMessages).toHaveLength(0);
+  });
+
+  it("after reset, new messages can still be appended", () => {
+    useStateStore.getState().appendTtsMessage({
+      id: "tts-old",
+      text: "舊訊息",
+      timestamp: 1000,
+      origin: "tts",
+    });
+
+    // Reset
+    useStateStore.setState({ ttsMessages: [] });
+
+    // Should be able to append again
+    useStateStore.getState().appendTtsMessage({
+      id: "tts-new",
+      text: "新訊息",
+      timestamp: 2000,
+      origin: "tts",
+    });
+
+    const msgs = useStateStore.getState().ttsMessages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe("tts-new");
+  });
+});

--- a/pawai-studio/gateway/requirements.txt
+++ b/pawai-studio/gateway/requirements.txt
@@ -1,3 +1,4 @@
 fastapi>=0.104.0
 uvicorn[standard]>=0.24.0
 requests>=2.28.0
+opencc-python-reimplemented>=0.1.0

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -30,7 +30,7 @@ from fastapi.staticfiles import StaticFiles
 import rclpy
 from rclpy.node import Node
 from rclpy.qos import QoSProfile, ReliabilityPolicy, DurabilityPolicy
-from std_msgs.msg import Bool, String
+from std_msgs.msg import Bool, Empty, String
 
 from asr_client import resample_to_wav16k, transcribe
 
@@ -173,6 +173,9 @@ class GatewayNode(Node):
         )
         self.text_input_pub = self.create_publisher(
             String, "/brain/text_input", QOS_EVENT
+        )
+        self._reset_pub = self.create_publisher(
+            Empty, "/brain/reset_context", 10
         )
 
         # Subscribers — ROS2 → browser
@@ -352,6 +355,11 @@ class GatewayNode(Node):
         msg = String()
         msg.data = json.dumps(payload, ensure_ascii=False)
         self.text_input_pub.publish(msg)
+
+    def publish_reset_context(self) -> None:
+        """P1-2: Publish Empty to /brain/reset_context to clear conversation state."""
+        self._reset_pub.publish(Empty())
+        self.get_logger().info("Published reset_context to /brain/reset_context")
 
     def _on_video_frame(self, source: str, msg) -> None:
         """ROS2 Image callback → JPEG encode → broadcast to video clients."""
@@ -558,6 +566,15 @@ async def post_text_input(payload: TextInputPayload):
     }
     node.publish_text_input(msg)
     return {"ok": True, "request_id": request_id}
+
+
+@app.post("/api/reset")
+async def post_reset():
+    """P1-2: Clear conversation context — resets ConversationMemory + cancels PendingConfirm."""
+    if node is None:
+        return {"ok": False, "error": "ros_node_not_ready"}
+    node.publish_reset_context()
+    return {"ok": True}
 
 
 # ── WebSocket: Event Broadcast (ROS2 → Browser) ────────────────

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -47,9 +47,14 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".." / "speech_proc
 from intent_classifier import IntentClassifier
 
 # ── Config ───────────────────────────────────────────────────────
+import os
+
 PORT = 8080
 ASR_URL = "http://127.0.0.1:8001/v1/audio/transcriptions"
 STATIC_DIR = Path(__file__).parent / "static"
+
+# P1-3: ASR 簡→繁 — enable by default; set PAWAI_ENABLE_S2TWP=false to disable
+ENABLE_S2TWP = os.getenv("PAWAI_ENABLE_S2TWP", "true").lower() == "true"
 
 QOS_EVENT = QoSProfile(
     reliability=ReliabilityPolicy.RELIABLE,
@@ -601,6 +606,9 @@ async def ws_text(ws: WebSocket):
             if not text:
                 await ws.send_json({"error": "empty_text", "published": False})
                 continue
+            if ENABLE_S2TWP:
+                from text_normalization import to_traditional_tw
+                text = to_traditional_tw(text)
             session_id = str(uuid.uuid4())[:8]
             started = time.monotonic()
             match = classifier.classify(text)
@@ -659,6 +667,9 @@ async def ws_speech(ws: WebSocket):
                 # 2. ASR
                 asr_result = await asyncio.to_thread(transcribe, wav16k, ASR_URL)
                 text = asr_result["text"].strip()
+                if ENABLE_S2TWP:
+                    from text_normalization import to_traditional_tw
+                    text = to_traditional_tw(text)
                 asr_latency = asr_result["latency_ms"]
                 print(f"[gateway] ASR result: text={text!r} latency={asr_latency}ms", flush=True)
 

--- a/pawai-studio/gateway/test_gateway.py
+++ b/pawai-studio/gateway/test_gateway.py
@@ -266,3 +266,48 @@ class TestPayloadSchema:
             assert field in payload, f"Missing field: {field}"
         assert payload["event_type"] == "intent_recognized"
         assert payload["source"] == "web_bridge"
+
+
+class TestTextNormalizationGateway:
+    """Integration tests for P1-3 s2twp in gateway text_normalization."""
+
+    def test_basic_conversion(self):
+        """「网络」→「網路」 when OpenCC is available."""
+        sys.path.insert(0, str(Path(__file__).parent))
+        try:
+            from opencc import OpenCC  # noqa: F401
+        except ImportError:
+            pytest.skip("opencc not installed")
+        # Reset module state
+        import text_normalization as tn
+        tn._converter = None
+        result = tn.to_traditional_tw("网络")
+        assert result == "網路", f"Expected 網路, got {result!r}"
+
+    def test_empty_passthrough(self):
+        """Empty string returns immediately."""
+        sys.path.insert(0, str(Path(__file__).parent))
+        import text_normalization as tn
+        result = tn.to_traditional_tw("")
+        assert result == ""
+
+    def test_opencc_unavailable_fallback(self):
+        """When OpenCC is absent, original text is returned."""
+        sys.path.insert(0, str(Path(__file__).parent))
+        import text_normalization as tn
+        tn._converter = False
+        result = tn.to_traditional_tw("网络")
+        assert result == "网络"
+        tn._converter = None  # restore for other tests
+
+    def test_convert_error_fallback(self):
+        """When converter.convert() raises, original text is returned."""
+        sys.path.insert(0, str(Path(__file__).parent))
+        from unittest.mock import MagicMock
+        import text_normalization as tn
+        bad = MagicMock()
+        bad.convert.side_effect = RuntimeError("fail")
+        tn._converter = bad
+        result = tn.to_traditional_tw("网络")
+        assert result == "网络"
+        tn._converter = None  # restore

--- a/pawai-studio/gateway/text_normalization.py
+++ b/pawai-studio/gateway/text_normalization.py
@@ -1,0 +1,28 @@
+"""Lazy-import OpenCC s2twp; fallback 原文 on any error."""
+_converter = None
+
+
+def to_traditional_tw(text: str) -> str:
+    """Convert Simplified Chinese to Traditional Chinese (Taiwan variant).
+
+    Uses opencc-python-reimplemented with s2twp.json dictionary.
+    Lazily initialises the converter on first call.
+    Falls back to returning the original text if OpenCC is unavailable or
+    conversion raises an exception.
+    """
+    global _converter
+    if not text:
+        return text
+    if _converter is None:
+        try:
+            from opencc import OpenCC
+            _converter = OpenCC("s2twp.json")
+        except Exception:
+            _converter = False
+            return text
+    if _converter is False:
+        return text
+    try:
+        return _converter.convert(text)
+    except Exception:
+        return text

--- a/pawai_brain/pawai_brain/conversation_graph_node.py
+++ b/pawai_brain/pawai_brain/conversation_graph_node.py
@@ -26,6 +26,7 @@ import rclpy
 from rclpy.node import Node
 from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
 from std_msgs.msg import Bool as BoolMsg
+from std_msgs.msg import Empty
 from std_msgs.msg import String
 
 from .capability.demo_guides_loader import load_demo_guides, load_demo_policy
@@ -221,6 +222,11 @@ class ConversationGraphNode(Node):
         )
         self.create_subscription(
             String, "/brain/skill_result", self._on_skill_result, 10
+        )
+
+        # P1-2: context reset — clear ConversationMemory on page refresh / new-conversation
+        self.create_subscription(
+            Empty, "/brain/reset_context", self._on_reset_context, 10
         )
 
         self._graph = build_graph()
@@ -518,6 +524,11 @@ class ConversationGraphNode(Node):
             "detail": str(payload.get("detail", ""))[:80],
             "ts": time.time(),
         })
+
+    def _on_reset_context(self, msg: Empty) -> None:  # noqa: ARG002
+        """P1-2: Clear ConversationMemory when browser requests a context reset."""
+        self._memory.clear()
+        self.get_logger().info("ConversationMemory cleared by /brain/reset_context")
 
     def _publish_error_trace(self, session_id: str, detail: str) -> None:
         payload = TracePayload(

--- a/scripts/ci/check_topic_contracts.py
+++ b/scripts/ci/check_topic_contracts.py
@@ -132,6 +132,8 @@ INTERNAL_TOPICS = {
     "/state/obstacle/lidar_alive",
     # PawAI Brain MVS (Phase 0+ internal)
     "/brain/chat_candidate",
+    # P1-2 context reset — internal signal, not in frozen public contract
+    "/brain/reset_context",
     # Test observer internal
     "/speech_test_observer/round_meta_req",
     "/speech_test_observer/round_meta_ack",

--- a/speech_processor/setup.py
+++ b/speech_processor/setup.py
@@ -23,6 +23,7 @@ setup(
         "silero-vad",
         "faster-whisper",
         "edge-tts",
+        "opencc-python-reimplemented",
     ],
     zip_safe=True,
     maintainer="Nuralem Abizov",

--- a/speech_processor/speech_processor/stt_intent_node.py
+++ b/speech_processor/speech_processor/stt_intent_node.py
@@ -492,6 +492,7 @@ class SttIntentNode(Node):
         self.declare_parameter("intent_topic", "/intent")
         self.declare_parameter("asr_result_topic", "/asr_result")
         self.declare_parameter("text_input_topic", "/speech/text_input")
+        self.declare_parameter("enable_s2twp", True)
 
         self.declare_parameter("qwen_asr.base_url", "")
         self.declare_parameter("qwen_asr.api_key", "")
@@ -544,6 +545,7 @@ class SttIntentNode(Node):
         self.intent_topic = str(self.get_parameter("intent_topic").value)
         self.asr_result_topic = str(self.get_parameter("asr_result_topic").value)
         self.text_input_topic = str(self.get_parameter("text_input_topic").value)
+        self._enable_s2twp = bool(self.get_parameter("enable_s2twp").value)
 
         self.qwen_base_url = str(self.get_parameter("qwen_asr.base_url").value)
         self.qwen_api_key = str(self.get_parameter("qwen_asr.api_key").value)
@@ -978,6 +980,9 @@ class SttIntentNode(Node):
                 return
 
             transcript = transcript_result.text.strip()
+            if self._enable_s2twp:
+                from speech_processor.text_normalization import to_traditional_tw
+                transcript = to_traditional_tw(transcript)
             self._last_provider = transcript_result.provider
             self._last_transcript = transcript
             self._publish_asr_result(
@@ -1070,6 +1075,9 @@ class SttIntentNode(Node):
         if not text:
             return
 
+        if self._enable_s2twp:
+            from speech_processor.text_normalization import to_traditional_tw
+            text = to_traditional_tw(text)
         session_id = self._new_session_id(prefix="txt")
         self._last_provider = "text_fallback"
         self._last_transcript = text

--- a/speech_processor/speech_processor/text_normalization.py
+++ b/speech_processor/speech_processor/text_normalization.py
@@ -1,0 +1,28 @@
+"""Lazy-import OpenCC s2twp; fallback 原文 on any error."""
+_converter = None
+
+
+def to_traditional_tw(text: str) -> str:
+    """Convert Simplified Chinese to Traditional Chinese (Taiwan variant).
+
+    Uses opencc-python-reimplemented with s2twp.json dictionary.
+    Lazily initialises the converter on first call.
+    Falls back to returning the original text if OpenCC is unavailable or
+    conversion raises an exception.
+    """
+    global _converter
+    if not text:
+        return text
+    if _converter is None:
+        try:
+            from opencc import OpenCC
+            _converter = OpenCC("s2twp.json")
+        except Exception:
+            _converter = False
+            return text
+    if _converter is False:
+        return text
+    try:
+        return _converter.convert(text)
+    except Exception:
+        return text

--- a/speech_processor/test/test_text_normalization.py
+++ b/speech_processor/test/test_text_normalization.py
@@ -1,0 +1,99 @@
+"""Unit tests for speech_processor.text_normalization."""
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _reload_module():
+    """Reload text_normalization so _converter is reset between tests."""
+    mod_name = "speech_processor.text_normalization"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+    # Also reset any cached state on the module if it was imported before
+    import speech_processor.text_normalization as m
+    m._converter = None
+    return m
+
+
+class TestToTraditionalTw:
+    def test_basic_conversion(self):
+        """「网络」→「網路」 (simplified → traditional TW)."""
+        m = _reload_module()
+        try:
+            from opencc import OpenCC  # noqa: F401
+        except ImportError:
+            pytest.skip("opencc not installed")
+        result = m.to_traditional_tw("网络")
+        assert result == "網路", f"Expected 網路, got {result!r}"
+
+    def test_mixed_en_zh(self):
+        """Mixed English + Chinese: English passthrough, Chinese converted."""
+        m = _reload_module()
+        try:
+            from opencc import OpenCC  # noqa: F401
+        except ImportError:
+            pytest.skip("opencc not installed")
+        result = m.to_traditional_tw("Hello 网络")
+        assert "網路" in result
+        assert "Hello" in result
+
+    def test_empty_string(self):
+        """Empty string is returned as-is without calling OpenCC."""
+        m = _reload_module()
+        result = m.to_traditional_tw("")
+        assert result == ""
+
+    def test_none_like_empty(self):
+        """Empty string (falsy) returns immediately."""
+        m = _reload_module()
+        result = m.to_traditional_tw("")
+        assert result == ""
+
+    def test_opencc_import_error_fallback(self):
+        """When OpenCC import fails, return original text unchanged."""
+        m = _reload_module()
+        m._converter = None  # force lazy init
+
+        # Patch builtins.__import__ to simulate ImportError for opencc
+        original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "opencc":
+                raise ImportError("mocked: opencc not available")
+            return original_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            m._converter = None  # ensure fresh lazy init
+            result = m.to_traditional_tw("网络")
+
+        # Fallback: original text returned
+        assert result == "网络"
+
+    def test_converter_false_fallback(self):
+        """When _converter is False (import failed), return text unchanged."""
+        m = _reload_module()
+        m._converter = False
+        result = m.to_traditional_tw("网络")
+        assert result == "网络"
+
+    def test_convert_raises_fallback(self):
+        """When converter.convert() raises, return text unchanged."""
+        m = _reload_module()
+        bad_converter = MagicMock()
+        bad_converter.convert.side_effect = RuntimeError("conversion error")
+        m._converter = bad_converter
+        result = m.to_traditional_tw("网络")
+        assert result == "网络"
+
+    def test_already_traditional(self):
+        """Traditional Chinese passes through without change."""
+        m = _reload_module()
+        try:
+            from opencc import OpenCC  # noqa: F401
+        except ImportError:
+            pytest.skip("opencc not installed")
+        result = m.to_traditional_tw("網路")
+        assert result == "網路"


### PR DESCRIPTION
## Summary

解 issue 6（ASR 簡→繁 OpenCC s2twp）+ issue 7（refresh 重置 context）。

5 commits (C-1 helper × 2 / C-2 dual entry / C-3 reset endpoint+topic / C-4 ChatPanel 新對話按鈕 / C-5 F5 hybrid dev-flag)

## Test
- speech_processor 185 pass + 21 skip（新 8 tests）
- gateway 25 pass + 1 skip（新 4 tests）
- frontend vitest 13 pass / tsc 0 errors

## Notes
- text_normalization helper 兩份（speech_processor + gateway）— Roy 5/9 review 邊界決定
- pre-commit `INTERNAL_TOPICS` 加 `/brain/reset_context`
- F5 dev flag `NEXT_PUBLIC_AUTO_RESET_ON_REFRESH` 預設 false (demo)；手動「新對話」按鈕為主用

🤖 Generated with [Claude Code](https://claude.com/claude-code)