### PR TITLE
fix(tts): issue 1 — threshold + audio tag override + ElevenLabs spike

### DIFF
--- a/docs/pawai-brain/dev-logs/2026-05-XX-elevenlabs-spike-mini.md
+++ b/docs/pawai-brain/dev-logs/2026-05-XX-elevenlabs-spike-mini.md
@@ -1,0 +1,59 @@
+# ElevenLabs Spike-Mini — Voice + Latency Evaluation
+
+> **Run date**: 2026-05-XX (replace XX with actual date)
+> **Operator**: Roy
+> **Goal**: GO/NO-GO decision for ElevenLabs Flash v2.5 in TTS quality lane
+
+## Setup
+
+- API key: `ELEVENLABS_API_KEY=sk_...` (NOT committed)
+- Model: `eleven_flash_v2_5`
+- PAYG balance before: $X.XX
+- Voices tested (replace placeholders in `tools/tts_spike/elevenlabs_mini.py` first):
+
+| name | voice_id | source/notes |
+|---|---|---|
+| MandarinChild_F | `<id>` | Childlike Mandarin female |
+| MandarinYoung_F | `<id>` | Young Chinese female |
+| Bella_or_Hope_multi | `<id>` | Multilingual young female |
+
+## Scores (Roy fills 1-5)
+
+| Voice | Sentence | 雪寶感 | 中文自然度 | 破音/吞字 | 簡體腔 | latency_s |
+|---|---|---|---|---|---|---|
+| MandarinChild_F | short | | | | | |
+| MandarinChild_F | medium | | | | | |
+| MandarinChild_F | long | | | | | |
+| MandarinChild_F | emotional | | | | | |
+| MandarinChild_F | safety | | | | | |
+| MandarinYoung_F | short | | | | | |
+| MandarinYoung_F | medium | | | | | |
+| MandarinYoung_F | long | | | | | |
+| MandarinYoung_F | emotional | | | | | |
+| MandarinYoung_F | safety | | | | | |
+| Bella_or_Hope_multi | short | | | | | |
+| Bella_or_Hope_multi | medium | | | | | |
+| Bella_or_Hope_multi | long | | | | | |
+| Bella_or_Hope_multi | emotional | | | | | |
+| Bella_or_Hope_multi | safety | | | | | |
+
+## Latency summary (auto from _results.json)
+
+| voice | short avg | medium avg | long avg |
+|---|---|---|---|
+| | | | |
+
+## PAYG quota
+
+- chars sent: ___ / approx 50k available
+- balance after: $X.XX
+
+## Decision
+
+- [ ] **GO** — winning voice: ___ (voice_id: ___)
+   - Reason: 音色 X/5, 中文 X/5, latency ___s short / ___s long, no defects
+   - Next: spike-real branch (Megaphone integration)
+- [ ] **NO-GO** — failing criterion: ___
+   - Next: spike Gemini native SDK (P2-2-fallback)
+
+## Notes

--- a/speech_processor/speech_processor/tts_node.py
+++ b/speech_processor/speech_processor/tts_node.py
@@ -711,10 +711,17 @@ SAFETY_KEYWORDS: re.Pattern = re.compile(
     re.IGNORECASE,
 )
 
-FAST_LANE_THRESHOLD: int = 30  # effective char/word units
+FAST_LANE_THRESHOLD: int = 12  # effective char/word units (5/9 review: was 30 — too high, LLM short answers all fell to edge-tts)
+
+# Audio tags that signal emotional / story content → force quality lane regardless of length.
+# (Issue 1 fix: short emotional sentences like "[playful] 嗨～" should NOT use edge-tts robotic voice.)
+QUALITY_LANE_AUDIO_TAGS: frozenset[str] = frozenset({
+    "excited", "curious", "playful", "worried", "whispers", "laughs", "sighs", "thinking",
+    "gentle", "happy", "sad", "shy",
+})
 
 # Regex to strip audio-tag markup like [playful], [excited] before counting.
-_AUDIO_TAG_RE_LANE: re.Pattern = re.compile(r"\[\w+\]")
+_AUDIO_TAG_RE_LANE: re.Pattern = re.compile(r"\[(\w+)\]")
 
 # Chinese / English punctuation that doesn't count as content.
 _PUNCT_RE: re.Pattern = re.compile(r"[，。！？：；、,.!?:;\s]")
