### PR TITLE
fix(brain): issue 2 — LLM 死板 root causes (capability leak + regex + temp)

### DIFF
--- a/pawai_brain/launch/pawai_conversation_graph.launch.py
+++ b/pawai_brain/launch/pawai_conversation_graph.launch.py
@@ -57,8 +57,8 @@ def generate_launch_description() -> LaunchDescription:
         DeclareLaunchArgument("llm_max_tokens", default_value="500"),
         DeclareLaunchArgument(
             "llm_temperature",
-            default_value="0.6",  # 1E: was 0.2; 0.6 balances JSON stability + naturalness
-            description="LLM temperature (0.6 demo main; OpenClaw chat 0.7-1.0)",
+            default_value="0.8",  # 5/9 review: 0.6 still felt templated; 0.8 toward OpenClaw 0.7-1.0 chat sweet spot
+            description="LLM temperature (0.8 demo main; OpenClaw chat 0.7-1.0). Lower if JSON schema gets unstable.",
         ),
         DeclareLaunchArgument(
             "engine_label", default_value="langgraph",

--- a/pawai_brain/pawai_brain/conversation_graph_node.py
+++ b/pawai_brain/pawai_brain/conversation_graph_node.py
@@ -424,7 +424,14 @@ class ConversationGraphNode(Node):
         if ws.get("current_speaker") and ws["current_speaker"] != "unknown":
             parts.append(f"[眼前的人] {ws['current_speaker']}")
 
-        # 1D: lazy inject CAPABILITIES.md + capability_context only when needed
+        # 1D: lazy inject CAPABILITIES.md + capability_context ONLY for explicit
+        # capability/action modes. chat / identity / safety modes do NOT see
+        # the skill JSON in their prompt — that's the issue 2 root cause: every
+        # turn LLM seeing 17-skill JSON pulls it into "tool listing" persona,
+        # making "介紹一下" come back as a feature catalog.
+        #
+        # capability_context still flows through graph state (skill_policy_gate
+        # v2 reads from state.capability_context, not from rendered prompt).
         cap = state.get("capability_context") or {}
         if mode in ("capability_question", "action_request"):
             if self._capabilities_md:
@@ -437,16 +444,7 @@ class ConversationGraphNode(Node):
                     "recent_skill_results": list(cap.get("recent_skill_results") or []),
                 }
                 parts.append("[能力 runtime] " + json.dumps(cap_payload, ensure_ascii=False))
-        elif cap:
-            # chat / safety / identity: still emit capability_context
-            # so skill_policy_gate v2 can work downstream (prompt stays lean)
-            compact_caps = _compact_capabilities(cap)
-            cap_payload = {
-                "capabilities": compact_caps,
-                "limits": list(cap.get("limits") or []),
-                "recent_skill_results": list(cap.get("recent_skill_results") or []),
-            }
-            parts.append("[能力] " + json.dumps(cap_payload, ensure_ascii=False))
+        # else: chat / identity / safety — DELIBERATELY no capability inject.
 
         if mode == "identity":
             parts.append(

--- a/pawai_brain/pawai_brain/nodes/mode_classifier.py
+++ b/pawai_brain/pawai_brain/nodes/mode_classifier.py
@@ -12,6 +12,9 @@ import re
 from typing import Final
 
 # Patterns ordered by priority (safety checked first)
+# 5/9 review: regex broadened — "介紹一下" / "介紹一下你自己" / "自我介紹"
+# / "介紹一下 PawAI" all previously missed and fell to chat mode (then got
+# capability JSON injected → feature-list answer).
 MODE_PATTERNS: Final[list[tuple[str, str]]] = [
     (
         "safety",
@@ -19,11 +22,18 @@ MODE_PATTERNS: Final[list[tuple[str, str]]] = [
     ),
     (
         "identity",
-        r"你是誰|你叫什麼|介紹.*自己|你誰啊|你是\s*AI",
+        # Order: most specific first
+        r"你是誰|你叫什麼|你叫啥|你誰啊|你是\s*AI"
+        r"|自我介紹|介紹.{0,5}(自己|你|妳|PawAI|paw\s*ai)"
+        r"|介紹一下"  # bare "介紹一下" — chat continuation, still identity-flavoured
+        r"|你會做(自我介紹|介紹)",
     ),
     (
         "capability_question",
-        r"你會什麼|你會啥|有什麼功能|能做什麼|會做啥|有哪些能力|功能有哪些",
+        r"你會(什麼|啥|哪些|做什麼|做啥)"
+        r"|(有|你有)(什麼|哪些)(功能|能力|技能)"
+        r"|能做(什麼|啥)"
+        r"|功能有(哪些|什麼)",
     ),
     (
         "action_request",

--- a/pawai_brain/test/test_mode_classifier.py
+++ b/pawai_brain/test/test_mode_classifier.py
@@ -19,11 +19,21 @@ from pawai_brain.nodes.mode_classifier import classify_mode
     ("你是誰？", "identity"),
     ("介紹一下你自己", "identity"),
     ("你叫什麼", "identity"),
+    # 5/9 review additions: previously fell to chat → got capability JSON
+    ("介紹一下", "identity"),
+    ("自我介紹", "identity"),
+    ("介紹一下 PawAI", "identity"),
+    ("介紹一下你", "identity"),
+    ("你叫啥", "identity"),
     # Capability question
     ("你會什麼？", "capability_question"),
     ("有什麼功能", "capability_question"),
     ("能做什麼", "capability_question"),
     ("你有哪些能力", "capability_question"),
+    # 5/9 review additions
+    ("你會啥", "capability_question"),
+    ("你會哪些", "capability_question"),
+    ("功能有哪些", "capability_question"),
     # Action request
     ("扭一下", "action_request"),
     ("伸個懶腰", "action_request"),


### PR DESCRIPTION
## Reviewer 5/9 真兇 3 條

1. **`elif cap:` 在 chat/identity/safety mode 仍 inject [能力] JSON**
   - LLM 每輪都看到 17-skill JSON → anchor 到工具人模式
   - 註解說是給 skill_policy_gate v2 用，**但那 node 從 state 讀，根本不從 prompt 讀**
   - 結論：純 LLM prompt 噪音，移除整個 elif branch

2. **mode_classifier regex 漏判**
   - 「介紹一下」、「介紹一下 PawAI」、「自我介紹」全分到 chat
   - 「你會啥」、「功能有哪些」也漏
   - 全補進 identity / capability_question pattern

3. **temperature 0.6 還是模板感 → 0.8**
   - OpenClaw 建議 0.7-1.0，0.8 是 chat sweet spot
   - JSON schema 穩定度需 demo 期觀察

## Tests
184/184 pawai_brain（含 8 個新 identity/capability case）

## 預期
「介紹一下」現在進 identity mode（mode_hint「不要列功能清單」+ 不注入 capability JSON），LLM 應從 IDENTITY.md 講性格。

🤖 Generated with [Claude Code](https://claude.com/claude-code)