### PR TITLE
fix(gateway): issue 5+6 — text_input s2twp; verify source pipeline + reset working

### DIFF
--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -558,8 +558,19 @@ async def post_text_input(payload: TextInputPayload):
     if node is None:
         return {"ok": False, "error": "ros_node_not_ready"}
     request_id = payload.request_id or f"txt-{int(time.time() * 1000)}"
+    text = payload.text
+    # 5/9 review: Studio chat-panel typing path was missing s2twp normalization.
+    # User typing is normally already 繁體, but pasted content / mobile keyboard /
+    # mixed input can leak 簡體; normalize defensively for consistency with the
+    # two ASR paths (stt_intent_node + /ws/speech).
+    if ENABLE_S2TWP and text:
+        try:
+            from text_normalization import to_traditional_tw
+            text = to_traditional_tw(text)
+        except Exception:
+            pass  # silent fallback to original text
     msg = {
-        "text": payload.text,
+        "text": text,
         "request_id": request_id,
         "source": "studio_text",
         "created_at": time.time(),


### PR DESCRIPTION
## Reviewer 5/9 audit findings

### Issue 5 (Studio 顯示每句) — **NOT BROKEN, REVIEWER WRONG**

Reviewer claimed:
- ❌ `source` 欄位 plan→step 斷路、永遠 None
- ❌ frontend reset 是 silent no-op

Re-verified end-to-end:
- `skill_contract.build_plan()` L661 `step_args.setdefault('source', say_source)` ✅
- `interaction_executive_node._dispatch_step` L187-194 envelope source field ✅
- `gateway._parse_tts_payload` L100 source extraction ✅
- `gateway.build_tts_event` L116-117 source in broadcast ✅
- `use-event-stream.ts` L107 source forwarded to ttsMessages ✅
- `chat-panel.tsx` L55-67 `getBubbleClassName` 三色 routing ✅
- `state-store` L46+L79 `ttsMessages` field exists; `useStateStore.setState({ttsMessages: []})` works ✅

**Pipeline 完整**, Roy 自己 smoke 也說 'ui 郝非常多 很棒'. No code change needed.

### Issue 6 (ASR 簡→繁) — **REAL HALF-SOLUTION FIXED**

Branch C 加了 s2twp 在兩條 ASR 入口（stt_intent_node + /ws/speech browser mic），但漏了 `/api/text_input` POST endpoint — Studio chat-panel 文字輸入走這條。

修法：endpoint 也呼叫 `to_traditional_tw`（lazy-import + ENABLE_S2TWP env gate + silent fallback，pattern 跟 /ws/speech 一致）。

Test: 25/25 gateway pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)