@@ -761,15 +768,30 @@ def _compute_effective_length(text: str) -> int:
     return cjk_count + en_words_count
 
 
+def _has_quality_lane_audio_tag(text: str) -> bool:
+    """Return True if text contains an emotional audio tag → force quality lane.
+
+    This overrides length-based routing because short emotional sentences
+    (e.g. "[playful] 嗨～") sound terrible in edge-tts robotic voice.
+    Safety/stop keywords still take precedence (handled before this check).
+    """
+    matches = _AUDIO_TAG_RE_LANE.findall(text)
+    return any(tag.lower() in QUALITY_LANE_AUDIO_TAGS for tag in matches)
+
+
 def _should_use_fast_lane(text: str, threshold: int = FAST_LANE_THRESHOLD) -> bool:
     """Return True when fast lane (edge-tts → Piper) should handle ``text``.
 
-    Fast lane is used when:
-    - Text contains a safety/stop keyword (always fast, overrides length), OR
-    - Effective text length ≤ ``threshold`` (default 30 units).
+    Decision priority:
+    1. Safety/stop keyword present → ALWAYS fast lane (override everything).
+    2. Emotional audio tag (e.g. [excited]/[playful]) → quality lane for voice fidelity.
+    3. Effective length > threshold → quality lane (long content = quality investment).
+    4. Otherwise (short, plain) → fast lane.
     """
     if SAFETY_KEYWORDS.search(text):
         return True
+    if _has_quality_lane_audio_tag(text):
+        return False
     return _compute_effective_length(text) <= threshold
 
 
@@ -914,7 +936,7 @@ class EnhancedTTSNode(Node):
         )
         self.declare_parameter(
             "tts_fast_lane_threshold",
-            _env_int("TTS_FAST_LANE_THRESHOLD", 30),
+            _env_int("TTS_FAST_LANE_THRESHOLD", 12),  # 5/9 review: was 30 — too high
         )
 
     def _load_configuration(self) -> TTSConfig:

--- a/speech_processor/test/test_tts_dual_route.py
+++ b/speech_processor/test/test_tts_dual_route.py
@@ -118,14 +118,15 @@ class TestShouldUseFastLane:
         _, fast, _ = _helpers()
         assert fast("危險") is True
 
-    def test_short_chinese_fast(self):
+    def test_short_emotional_audio_tag_forces_quality(self):
         _, fast, _ = _helpers()
-        # "嗨～" is short → fast lane
-        assert fast("[playful] 嗨～") is True
+        # 5/9 fix: short emotional sentences with audio tag should NOT use
+        # fast lane (edge-tts robotic) — voice fidelity matters more than latency.
+        assert fast("[playful] 嗨～") is False
 
-    def test_short_greeting_fast(self):
+    def test_short_greeting_no_tag_fast(self):
         _, fast, _ = _helpers()
-        assert fast("你好啊！") is True  # 3 CJK ≤ 30
+        assert fast("你好啊！") is True  # 3 CJK ≤ 12, no audio tag
 
     def test_long_chinese_quality(self):
         _, fast, _ = _helpers()
@@ -133,21 +134,36 @@ class TestShouldUseFastLane:
         long_text = "今天天氣很好，我們去公園散步好嗎？你可以給我一些建議嗎，比如穿什麼衣服最合適。"
         assert fast(long_text) is False
 
-    def test_threshold_boundary_at_exactly_30(self):
+    def test_threshold_boundary_at_exactly_threshold(self):
         _, fast, threshold = _helpers()
-        # Build a text that is exactly threshold CJK chars
+        # Build a text that is exactly threshold CJK chars (no audio tag)
         text = "一" * threshold
-        assert fast(text) is True  # equal → fast
+        assert fast(text) is True  # equal → fast (no emotional tag)
 
-    def test_threshold_boundary_at_31(self):
+    def test_threshold_boundary_above_threshold(self):
         _, fast, threshold = _helpers()
         text = "一" * (threshold + 1)
         assert fast(text) is False  # over → quality
 
-    def test_audio_tag_stripping_makes_short(self):
+    def test_audio_tag_emotional_overrides_short(self):
+        # Short content + emotional audio tag → quality lane (not fast)
+        # This is the core 5/9 fix: short emotional → quality voice.
         _, fast, _ = _helpers()
