### PR TITLE
fix(p0): 5/9 review must-fix — temp default + attention snapshot

### DIFF
--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -685,7 +685,7 @@ class BrainNode(Node):
         if self._world.snapshot().tts_playing:
             return
         # Gate 4: attention must be IDLE (no active person)
-        if self._attention.state != AttentionState.IDLE:
+        if self._attention_state_snapshot() != AttentionState.IDLE:
             return
         # Gate 5: max per hour cap (count recent_idle_phrases timestamps —
         # we use a separate per-hour ring? simplest: count idle_max_per_hour
@@ -973,7 +973,7 @@ class BrainNode(Node):
         #   3. not pending_confirm (middle of gesture confirmation flow)
         #   4. not tts_playing (TTS currently speaking — don't interrupt mid-SAY)
         snap = self._world.snapshot()
-        if self._attention.state != AttentionState.ENGAGED:
+        if self._attention_state_snapshot() != AttentionState.ENGAGED:
             return  # IDLE / NOTICED / INTERACTING — stay quiet
         if self._has_active_skill_or_sequence():
             return

--- a/pawai_brain/pawai_brain/conversation_graph_node.py
+++ b/pawai_brain/pawai_brain/conversation_graph_node.py
@@ -305,7 +305,7 @@ class ConversationGraphNode(Node):
         self.declare_parameter("openrouter_request_timeout_s", 4.0)
         self.declare_parameter("openrouter_overall_budget_s", 5.0)
         self.declare_parameter("llm_persona_file", "")
-        self.declare_parameter("llm_temperature", 0.2)
+        self.declare_parameter("llm_temperature", 0.8)
         self.declare_parameter("llm_max_tokens", 500)
         self.declare_parameter("chat_history_max_turns", 5)
 

--- a/speech_processor/speech_processor/llm_bridge_node.py
+++ b/speech_processor/speech_processor/llm_bridge_node.py
@@ -199,7 +199,7 @@ class LlmBridgeNode(Node):
         self.declare_parameter("llm_endpoint", "http://140.136.155.5:8000/v1/chat/completions")
         self.declare_parameter("llm_model", "Qwen/Qwen2.5-7B-Instruct")
         self.declare_parameter("llm_timeout", 15.0)
-        self.declare_parameter("llm_temperature", 0.2)
+        self.declare_parameter("llm_temperature", 0.8)
         self.declare_parameter("llm_max_tokens", 80)
         self.declare_parameter("intent_event_topic", "/event/speech_intent_recognized")
         self.declare_parameter("face_event_topic", "/event/face_identity")


### PR DESCRIPTION
## Summary

Three 1-line fixes uncovered by the 6-PR review pass on PRs #57-#62.

| Fix | File:line | Why |
|---|---|---|
| temp default 0.2 → 0.8 | `pawai_brain/.../conversation_graph_node.py:308` | PR #58 only changed launch arg default; node default was still 0.2. Affects `ros2 run` / unit tests / fallback path. |
| temp default 0.2 → 0.8 | `speech_processor/.../llm_bridge_node.py:202` | Same bug, Jetson Cloud Qwen fallback path. |
| `_on_object` use snapshot | `brain_node.py:976` | PR #59 fixed `_on_face` and `_on_stranger_alert` but missed the third bare read. |
| `_maybe_emit_idle` Gate 4 | `brain_node.py:688` | Same bare-read pattern in idle path; OFF by default but still wrong. |

## Tests
- `interaction_executive`: 191 pass
- `pawai_brain`: 184 pass
- `speech_processor`: 185 pass / 64 skip (pre-commit)

## Out of scope (bigger changes, separate PRs)

These were flagged in the review pass but need design discussion:

- **PR #57** — quality lane silent fallback to ElevenLabs without `OPENROUTER_KEY` (no callback-path warn; ElevenLabs timeout 3-6s)
- **PR #61** — frontend has no "新對話" button; `/api/reset` endpoint exists but no caller
- **Issue 5** — `SkillPlan.source` doesn't propagate to `/tts` envelope; gateway hardcodes `origin: "unknown"` at `studio_gateway.py:78-90`
- **PR #62** — `idle_max_per_hour` is a declared-but-unenforced ROS param; `import random` mid-file violates PEP 8

## Test plan
- [ ] `colcon build --packages-select pawai_brain interaction_executive speech_processor`
- [ ] `ros2 run pawai_brain conversation_graph_node` → confirm `llm_temperature: 0.8` in startup log
- [ ] Demo smoke: 「介紹一下 PawAI」 — should be less template-y with temp 0.8 (combined with PR #58 persona)
- [ ] Object remark gate still works (ENGAGED-only, snapshot read)

🤖 Generated with [Claude Code](https://claude.com/claude-code)