-        # Long audio tag + short content → fast after strip
-        assert fast("[playful][excited][laughs] 好") is True
+        assert fast("[playful][excited][laughs] 好") is False
+
+    def test_unknown_audio_tag_does_not_force_quality(self):
+        # An unknown tag (not in QUALITY_LANE_AUDIO_TAGS) shouldn't override.
+        _, fast, _ = _helpers()
+        assert fast("[noise] 嗯") is True  # 1 CJK after strip → fast
+
+    def test_threshold_default_is_12(self):
+        _, _, threshold = _helpers()
+        assert threshold == 12, "5/9 review: threshold lowered from 30 to 12"
+
+    def test_safety_keyword_overrides_audio_tag(self):
+        # Safety > emotional tag — even with [worried], 停 forces fast lane.
+        _, fast, _ = _helpers()
+        assert fast("[worried] 停下來") is True
 
     def test_dont_move_keyword_is_fast(self):
         _, fast, _ = _helpers()

--- a/tools/tts_spike/README.md
+++ b/tools/tts_spike/README.md
@@ -1,0 +1,68 @@
+# TTS Spike Tools
+
+Scripts for evaluating new TTS providers before integrating into main chain.
+
+## ElevenLabs Spike-Mini
+
+**Goal**: Decide whether to add ElevenLabs to TTS quality lane (replacing OpenRouter Gemini for emotional/long content).
+
+**Time**: ~30 min setup + 30 min listening + scoring
+
+### Steps
+
+1. **Get API key**: Sign up at https://elevenlabs.io, top up $5 PAYG, copy API key from settings.
+
+   ```bash
+   export ELEVENLABS_API_KEY=sk_...
+   ```
+
+2. **Pick 3 voice candidates** at https://elevenlabs.io/app/voice-library
+   - Filter by language: Chinese / Mandarin (or Multilingual)
+   - Look for: female, young, warm/playful tone (closest to '雪寶'-like)
+   - Copy each voice's ID (from voice detail page URL or copy button)
+
+3. **Edit `elevenlabs_mini.py`**: replace 3 `REPLACE_WITH_VOICE_ID_*` placeholders with real voice IDs + names.
+
+4. **Run**:
+
+   ```bash
+   cd /home/roy422/newLife/elder_and_dog
+   python3 tools/tts_spike/elevenlabs_mini.py
+   ```
+
+   Output:
+   - `tools/tts_spike/output/<voice_name>_<sentence>.mp3` — 5 sentences × 3 voices = 15 mp3
+   - `tools/tts_spike/output/_results.json` — latency table
+
+5. **Listen + score** each .mp3 (1-5 scale):
+   - 雪寶感 (childlike warmth)
+   - 中文自然度 (no robotic / no English-accent / no Mainland accent)
+   - 破音/吞字/簡體腔 (any)
+
+6. **Fill in dev-log**: `docs/pawai-brain/dev-logs/2026-05-XX-elevenlabs-spike-mini.md`
+
+7. **Decision**:
+   - **GO**: ≥ 1 voice ≥ 4/5 音色 AND ≥ 4/5 中文 AND short < 2s AND long < 4s AND no defects → proceed to Spike-Real
+   - **NO-GO**: any criterion fails → fall back to Gemini native SDK spike (`spike/gemini-native-tts`)
+
+### Cost estimate
+
+PAYG $5 ≈ 50k characters Flash v2.5 (rate from https://elevenlabs.io/pricing — verify current).
+
+5 sentences × 3 voices ≈ 200 chars total → < 1% of $5 quota. Plenty of headroom for Spike-Real (Megaphone integration test).
+
+### Out of scope
+
+- Voice cloning (custom voice from sample) — Pro plan only, demo 後再評估
+- Streaming endpoint integration — Spike-Real (separate phase)
+- Megaphone DataChannel wiring — Spike-Real
+
+## Gemini native SDK fallback
+
+If ElevenLabs Mini NO-GO, the alternative spike script will live at:
+
+```
+tools/tts_spike/gemini_native_mini.py
+```
+
+(not yet written — only build if ElevenLabs fails)

--- a/tools/tts_spike/elevenlabs_mini.py
+++ b/tools/tts_spike/elevenlabs_mini.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""ElevenLabs Spike-Mini — voice + latency probe.
+
+Usage:
+    export ELEVENLABS_API_KEY=sk_...
+    python3 tools/tts_spike/elevenlabs_mini.py
+
+Output:
+    tools/tts_spike/output/<voice_id>_<idx>.mp3 — 5 sentences × N voices
+    tools/tts_spike/output/_results.json        — latency + metadata
+    docs/pawai-brain/dev-logs/2026-05-XX-elevenlabs-spike-mini.md  (Roy fills in scores)
+
+GO/NO-GO criteria (Roy listens + scores 1-5):
+    1. ≥ 1 voice 音色 ≥ 4/5
+    2. 中文自然度 ≥ 4/5
+    3. 短句 < 2s AND 長句 < 4s (latency only — no Megaphone integration)
+    4. 無破音 / 吞字 / 簡體腔
+    5. PAYG quota dashboard 看實際消耗（記下 character usage）
+
+If GO → spike-real (Megaphone integration) on `spike/elevenlabs-tts-real`.
+If NO-GO → fall back to Gemini native spike (`spike/gemini-native-tts`).
+
+Spec: docs/pawai-brain/specs/2026-05-09-interaction-quality-improvements-design.md P2-2a
+Plan: docs/pawai-brain/plans/2026-05-11-elevenlabs-spike-and-dual-route.md Phase E-1
+"""
+from __future__ import annotations
+import json
+import os
+import time
+from pathlib import Path
+from typing import NamedTuple
+
+try:
+    import requests
+except ImportError:
+    raise SystemExit(
+        "requests not installed; run `uv pip install requests` or `pip install requests`"
+    )
+
+
+class Voice(NamedTuple):
+    voice_id: str
+    name: str
+    notes: str  # why we picked this voice
+
+
+# 3 Mandarin/multilingual female voices to spike-test.
+# Voice IDs from ElevenLabs Voice Library — refresh from dashboard if changed.
+# https://elevenlabs.io/app/voice-library  (filter language=Chinese / Mandarin)
+VOICE_CANDIDATES: list[Voice] = [
+    # NOTE: voice IDs below are PLACEHOLDERS — fill in from Voice Library.
+    # Search "Mandarin", "Chinese", or multilingual female voices < 30y.
+    # Roy: replace these 3 IDs before running.
+    Voice(
+        voice_id="REPLACE_WITH_VOICE_ID_1",
+        name="MandarinChild_F",
+        notes="Childlike Mandarin female; closest to '雪寶' tone",
+    ),
+    Voice(
+        voice_id="REPLACE_WITH_VOICE_ID_2",
+        name="MandarinYoung_F",
+        notes="Young Chinese female; warm/casual",
+    ),
+    Voice(
+        voice_id="REPLACE_WITH_VOICE_ID_3",
+        name="Bella_or_Hope_multi",
+        notes="Multilingual young female (e.g., Bella/Hope) — tests Chinese coverage",
+    ),
+]
+
+TEST_SENTENCES: list[tuple[str, str]] = [
+    ("short", "嗨！"),
+    ("medium", "我看到桌上有杯子，是紅色的，是新買的嗎？"),
+    ("long", "我是 PawAI，住在你家的小狗。今天天氣不錯欸，你想出去散步嗎？我會跟著你到處看看。"),
+    ("emotional", "[whispers] 我剛剛聽到外面有聲音，有點怕怕的，你陪我一下好嗎？"),
+    ("safety", "停下來！前面有東西不要動。"),
+]
+
+OUTPUT_DIR = Path(__file__).parent / "output"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+API_URL = "https://api.elevenlabs.io/v1/text-to-speech"
+MODEL_ID = "eleven_flash_v2_5"  # low-latency, multilingual
+
+
+def synthesize(api_key: str, voice_id: str, text: str) -> tuple[bytes | None, float, str | None]:
+    """Synthesize via ElevenLabs Flash v2.5; return (audio_mp3, latency_s, error)."""
+    headers = {
+        "xi-api-key": api_key,
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "text": text,
+        "model_id": MODEL_ID,
+        "voice_settings": {"stability": 0.5, "similarity_boost": 0.75, "style": 0.0},
+    }
+    t0 = time.monotonic()
+    try:
+        resp = requests.post(
+            f"{API_URL}/{voice_id}",
+            headers=headers,
+            json=payload,
+            timeout=30,
+        )
+        latency = time.monotonic() - t0
+        if resp.status_code != 200:
+            return None, latency, f"HTTP {resp.status_code}: {resp.text[:200]}"
+        return resp.content, latency, None
+    except Exception as e:
+        return None, time.monotonic() - t0, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    api_key = os.getenv("ELEVENLABS_API_KEY", "").strip()
+    if not api_key:
+        print("ERROR: ELEVENLABS_API_KEY not set in env")
+        return 1
+
+    placeholder_voices = [v for v in VOICE_CANDIDATES if v.voice_id.startswith("REPLACE")]
+    if placeholder_voices:
+        print("ERROR: VOICE_CANDIDATES still has placeholder IDs.")
+        print("       Pick voices from https://elevenlabs.io/app/voice-library")
+        print("       and replace REPLACE_WITH_VOICE_ID_* in this script.")
+        return 2
+
+    results: list[dict] = []
+    total_chars = 0
+
+    for voice in VOICE_CANDIDATES:
+        for sentence_kind, sentence_text in TEST_SENTENCES:
+            print(f"[{voice.name}] {sentence_kind}: {sentence_text!r}")
+            audio, latency, err = synthesize(api_key, voice.voice_id, sentence_text)
+            chars = len(sentence_text)
+            total_chars += chars
+
+            entry = {
+                "voice_id": voice.voice_id,
+                "voice_name": voice.name,
+                "voice_notes": voice.notes,
+                "sentence_kind": sentence_kind,
+                "sentence_text": sentence_text,
+                "chars": chars,
+                "latency_s": round(latency, 3),
+                "ok": audio is not None,
+                "error": err,
+            }
+            if audio is not None:
+                out_path = OUTPUT_DIR / f"{voice.name}_{sentence_kind}.mp3"
+                out_path.write_bytes(audio)
+                entry["output_file"] = str(out_path)
+                print(f"  → {out_path} ({len(audio)} bytes, {latency:.2f}s)")
+            else:
+                print(f"  ✗ FAIL: {err}")
+
+            results.append(entry)
+
+    summary_path = OUTPUT_DIR / "_results.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "model_id": MODEL_ID,
+                "total_chars": total_chars,
+                "voices_tested": len(VOICE_CANDIDATES),
+                "sentences": [k for k, _ in TEST_SENTENCES],
+                "results": results,
+            },
+            ensure_ascii=False,
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    print(f"\n=== Summary ===")
+    print(f"Total chars sent: {total_chars}")
+    print(f"Output dir: {OUTPUT_DIR}")
+    print(f"Summary JSON: {summary_path}")
+    print(f"\nNext steps:")
+    print(f"  1. Listen to all .mp3 in {OUTPUT_DIR}")
+    print(f"  2. Score each voice (1-5) on: 雪寶感 / 中文自然度")
+    print(f"  3. Check ElevenLabs dashboard for actual quota usage")
+    print(f"  4. Fill scores in docs/pawai-brain/dev-logs/2026-05-XX-elevenlabs-spike-mini.md")
+    print(f"  5. If ≥ 1 voice scored ≥ 4/5 + latency targets met → GO; else NO-GO (try Gemini native)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Reviewer 5/9 finding

> threshold=30 讓 LLM 短句全卡 fast lane (edge-tts 還是 google 小姐)，quality lane 幾乎不觸發

## Fix

| Change | Why |
|---|---|
| `FAST_LANE_THRESHOLD` 30 → 12 | LLM short answers (5-12 字) now route based on intent, not blanket fast |
| `QUALITY_LANE_AUDIO_TAGS` (12 emotional tags) | `[playful] 嗨～`(2 字) now → quality lane (was fast) |
| Decision priority: safety > tag > length | Stop/safety still always fast (override emotional) |

## ElevenLabs Spike (Roy hand-off)

- `tools/tts_spike/elevenlabs_mini.py` — 5 sentences × 3 voices probe
- `tools/tts_spike/README.md` — step-by-step
- `docs/pawai-brain/dev-logs/2026-05-XX-elevenlabs-spike-mini.md` — score template

Roy needs to:
1. Pick voice IDs from ElevenLabs Voice Library
2. Run script, listen to 15 mp3
3. Score 1-5; decide GO/NO-GO

## Tests
43/43 dual-route tests pass.

## Out of scope this PR
- ElevenLabs in main chain (waits for Mini GO)
- Spike-Real Megaphone integration
- OPENROUTER_KEY missing warn at routing layer (already at provider construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)