### PR TITLE
docs: 6/18 capability baseline & scoreboard plan + North Star v2 + issue drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ node_modules/
 ## Agent runtime artefacts（自動產生）
 /.agents/
 
+## Capability baseline 量測產物（snapshot/preflight 是量測輸出，不入 repo；example fixture 例外，見 pawai_brain/test/fixtures/）
+/artifacts/
+
 ## 會議錄音 / datasheet PDF（保留在硬碟但不入 repo）
 /*.m4a
 /*.mp3

--- a/docs/mission/2026-06-18-demo-north-star.md
+++ b/docs/mission/2026-06-18-demo-north-star.md
@@ -1,0 +1,206 @@
+# 2026-06-18 Demo North Star v2
+
+> **Status**: v2 — 戰略邊界文件（取代 2026-05-29 v1 draft）
+> **Created**: 2026-05-29 ｜ **v2**: 2026-05-31 ｜ **Deadline**: 2026-06-18
+> **性質**：這是 6/18 專題驗收的**戰略邊界文件**，不是開發計劃。它回答「要展示什麼、為什麼需要機器狗、哪些話不能講、哪些能力只是候選、哪些一定要守住」。實作計劃見 `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md`。
+> **與 ADR 的關係**：本文件的定位用詞 **amend ADR-0001 / ADR-0002**（平台/demo 雙層敘事保留；demo 層由「非接觸式機構巡檢助理」reframe 為「機構公共空間非接觸式守望互動 POC」）。ADR 正文待本文件 review 後再正式 amend，此處先記錄不 silent conflict。
+> **可靠度紀律**：本文件所有 P0 / P1 / P2 分層皆標 **`provisional until baseline`**——必須等上機 capability baseline 跑出數據，才從 provisional 轉 locked。先決定後量化是被禁止的。
+
+---
+
+## 1. One-Line North Star
+
+> **PawAI 是面向機構公共空間的非接觸式守望互動四足機器人 POC。**
+
+6/18 demo **不宣稱**完整長照、完整導盲或完整自主導航；它展示的是一台四足機器人如何以**量化驗證過的**感知、語音、短距移動與安全停車能力，在室內場域完成一段**安全、可解釋**的守望互動。
+
+6/18 是現場展示，不是剪輯影片，也不是展示「功能清單全部完成」。目標是跑出一條可信的守望互動閉環，而非把每個研究方向做到 production。
+
+---
+
+## 2. Positioning
+
+定位分兩層（沿用 ADR-0002 雙層敘事）：
+
+- **平台層**：PawAI 是**安全優先的居家 / 機構四足具身互動機器人**。
+- **6/18 demo 層**：**面向機構公共空間的非接觸式守望互動 POC**。
+
+明確標記：
+
+- **照護**是長期 vision，**不是** 6/18 主張。
+- **導盲犬**是價值參考（借鑑「幫看不到危險的人先看到」的非接觸守望價值），**不是** 6/18 能力主張。
+- **巡檢**是 future / 可延伸場景，**不是**完整 patrol demo。
+
+### 「守望」canonical 定義（6/18 用詞）
+
+> **守望**：PawAI 在**非接觸**前提下，觀察室內公共空間中的人、物與互動狀態，提供**提醒、回報與可解釋的互動**；**不包含**攙扶、接觸、主動保護、陌生人警報或替代照護人員。
+
+> ⚠️ **用詞紀律**：6/18 一律用「守望」，**不用**「守護 / guardian / 陌生人警報 / 保護長者 / 照護安全」——後者在既有文件綁定 guardian mode + 已停用的陌生人警報，責任感過重且會引來無法承諾的期待。「守護 / guardian」屬舊框架 / future，不進本文件主語言。
+
+### 為什麼選機構而非居家
+
+Go2 機體大、重（**十多公斤級，約 15–20kg**），**居家空間不實用**；機構公共空間（長照中心交誼廳 / 校園公共區）較適合四足平台移動，也對齊 ADR-0001 既有的「機構」定位。
+
+---
+
+## 3. Why Quadruped（回答老師最核心的質疑）
+
+> 為什麼一定要機器狗？不是 APP / 音箱 / 固定攝影機 / 一般機器人就好？
+
+| 替代方案 | 做得到 | 做不到 |
+|---|---|---|
+| APP | 語音 / 通知 | 無法在場、無法移動、無法看見現場 |
+| 智慧音箱 | 對話 | 無法視覺感知、無法移動、無法展示安全停車 |
+| 固定攝影機 | 監看固定角度 | 無法走到角落、無法實體回應、無低視角 |
+| 一般輪式機器人 | 移動較穩 | 較少四足平台的在場感與互動辨識特色 |
+| **PawAI / Go2** | **看、聽、走、停、回報、Studio 證據** | 不承諾接觸式照護或完整自主導航 |
+
+**「非狗不可」錨在我們能可靠展示的具身核心**（不是錨在完整引導/跟隨）：
+
+- 能移動到現場
+- 有在場感
+- 能從低視角觀察人與物
+- 能用身體反應（坐下 / 拒絕危險動作）
+- 能在物理空間中**安全停下**
+- 能把現場證據送回 Studio
+
+> **重點句**：PawAI 的價值不是「更會聊天」（那會輸雲端大模型），而是能在**物理空間中到場、觀察、提醒、回報，並在遇到風險時安全停下**——這些 APP / 音箱 / 固定攝影機本質上做不到。
+
+---
+
+## 4. Demo Promise（6/18 承諾）
+
+> PawAI **只使用目前量化驗證為可靠的能力**進入 Brain 主線，完成一段**非接觸式室內守望互動流程**；每個判斷都能在 Studio 顯示證據；不可靠能力**只顯示、不觸發、不宣稱**。
+
+被問「可靠嗎」時，回答方式是指向 scoreboard：「這項 pass 所以 Brain 在用、這項 degraded 所以只顯示、這項 fail 所以 6/18 不宣稱」——**scoreboard 的誠實本身就是可信度**（見 §9）。
+
+---
+
+## 5. Non-Claims / 禁說清單（避免 overclaim）
+
+6/18 **不宣稱**：
+
+- 完整自主導航
+- 自動找人
+- 動態繞障已完成
+- 導盲犬能力已完成 / 可引導盲人
+- 跟隨人
+- 巡邏整個機構
+- 長照照護可靠
+- 跌倒偵測可靠
+- 通用物體辨識
+- 功能全開 / 全自主
+- LLM 回答自然度 = 機器人可靠性
+- 守護 / 陌生人警報 / 主動保護
+
+分兩層講，避免提前宣稱未經 baseline 的能力：
+
+- **目前（baseline 前）可說的「價值 / 角色語言」**：守望、提醒、回報、非接觸、可解釋互動、Studio evidence；以及「借鑑導盲犬的非接觸守望價值，但 6/18 不宣稱導盲能力」。
+- **通過 baseline（scoreboard 標 pass）後才說的「能力宣稱」**：短距安全移動、遇障安全停車、揮手互動、物件辨識——**每一項都要在 scoreboard 標 pass，才進旁白**；未 pass 前只在 Studio 顯示，不口頭宣稱。
+
+---
+
+## 6. Canonical Demo Story（串成故事，不是功能清單）
+
+1. PawAI 在機構公共空間待機。
+2. 使用者靠近，PawAI 透過**人臉辨識**確認是否為註冊對象。
+3. PawAI 主動打招呼，並透過**語音 / Studio** 進入互動。
+4. 使用者給出**固定語音指令**，Brain 解析意圖並通過 safety / capability 檢查。
+5. 使用者**揮手**：若 baseline 顯示 `gesture.wave` 可靠則回應互動；若不可靠，只在 Studio 顯示（不觸發動作）。
+6. PawAI 執行**短距移動**或準備靠近。
+7. 前方出現人或障礙物時，PawAI **安全停下，不自動暴衝恢復**（no_auto_resume）。
+8. PawAI 辨識桌上 demo 物件（例如杯子），做**提醒 / 描述**。
+9. **Studio 顯示每一步的 evidence**：感知 event → Brain decision → safety / capability gate → skill result。
+
+> 規則：影片 / 旁白裡每一句宣稱，都要有對應的 ROS topic、debug image 或 Studio trace 背書。
+
+---
+
+## 7. P0 必留底線（`provisional until baseline`）
+
+> 「必留底線」= 範圍優先級（不能再砍的東西），**不是** runtime 攔截。runtime 攔截一律用 gate（Engagement / capability / safety / depth gate、證據用的 gate-0）。
+> 以下全為 **provisional**，需上機 baseline 後轉 locked。
+
+- **face.recognition**：註冊者辨識與問候
+- **voice.command**：固定指令輸入
+- **brain.skill_gate**：Brain 不亂執行不可靠能力（fail-closed）
+- **studio.evidence**：Studio 顯示每步證據（差異化全押可驗證，這是硬前提）
+- **nav.short_move + nav.safe_stop**：6/18 的具身證明——「機器狗非噱頭」靠這一條。完整自主導航、動態繞障、跟隨人**不屬於 6/18 主張**。（隱含前置：F7 `cmd_vel_nav` 不出的 root cause 須在 fresh stack 上定位；未定位前 nav 相關 claim 一律不講。）
+- **object.cup**：至少一類 demo 物件可靠辨識
+- **gesture.wave**：**P0 target / candidate**——需 baseline 驗證誤觸率後才鎖定（不寫「P0 必成」，否則與「先量化」矛盾）
+
+---
+
+## 8. Scope Boundary（`provisional until baseline`）
+
+**P1 / Bonus**：
+
+- 完整導航
+- 動態繞障
+- D435 active pause / cancel
+- 多物件追蹤
+- 粗姿勢描述（standing / sitting / bending）
+- PINTO WHC / SC spike（go/no-go 2026-06-06）
+
+**P2 / Future**：
+
+- 導盲犬能力
+- 跟隨人
+- 跌倒偵測
+- 雙手插腰 / 單腳跪地
+- 假牙 / 鑰匙 / 錢包（COCO 不含、不自訓）
+- 真 VLM 場景理解
+- ElevenLabs 主線
+- 照護場景 / 守護 / 陌生人警報
+
+---
+
+## 9. Scoreboard-First Principle（整份文件的核心方法論）
+
+能力不是二元的「有 / 沒有」，而是分級：
+
+- **pass**：可進 Brain 主線（可控制機器人）
+- **degraded**：可顯示、可語音說明，但**不可控制機器人**
+- **fail**：不宣稱、不觸發
+- **insufficient_data**：不放行高風險動作（motion / nav）
+
+> **Brain 必須 fail-closed**：當能力為 `degraded` / `fail` / `insufficient_data` 時，**不得用該能力觸發 motion / nav 類動作**。**預計落點**是 `pawai_brain` 既有的 capability / effective_status 純函式——**目前該純函式有 gate 骨架但缺 health 維度，需補上 `capability_health` 分支後單測**（尚未存在，不是現成品）；不在 LLM prompt 層做。
+
+這也是 §4 demo promise 的執行機制：scoreboard 決定 Brain 能不能用某能力，而不是「功能寫了就用」。
+
+---
+
+## 10. Edge AI Framing（回應老師「不要只用 PC / GPU 算力評估」）
+
+> PawAI 的 Edge AI 價值在於 **Jetson 端即時感知、ROS2 狀態整合、安全 gate、fallback 行為與 Studio evidence**。雲端 LLM / TTS 是**互動品質加分，不是系統可靠性的唯一來源**。
+
+具體證明：感知（face / pose / gesture / object）+ 安全層 + reactive_stop 全在 Jetson 邊緣跑。斷網時**可降級到本地感知 + 固定指令 / RuleBrain / Piper 的守望模式**，**需 baseline 驗證後**作為 Edge AI 證據（repo 已有 `sensevoice_local` / `whisper_local` / `piper` / RuleBrain fallback 線索，但語音主線含 Studio / Gateway / Cloud path，完整斷網閉環尚待 current-path baseline，不寫成已驗證完成品）。不要用桌機 GPU 標準評估 Jetson 表現。
+
+---
+
+## 11. Reporting Guidance（簡報怎麼講）
+
+**優先講**：
+
+- Before / After（Before：Go2 只是遙控機器狗；After：能語音、視覺、Brain、安全 gate、Studio 監控）
+- 為什麼需要 Go2（§3）
+- 硬體與系統整合難點（第三方 SDK、降壓板防燒、3D 列印固定座、有線網路、TTS/ASR/LLM fallback、危險動作鎖定）
+- 高層架構圖（User / D435 / Jetson / ROS2 / PawAI Brain / Studio / 雲端 LLM / Go2）
+- 資料流程圖（感知 event → Brain → safety / capability gate → skill → robot action → Studio evidence）
+- 實測數據與 Studio evidence
+
+**避免一開場就講**：
+
+- 我們還做不到完整導航
+- 我們還不能真的長照
+- 我們還不能導盲
+
+（老師原則：先講你做到的，人家追問再說限制；單一功能串成故事。）
+
+---
+
+## 一句話總結
+
+這份文件不是在說「我們要做哪些功能」，而是在說：
+
+> **6/18 我們如何誠實但有力地展示 PawAI 的價值，並避免過度承諾。**

--- a/docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md
+++ b/docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md
@@ -1,0 +1,247 @@
+# Capability Baseline & Scoreboard — Implementation Plan
+
+> **文件修訂 v0.2.3（2026-06-01，drift 清掃）**。清掉 v0.2.2 fold 後的殘留矛盾：開頭 Architecture / scope / File Structure 標題 / Self-Review / Handoff 全部從「4 件」統一成「6 deliverable（核心 4 + Task 3b build_scoreboard + Task 4b face observer）」；runbook step3 face 改走 `face_baseline_observer`（勿用 event observer）；canonical 表 face observer 欄改 Task 4b。**`to_snapshot` 預設 fail-closed**：`run_trusted = bool(run_meta.get("run_trusted", False))`（caller 漏帶 → 視為不可信，杜 fail-open），3 個 trusted-case test 補 `run_trusted=True` + 新增 `test_missing_run_trusted_defaults_failclosed`；全部 dry-run 5 test 綠。
+> **文件修訂 v0.2.2（2026-06-01，code-review fold）**。在 v0.2.1 上 fold 進 Roy code review 的 5 finding 修法（全部 dry-run 驗證綠）：F1 snapshot 永遠列 15 能力（未測=insufficient_data）、F2 Layer-0 preflight fail→`run_trusted=False`→`to_snapshot` 覆寫全 grade、F3 face 拆獨立 `face_baseline_observer`（state 流）、F4 demo.yaml canonical=`.claude/`（git-tracked；Roy 建議的 `.agents/` 方向被 `.gitignore:84` 反駁）、F5 dependency_role 入 snapshot；+ completeness critic 的 A2（voice record 轉換）/A4（build_scoreboard 簽名）。
+> **文件修訂 v0.2.1（2026-06-01，BLOCKING fold）**。在 v0.2 上 fold 進 4 個 BLOCKING 決定 + 1 個結構發現（見下「2026-06-01 fold」段）。
+> **文件修訂 v0.2（2026-05-31，recon-grounded）**。本版把 6 路 file:line 級調查 + grill 收斂的決策 fold 進來。
+> **交付的 scope = v0.1（"Baseline-First"，= 選項 B）**：量測框架 6 個 deliverable（核心 4 + build_scoreboard + face observer）+ Layer-0 Preflight gate + 設計/runbook。**不**做 Brain runtime gate / Studio UI / 換模型（v0.2 / v0.3）。
+> **性質**：這是「**讓 baseline 可以被量出來的工程計劃**」，不是 baseline 結果報告。今天的實機只證明「感知 lane 可起、資源健康、topic 會發」，**不能**宣稱任何能力 pass/fail。
+
+> **For agentic workers:** 工具中立——用 TDD；可選擇每個 task 派 fresh subagent/worker 實作、task 間 review。Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 先跑出可信的能力 baseline 數據（pass / degraded / fail / insufficient_data），用來決定哪些能力允許進 6/18 demo 主線——不在這一版把 Brain 自動 gate、Studio UI、CLI JSON、ROS health publisher 全做完。
+
+**Architecture:** v0.1 = **6 個 deliverable**（核心 4 件：schema / grader / 聚合器 / gesture-object observer；＋ Task 3b `build_scoreboard` CLI；＋ Task 4b `face_baseline_observer`）+ Layer-0 Preflight（填既有 `jetson-verify` 的 `demo.yaml` profile）+ 設計/runbook 文件。資料來源分四路：**voice 用現成 `speech_test_observer`**（→ A2 轉 record）；**gesture/object 用 `perception_baseline_observer`（event-only）**；**face 用 `face_baseline_observer`（吃 `/state/perception/face` 連續流，F3）**；**nav.short_move 用 `/event/nav/mission`（partial）、nav.safe_stop/no_auto_resume 標 insufficient 等 BD-7/BD-8**。硬體資源 reuse `benchmarks/core/monitor.py JetsonMonitor`，門檻 check reuse `benchmarks/core/criteria.py GateEvaluator`，per-run schema reuse `benchmarks/core/reporter.py build_result` 範式（**JSONL，非 SQLite**）。聚合件 dev 機可跑、無 ROS 依賴、走 TDD；observer 的純比對邏輯 TDD，ROS node wrapper 在 Jetson 跑。
+
+**Tech Stack:** Python 3 + dataclasses + pytest（純函式）；既有 `benchmarks/`（reporter / monitor / criteria）；`speech_test_observer.py` 的 PASS/MARGINAL/FAIL grading 範式；`jetson-verify` YAML-driven check runner（preflight）。
+
+---
+
+## v0.1 成功定義（最重要，整份 plan 的北極星）
+
+> **v0.1 的成功定義不是「Brain 已經會自動 gate 所有能力」，而是「我們已經有可信 baseline 數據，可以決定哪些能力允許進 demo 主線」。**
+
+不要在 v0.1 同時做量測框架 + runtime gate + UI + CLI + adapter，否則沒有一個會完成。
+
+## 2026-06-01 fold（4 BLOCKING + 1 結構發現，workflow file:line 接地）
+
+1. **skill alias 校正（A 級，會讓 v0.2 runtime 接錯）**：設計段 C 的 7 個 demo skill 名，subagent 雙輪核對 `skill_contract.py`（29 條真實 `SKILL_REGISTRY`）→ 4 個名錯已更正（`sit_down→sit_along`、`approach_short→nav_demo_point`（1.2m 非 0.3/0.5）、`refuse_unsafe→request_backflip`、`answer_fixed_command`→無單一 skill，demo alias →〔chat_reply｜say_canned〕）。
+2. **+`dependency_role`（第 5 靜態屬性，design-only）**：CAPABILITY_META + canonical 表加；15 能力各標 `trigger/content/safety_guard/actuation/evidence`。語意=「fail 時依賴它的 skill 怎麼降級」，與 `risk_role` 正交。v0.1 不被 grader 消費。
+3. **Brain fail-closed 落點校正（結構發現，推翻 v0.2 草稿）**：`compute_effective_status()`（effective_status.py:26）**已是 runtime 純函式、已吃 `demo_status_baseline`、已輸出 8 態**。v0.2 不造新機制，只**擴既有函式加 grade 分支**。並鎖「四欄不混、不雙真相源」紀律（見設計段 D）。
+4. **version_snapshot 補 stale 判（洞④）**：`current_run_meta()` 加 `wsl_dirty/branch/jetson_dirty/manifest_exists/version_stale`（manifest age>6h）。
+5. **demo.yaml（洞③ Layer-0）無爭議**：smoke.yaml 現有 9 check（非 plan 原寫 7），搬+補 3，issue #5 獨立做。
+
+## v0.1 → v0.2 改了什麼（recon + grill 收斂）
+
+1. **+Task 4 `perception_baseline_observer`**：recon 證實 face/gesture/object 的 topic 全是 event JSON，**沒有任何 accuracy/false_trigger/latency 是 topic 自帶**，且現有 `verification_observer.py` **只計數、無判定層**。所以「schema/grader/aggregator 做完，第一張 scoreboard 仍只評得到 voice」——必須補 perception observer，視覺三能力才量得到（選項 B）。**（v0.2.2 校正：face 後來證實必須走 `/state/perception/face` 連續流，已拆出獨立 `face_baseline_observer`＝Task 4b；本 Task 4 收斂為 gesture/object event-only。）**
+2. **Layer-0 Preflight 從能力降為 top-level gate**：`layer0.preflight=fail → 本次 run 不可信 → 全 capability 維持 insufficient_data，不產 pass/fail`。落地 = 填 `jetson-verify` 既有但 stub 的 `demo.yaml`（不自寫 runner）。
+3. **+`claim_level` / `risk_role`（capability 靜態屬性）**：`status(grade)` 是量出來的；`claim_level`/`risk_role` 是作者預先標的。Brain 主線放行 = `grade==pass AND claim_level==mainline`（`claim_level` 只能更嚴、不能放寬）。
+4. **+`version_snapshot`（雙 sha）**：Jetson **無 `.git`**，版本靠 `.pawai-last-deploy` manifest（`pawai jetson deploy` 寫）+ WSL commit；baseline runner 在 dev、能力在 Jetson 量 → 必須同記 `wsl_commit` 與 `jetson_install_sha`，mismatch fail-closed。
+5. **canonical capability 表正規化**：拆掉 `nav.short_move + nav.safe_stop` 複合列；每列單一能力 + 上述屬性。
+6. **recon Known Findings fold 進來（候選，非 pre-baseline fix）**：object whitelist / gesture score-floor / nav 0.85 motion-unverified / studio live / cli CI / wave 雙回應 / doc drift——一律「**baseline fail 後才開修**」。
+
+## Scope（scope 階段 v0.1 / v0.2 / v0.3 邊界）
+
+**v0.1（本 plan，要做）**：6 個 deliverable — 核心 4 件（`scoreboard_schema` / `grader` / 聚合器 `scoreboard` / `perception_baseline_observer` gesture+object）＋ Task 3b `build_scoreboard` CLI ＋ Task 4b `face_baseline_observer`（state 流）；+ Layer-0 Preflight（填 `demo.yaml`）+ canonical capability 表 + `gesture.wave` 事件層協定 + 手寫 dependency map + Brain fail-closed 規則**設計**（不接 runtime）+ 上機 runbook + Known Findings 清單。
+
+**v0.2（不在本 plan）**：`effective_status.py` 補 `capability_health` 分支並接 runtime、`pawai scoreboard --json`、Studio health chip（degraded 第 4 態 / `ScoreChip`）、trace drawer fail reason、perception health publisher、nav / object adapters。
+
+**v0.3（不在本 plan）**：data-driven 修復——見最後「Known Findings」段（gesture confidence floor、WHC A/B、object whitelist、YOLO26s A/B、nav F7、TTS fallback）。
+
+**對齊已鎖決策**：provisional(≥1 樣本，標黃) vs confirmed(≥3 樣本，可標綠)；as-is baseline **必走 demo entrypoint**（裸 `ros2 run` 會拿到錯的 mic_gain / gesture backend / whisper device）；demo skill **手寫 dependency map**；`distance_m` 對 gesture/pose 為人工宣告（`distance_source="manual_declared"`）；demo-day health 用 snapshot（凍結）。
+
+---
+
+## Canonical Capability Table（v0.1 鎖定，15 能力 + 1 前置 gate）
+
+> `layer0.preflight` **不是能力**，是前置 gate（見下節）。`risk_role ∈ {safety_critical, safety_support, actuation, convenience, evidence_only}`。`claim_level ∈ {mainline, studio_only, future, not_claimed}`。`default_status` 在跑 baseline 前一律 `insufficient_data`（除 cli 已有 dev 證據）。`observer_status` = 能不能**現在**產出可評分記錄。
+>
+> **`dependency_role`（2026-06-01 新增第 5 靜態屬性，design-only，v0.1 不被 grader 消費）** ∈ `{trigger, content, safety_guard, actuation, evidence}`：它與 `risk_role` 正交，回答的是「**這能力 fail 時，依賴它的 demo skill 怎麼降級**」——
+> `trigger` fail → 不觸發該 skill（連表情都不做）；`content` fail → skill 仍觸發但內容降級（如 face fail→不叫名字只說「有人來了」）；`safety_guard` fail → 禁 motion；`actuation` fail → 禁該動作；`evidence` fail → 只影響 Studio 顯示，不擋 skill。供設計段 C dependency map 與 v0.2 chain-gating 用（值見 Task 1 `CAPABILITY_META`）。
+
+| # | capability_id | depth | claim_level | risk_role | dependency_role | observer_status（誰產記錄）| Brain surface（pass 時）| fallback（not-pass）|
+|---|---|---|---|---|---|---|---|---|
+| 1 | `face.recognition` | deep | mainline | evidence_only | **content** | ❌ 新 `face_baseline_observer`（Task 4b，state 流）| 問候/識別(speech)，無 motion | 泛稱「有人來了」/ studio |
+| 2 | `voice.command` | deep | mainline | convenience | **trigger** | ✅ `speech_test_observer` 現成 | intent→允許 skill + tts | RuleBrain/請重說；degraded 不 motion |
+| 3 | `voice.stop` | deep | mainline | convenience（operator_abort）| **trigger** | 🟡 命中率現成；停車反應時間要新 observer | 觸發 stop_move（便利）| **不影響安全**（reactive_stop 獨立）|
+| 4 | `gesture.wave` | deep | mainline | convenience（emote）| **trigger** | ❌ 新 observer（confidence hardcode 1.0 無鑑別力）| wave→emote(api 1016)/招手 | studio_only 顯示，不觸發 |
+| 5 | `object.cup` | deep | mainline | evidence_only | **content** | ❌ 新 observer（無人訂 `/event/object_detected`）| remark(tts) | studio 顯示/不口頭 |
+| 6 | `nav.safe_stop` | deep | mainline | **safety_critical** | **safety_guard** | ❌ recorder `_cb_reactive_status` no-op（BD-7）| 啟用 motion 護欄（#8 前置）| **FAIL→禁所有 motion/nav** |
+| 7 | `nav.no_auto_resume` | deep | mainline | **safety_critical** | **safety_guard** | ❌ **BD-8 行為重設計（非只接 recorder）**：現行 `reactive_stop_node.py:307` 離開 danger 自動 `/nav/resume`＝auto-resume，與語意相反 | #8 前置 | **FAIL→禁所有 motion/nav** |
+| 8 | `nav.short_move` | deep | mainline | **actuation** | **actuation** | 🟡 `/event/nav/mission` 有 outcome；runs 表 persist 待 BD-7 | 走 0.3/0.5m（需 #6+#7 pass）| F7 未定位前→insufficient |
+| 9 | `nav.dynamic_avoidance` | future | future | actuation | **actuation** | —（架構 stop-only，不繞障）| none | 灰/未主張（非 fail）|
+| 10 | `pose.basic` | thin | studio_only | evidence_only | **content** | ❌ 新 observer | studio 顯示 +「我在幹嘛」語境，無 motion | studio-only |
+| 11 | `pose.fall` | future | future（debug_only）| evidence_only | **evidence** | ❌ 新 observer | none | studio 紅 alert，不 TTS/不停車 |
+| 12 | `brain.skill_gate` | deep | mainline | **safety_critical** | **safety_guard** | 🟡 340 offline tests（historical_evidence）；on-device harness 要新 | gate：放行/擋 skill | **FAIL→Brain 全面 fail-closed** |
+| 13 | `brain.trace` | deep | mainline | evidence_only | **evidence** | 🟡 `ros2 topic echo /brain/conversation_trace` 可量；completeness scorer 要新 | studio trace drawer | trace 節點少（RuleBrain 只 1 條）|
+| 14 | `studio.evidence` | deep | mainline | evidence_only | **evidence** | ❌ 要 Jetson live smoke（live path 零自動覆蓋）| n/a（顯示層）| 主張轉弱 / 部分 mock |
+| 15 | `cli.readiness` | thin | not_claimed | safety_support | **evidence** | ✅ 139 tests（dev 跑，未進 CI；1 紅燈）| none | 手動 ops |
+
+> **claim_level / risk_role 放哪層（我編碼的微決策，Roy review 可否決）**：兩者是 capability **靜態屬性**（存 `CAPABILITY_META`，見 Task 1），**不進每筆 `CapabilityResult` record**；聚合器在 snapshot 把它們附到每個 capability，並 derive `brain_allowed = (grade=="pass" and claim_level=="mainline")`。
+
+### `brain.skill_gate` 的 historical_evidence（非本輪 status）
+`default_status=insufficient_data`；`historical_evidence="340 offline tests pass (pawai_brain/test/, mock LLM)"`。本輪 on-device baseline 跑過 safety-block scenario 才可變 pass。
+
+---
+
+## Layer-0 Preflight（top-level gate，不是 capability）
+
+> `layer0_preflight=fail → 本次 baseline run 不可信 → 全 capability 維持 insufficient_data，不產 pass/fail`。只有 `pass / pass_with_warnings` 才開始量能力。
+> **落地不自寫 runner**：`jetson-verify` 的 `demo.yaml` profile 目前是 stub（`checks: []` → `verify.py` `sys.exit(2)`）。把 `smoke.yaml` 已驗證的 check 搬過去 + 補 3 個。8 項裡 5 項現成。
+
+| check | pass | degraded | fail | hard-blocker? | 現成來源 |
+|---|---|---|---|---|---|
+| `jetson.ssh_reachable` | 可達 | — | 不可達 | **YES（全域）** | ✅ `main.py:348` doctor SSH echo / `shell.ssh_args` |
+| `go2.ethernet_ping` | 0% loss & <5ms | jitter/間歇 | loss/不可達 | **YES（nav/motion + megaphone-voice）；純 vision 否** | ✅ `network.py:64` `jetson_ping_go2` |
+| `ros.runtime_started` | 該 lane expected node set 全 alive | 部分 | 0 nodes | **YES（冷機不能量）** | 🟡 補：`smoke.yaml` ros2.daemon/topic_count + node-count gate |
+| `demo.entrypoint_started` | 走 demo script（gateway 8080 / tmux `demo:` session）| bare `ros2 run` | 沒起 | **YES（Q3 鐵律）** | ✅ `network.py:290` gateway_8080 / `status.py:47` has_demo |
+| `go2.driver_alive` | webrtc subscriber ≥1 | webrtc degraded | 無 driver | **capability-conditional**（motion/Go2-TTS 要；純 vision 否）| 🟡 補：`smoke.yaml module.go2.webrtc_subscriber`（語意正向）|
+| `topic_contract_ok` | 0 FAIL,0 WARN | 0 FAIL, WARN 落在受測能力 path | 任一 FAIL on-path | **conditional** | ✅ `pawai contract check --jetson` |
+| `resource_idle_snapshot` | RAM headroom ≥0.8GB & temp<70°C | 0.5–0.8GB / 70–80°C | <0.5GB / >80°C / throttle | **fail 才 block** | ✅ `smoke.yaml` system.memory/disk/gpu_temp + JetsonMonitor |
+| `version_snapshot` | 記到 `{wsl_commit, wsl_dirty, branch, jetson_install_sha, deploy_ts, sync_method, manifest_exists, version_mismatch, version_stale, run_id, demo_profile_env}` | `wsl_dirty` / `version_stale`（manifest age>6h，標註）| 取不到版本（無 manifest→`version_mismatch=True`）| **fail 才 block；mismatch/stale 標註不 block** | 🟡 補：讀 `.pawai-last-deploy`（`status.py:11`）；`version_stale` 由 manifest `when` age 判（`current_run_meta(stale_after_h=6)`）|
+
+**lane-aware expected node set**（`ros.runtime_started` 判定依此；node 真名，非檔名）：
+```text
+vision-baseline : realsense + face_identity_node + vision_perception_node + object_perception_node
+voice-baseline  : stt_intent_node + tts_node + conversation_graph_node ﹝interaction_executive_node/llm_bridge 視 engine﹞
+                  ﹝VAD 是 stt_intent_node 內建 energy VAD，無獨立 vad_node——勿要求﹞
+                  ﹝go2_driver 只在 megaphone TTS 才需﹞
+nav-baseline    : sllidar_node + go2_driver_node + twist_mux + reactive_stop_node
+                  + nav_action_server_node + state_broadcaster_node + capability_publisher_node + depth_safety_node
+                  + Nav2 core(controller/planner/bt/behavior/smoother/velocity_smoother/waypoint_follower) + amcl + map_server
+```
+
+**`topic_contract_ok` 的 2 WARN 裁定（今日實機）**：`/state/executive/brain`(planned/未實作) + `/executive/status`(legacy，被 `/state/pawai_brain` 取代) 都是 off-path 孤兒 → **pass_with_warnings = GO**，WARN 進 Known Findings（contract 清理），不阻 baseline。
+
+**`version_snapshot` 雙-sha fail-closed**：`wsl_commit`(dev `git rev-parse`) 與 `jetson_install_sha`(`.pawai-last-deploy.git_sha_full`) **mismatch → 警告**（範本 `status.py:286-296`）。裸 `~/sync once` 不更新 manifest → 標 stale，由 manifest `when` age 判。
+
+---
+
+## 四文件結構（2026-06-01 拆檔）
+
+本 plan 已從 1375 行單檔拆成 4 份，本檔降級為**總控 / 架構決策 / index**：
+
+| 文件 | 路徑 | 放什麼 |
+|---|---|---|
+| **Master Plan（本檔）** | `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md` | goal / scope / 6 deliverable / Layer-0 Preflight / 15 能力 canonical 表 / 三軸定義 / dependency map / fail-closed 設計 / Known Findings / issue 入口 |
+| **Capability Baseline Spec** | `docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md` | 15 能力逐功能 9+1 問（門檻數字的**唯一真相源**）|
+| **Scoreboard Implementation Plan** | `docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md` | 6 deliverable 的 TDD skeleton（test→impl→commit）|
+| **Baseline Runbook** | `docs/runbook/2026-06-18-baseline-runbook.md` | 上機跑 baseline / JSONL / snapshot freeze / demo 當天用 |
+
+> **drift 防線**：門檻數字只在 Spec、code 結構只在 Implementation、上機步驟只在 Runbook。本檔不重複這三者，只放架構決策與 index。
+
+### 6 deliverable（實作見 Implementation Plan）
+
+| File | 責任 |
+|---|---|
+| `benchmarks/core/scoreboard_schema.py` | `CapabilityResult` + `CAPABILITY_META`(含 dependency_role) + `current_run_meta()`(雙-sha + layer0→run_trusted) |
+| `benchmarks/core/grader.py` | 四段 grade + `brain_allowed` |
+| `benchmarks/core/scoreboard.py` | 聚合器：snapshot 遍歷全 15 能力(F1) + preflight-fail 覆寫(F2) + dependency_role(F5) |
+| `benchmarks/core/perception_baseline_observer.py` | gesture/object（event-only）|
+| `benchmarks/core/face_baseline_observer.py` | face（`/state/perception/face` 連續流，F3）|
+| `benchmarks/core/build_scoreboard.py` | CLI thin wrapper（runbook 用）|
+| `.claude/skills/jetson-verify/profiles/demo.yaml` | Layer-0 Preflight 8 check（canonical=`.claude/`，git-tracked；`.agents/` 是未追蹤舊鏡像）|
+
+## 設計段 C：手寫 demo skill → capability dependency map（非 TDD code，供 v0.2 fail-closed 用）
+
+> demo skill 手寫 dependency map（不用 executor 種類自動粗推）。**安全依賴明確標 safety_critical**。
+> **2026-06-01 校正（subagent file:line 雙輪核對）**：skill name **一律用 `interaction_executive/interaction_executive/skill_contract.py` 的真實 `SKILL_REGISTRY` name**（29 條），不得自創。原 v0.2 草稿 4 個名錯已更正；非單一 skill 的 demo 段落明標「〔demo 段 alias〕」。`demo_status_baseline`（skill_contract.py:77-80，5 值 enum）是 skill 層既有的靜態 demo gate，與此 capability dependency map **分屬兩層、不可雙真相源**（見設計段 D）。
+
+| demo 段（alias）| 真實 skill（skill_contract.py）| 依賴 capability（全 pass 才允許進主線）|
+|---|---|---|
+| 熟人問候 | `greet_known_person`（:349, emote 1016）| face.recognition + voice.command(TTS) |
+| 回應固定指令〔alias〕| `chat_reply`（:199）or `say_canned`（:211）| voice.command |
+| 揮手回應 | `wave_hello`（:247, emote 1016）| gesture.wave |
+| 物件提醒 | `object_remark`（:432）| object.cup + voice.command(TTS) |
+| 坐下陪伴 | `sit_along`（:263, StandDown 1005）| voice.command |
+| 短距移動 | `nav_demo_point`（:450, goto_relative **1.2m**, requires_confirmation, baseline=`explain_only`）| nav.short_move + **nav.safe_stop + nav.no_auto_resume（safety_critical，硬性前置）** |
+| 拒絕危險動作 | `request_backflip`（:405, 觸發→IE `validate()` 發現 backflip→1301 BANNED→必 reject）| brain.skill_gate（deterministic，恆可用）|
+
+> **修正紀錄**：`sit_down`→`sit_along`、`approach_short`→`nav_demo_point`（注意是 1.2m 非 0.3/0.5m）、`refuse_unsafe`→`request_backflip`、`answer_fixed_command`→無單一 skill（demo alias →〔chat_reply｜say_canned〕，依 intent 決定）。`greet_known_person`/`wave_hello`/`object_remark` 三者本就正確。
+> **`voice.stop` 不在任何 skill 的安全依賴鏈**：它是 operator_abort/convenience，motion 安全一律由 `nav.safe_stop / nav.no_auto_resume / reactive_stop / 物理 e-stop` 保證，與「狗有沒有聽到『停』」無關。
+
+---
+
+## 設計段 D：Brain fail-closed 規則設計（v0.1 只設計，不接 runtime）
+
+> **2026-06-01 結構校正（subagent file:line 證實，推翻 v0.2 草稿假設）**：Brain fail-closed **不是要新造機制**。`pawai_brain/pawai_brain/capability/effective_status.py:26 compute_effective_status(skill, world)` **已是 runtime 純函式、已在跑**，已透過 `registry.py:72 baseline=contract.demo_status_baseline` 消費 skill 層 demo gate，已輸出 **8 態**（`disabled / studio_only / explain_only / cooldown / defer / blocked / needs_confirm / available`）。它真正缺的不是「health 維度不存在」，而是 **input 沒有 scoreboard 的 `grade` / `brain_allowed`**（現 `WorldFlags` 只有 `tts_playing/obstacle/nav_safe`）。
+>
+> **v0.1 = 只寫規格（本段）；v0.2 = 擴既有函式**：在 `WorldFlags`（或新 `CapabilityHealth` 參數）加 `capability_grade / brain_allowed / failure_reason`，**在既有 first-match 鏈插一個 grade 分支**，並補單測。**不另造平行 gate**（否則與既有 8 態邏輯衝突）。
+
+**四欄四問——不可混、不可雙真相源**（這是本段最重要的紀律）：
+
+| 欄位 | 在哪層 | 回答什麼 |
+|---|---|---|
+| `demo_status_baseline` | skill 層（skill_contract.py:77）| 這 **skill** demo 本來能不能執行？|
+| `claim_level` | capability 層（CAPABILITY_META）| 這 **能力** 6/18 是否主張？|
+| `grade` | baseline snapshot | 這 **能力** 量起來是否可靠？|
+| `dependency_role` | capability 層（CAPABILITY_META）| 它 fail 時依賴它的 skill 怎麼 **降級**？|
+
+> v0.2 runtime gate 必須**把四者合成**判 skill 最終狀態，不可各自獨立、不可讓 capability 層的 `claim_level` 與 skill 層的 `demo_status_baseline` 各標各的而 drift。Baseline scoreboard 只**提供能力健康資料**，skill 最終狀態仍由擴充後的 `compute_effective_status()` 決定。
+
+**前置（Layer-0）**：`layer0_preflight != pass/pass_with_warnings → 全 capability grade = insufficient_data`，以下規則不啟動。
+
+**v0.2 要插入的 grade 分支規格**（first-match-wins，查依賴 capability 的 `grade`（snapshot）+ `dependency_role`（CAPABILITY_META）；接在既有 disabled / studio_only / explain_only / demo_guide / static_enabled / enabled_when / cooldown 判定**之後**、physical-block（tts_playing / obstacle / nav_safe）判定**之前**；對齊 Spec §7a row 10 完整序列）：
+
+```
+對每個 demo skill，取其依賴 capability（設計段 C map）的 grade + dependency_role：
+- 任一依賴 grade == "fail":
+    - dependency_role == "trigger"      → ("disabled",  f"{cap} FAIL，trigger 不觸發該 skill")
+    - dependency_role == "safety_guard" → ("blocked",   f"{cap} FAIL，禁所有 motion/nav")
+    - dependency_role == "actuation"    → ("blocked",   f"{cap} FAIL，禁該動作")
+    - dependency_role == "content"      → 放行但內容降級（face→不叫名字；object→不口頭，只 studio）
+    - dependency_role == "evidence"     → 放行（只影響 studio 顯示）
+- 任一依賴 grade in ("degraded","insufficient_data"):
+    - dependency_role in ("safety_guard","actuation") → ("blocked", f"{cap} 未達 pass，不准 motion/nav")
+    - dependency_role == "trigger"                    → ("disabled", f"{cap} 未達 pass，不觸發")
+    - dependency_role in ("content","evidence")       → 放行（只允許 say/表情/顯示，不 motion）
+- 所有依賴 brain_allowed == True（grade==pass AND claim_level==mainline）→ 落回既有 8 態流程
+注：claim_level != mainline 的 capability（future/studio_only/not_claimed）即使 grade==pass 也不進主線（brain_allowed=False）。
+```
+
+demo-day health 來源 = **baseline snapshot（凍結）**，不在 demo 中即時重算（避免 grade 抖動讓 Brain 行為跳變）。
+
+---
+
+## Known Findings（recon 抓到的 root-cause / 風險；**候選，baseline fail 後才開修，非 pre-baseline fix**）
+
+> 紀律：主張能力 as-is baseline，這些不混進 P0 baseline。只有「決定主張該能力 **且** baseline fail」才開修（多屬 v0.3）。
+
+- **object 多類**：`object_perception.yaml:20 class_whitelist=[41,999]` 鎖 cup-only（commit b81cfdd，從未改回）。**但 `object.cup` 本身對齊 6/18 主張、不算壞**；只有要主張 `object.bottle/general` 時才改 yaml 一行 [0,16,39,41,56,60]（注意保留 ≥2 int 避 BYTE_ARRAY 坑）。
+- **gesture 靜態誤觸**：MediaPipe Recognizer 無 `score_threshold`（預設 -1=停用）→ 靜態手勢無 confidence floor。**但 6/18 只主張 `gesture.wave`（走 WaveDetector，不同路徑）**；score-floor 修的是靜態手勢（非主張）。
+- **nav 0.85 profile motion-UNVERIFIED**：唯一 logged motion 用已否決的 0.75/1.20；sensor-inventory 的「gate-c PASS」已校正為 unbacked（見該 doc + project-status §5/27 校正）。baseline 前不可當 pass。
+- **nav recorder BD-7 + no_auto_resume 行為衝突 BD-8**：`recorder_node` 的 `_cb_reactive_status`/`_cb_depth_safety` no-op → `safe_stop` 量不出（BD-7 接 recorder 即可）。**但 `no_auto_resume` 更嚴重——不只量測缺口，是行為定義衝突**：`reactive_stop_node.py:307 _maybe_call_nav_pause` 離開 danger 自動發 `/nav/resume`（=auto-resume），與「停了不自動衝、須等新命令」語意相反；hold_brake mode 又故意不 resume（:33-34），行為不統一。**BD-8 需行為重設計，不是接 recorder 就能過**（獨立 nav workstream）。
+- **studio live path 零自動覆蓋**：所有 studio commit 都是 layout/CORS fix，無一次乾淨 Jetson e2e 紀錄 → `studio.evidence` 必須補一條 live smoke。
+- **cli CI 缺口**：139 tests 不在 CI（`.github/workflows` 0 引用）+ 1 常態紅燈（`test_health_brain_passes_jetson_host_env` 測試隔離 bug）+ `demo-preflight` skill 指向不存在的 `scripts/preflight.py`。
+- **wave 雙回應（風險非 confirmed bug）**：`event_action_bridge` 也訂 `/event/gesture_detected`，但 `start_full_demo_tmux.sh:99` 會 `pkill event_action_bridge` → 預設不雙發。**preflight 檢查 `event_action_bridge` 不在主線**即可。
+- **doc drift**：contract 2 WARN（`/state/executive/brain` planned、`/executive/status` legacy）；測試數膨脹（brain 文件 ~30 實際 340、studio 221 實際 59、object 37 實際 34+1紅）；studio port 8001 vs 8080；brain mode 7 vs 8。場上 debug 會被誤導，列入清理候選。
+
+---
+
+## North Star 對齊（不在本 plan 改 North Star，只記錄）
+
+`docs/mission/2026-06-18-demo-north-star.md §7` 的 `nav.short_move + nav.safe_stop` 複合寫法，與本 plan 拆成 `nav.safe_stop` / `nav.no_auto_resume` / `nav.short_move` 三能力一致（North Star 是 scope 優先級層、本 plan 是量測層，不衝突）。North Star §7 的 F7 前置 caveat 仍有效。**North Star 正文待 ADR amend 時一併同步**，本 plan 不 silent conflict。
+
+---
+
+## Self-Review
+
+**1. Spec coverage**（6 deliverable）：scoreboard_schema → Task 1 ✓；grader(+brain_allowed) → Task 2 ✓；聚合器(+claim_level/risk_role/dependency_role snapshot + F1 全列 + F2 preflight 覆寫) → Task 3 ✓；gesture/object observer（event-only）→ Task 4 ✓；**face observer（state 流，F3）→ Task 4b ✓**；**`build_scoreboard` CLI（A4）→ Task 3b ✓**；Layer-0 Preflight gate → 專段 + `demo.yaml` ✓；canonical 15 能力表 ✓；gesture.wave 協定 → 設計段 B ✓；dependency map → 設計段 C ✓；Brain fail-closed（不接 runtime）→ 設計段 D ✓；上機 runbook（含 A2 voice 轉 record）→ 設計段 E ✓；Known Findings（候選非 pre-fix）✓。砍項（health publisher / Studio UI / full CLI json / nav recorder 深整合 / 換模型）全部不在本 plan ✓。
+
+> **例外（2026-06-01，對齊 Spec §8 `studio.evidence`）**：「Studio UI 砍項」有一個有限例外 ── §8 允許**最小唯讀 scoreboard chip**，只讀 frozen `baseline_snapshot.json`（`GET /api/scoreboard`）；**不包含** live health monitor、即時重算、或 Brain runtime gate 接線。超出此範圍的 Studio health panel / runtime monitor 仍砍。
+
+**2. Placeholder scan**：6 個 deliverable 的 test + 實作皆完整無 TBD；`perception_baseline_observer`/`face_baseline_observer` 的 ROS node wrapper 標「Jetson 跑、保持薄、不在 CI」（純邏輯已 TDD）；`build_scoreboard.py` 標 ≤30 行 CLI（runbook 工具，簽名見 File Structure 段 Task 3b）。
+
+**3. Type consistency**：`CapabilityResult` 欄位 ↔ 聚合器讀的 key（capability_id/pass_fail/false_trigger/latency_ms）一致；`evaluate_round` 產的 dict 欄位 ↔ `CapabilityResult` 子集一致（capability_id/scenario_id/expected_label/predicted_label/pass_fail/false_trigger/confidence/latency_ms/distance_m/distance_source）；`CAPABILITY_META` 的 claim_level/risk_role/**dependency_role** enum ↔ test 斷言一致；`brain_allowed(grade, claim_level)` 簽名在 grader/scoreboard/test 一致；canonical capability_id 全文單一能力（無 `+` 複合）。**2026-06-01 dry-run 驗證**：Task 1 `CAPABILITY_META`（15 能力含 dependency_role）+ `current_run_meta()`（含 version_stale/wsl_dirty/branch/manifest_exists）抽出實跑，4 組新斷言全綠（15 caps / stale-fresh / no-manifest fail-closed / dirty）；`_git` 在非 repo 環境正確降級 "unknown"。
+
+**3b. 四欄不雙真相源（2026-06-01）**：`demo_status_baseline`（skill 層 skill_contract.py:77）vs `claim_level`/`dependency_role`（capability 層 CAPABILITY_META）分屬兩層，v0.2 `compute_effective_status()` 合成判定、不各自獨立（設計段 D）。canonical capability ↔ 真實 skill name（設計段 C，錨 skill_contract.py）已對齊，無杜撰名。
+
+**4. 風險旗標**：Step 0 先確認 `benchmarks/test/` 慣例；`object.cup` baseline 先確認 whitelist=[41] 現況（改 config 屬 v0.3）；`nav.safe_stop` 卡 recorder BD-7（標 insufficient）；**`nav.no_auto_resume` 卡 BD-8 行為重設計（現行 auto-resume 與語意相反，非只接 recorder）**；`nav.short_move` 卡 3 blocker（Brain dispatch IE:278 stub / F7 / 無實機 pass，未達前標 insufficient，且 safety 兩項 pass 前只 dry-run）；version_snapshot 無 manifest → version_mismatch=True（fail-closed）；資源欄位 v0.1 可為 None（JetsonMonitor 整合屬 runbook 手動填）；gesture baseline 必走 recognizer backend（非壓測腳本的 mediapipe）。
+
+---
+
+## Execution Handoff
+
+Plan 完成，存於 `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md`。執行方式**工具中立**：用 TDD；可選擇 **(a)** 每個 task 派 fresh subagent/worker、task 間 review，或 **(b)** 本 session 批次執行 + checkpoint review。
+
+（6 個 deliverable：核心 4（schema/grader/scoreboard 聚合器 + gesture-object observer）+ Task 3b `build_scoreboard` CLI + Task 4b `face_baseline_observer`。聚合件純 Python、dev 機可跑、無 ROS 依賴；observer 純邏輯 TDD、ROS node wrapper Jetson 跑。`demo.yaml` preflight profile 是 YAML。設計段 A–E + Known Findings 是文件/runbook。**建議實作序**：Task 1 → 2 → 3（含 F1/F2/F5）→ 3b → 4（gesture/object）→ 4b（face）→ demo.yaml。）

--- a/docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md
+++ b/docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md
@@ -1,0 +1,1318 @@
+# Scoreboard Implementation Plan（TDD，給工程師照做）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: 用 superpowers:subagent-driven-development 或 executing-plans 逐 task 實作。Steps use checkbox (`- [ ]`) syntax。
+> **性質**：6 個 deliverable 的 TDD skeleton（test→impl→commit）。這份是「**怎麼寫 code**」的唯一真相源。
+> **不放**：架構決策（見 Master Plan）、逐功能門檻（見 Capability Baseline Spec）、上機步驟（見 Runbook）。
+> **關係**：
+> - 架構決策 / 三軸定義 / 15 能力 index → `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md`（Master Plan）
+> - 逐功能門檻（門檻數字的真相源）→ `docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md`
+> - 上機跑 → `docs/runbook/2026-06-18-baseline-runbook.md`
+
+**Goal:** 6 個 Python deliverable，dry-run 全綠：`scoreboard_schema` / `grader` / `scoreboard`(聚合器) / `perception_baseline_observer`(gesture+object) / `face_baseline_observer`(face state) / `build_scoreboard`(CLI)。
+
+**建議實作序**：Task 1 → 2 → 3（含 F1/F2/F5）→ 3b → 4（gesture/object）→ 4b（face）。
+
+**Step 0（執行前先確認）**：repo 測試目錄為 `benchmarks/test/`（已確認）。先確認 `python -m pytest benchmarks/test -q` 可跑再開始。
+
+> **注意：門檻數字不在本檔**。Criterion 的 pass_min/degraded_min 一律從 Capability Baseline Spec 取（provisional until baseline）。本檔只定 code 結構與 TDD 步驟。
+
+---
+
+## Task 1: `scoreboard_schema.py`（14 欄 record + CAPABILITY_META + version_snapshot）
+
+**Files:**
+- Create: `benchmarks/core/scoreboard_schema.py`
+- Test: `benchmarks/test/test_scoreboard_schema.py`
+
+- [ ] **Step 1: 寫失敗測試**
+
+```python
+# benchmarks/test/test_scoreboard_schema.py
+from benchmarks.core.scoreboard_schema import (
+    CapabilityResult, SCHEMA_VERSION, CAPABILITY_META, current_run_meta,
+)
+
+
+def test_to_record_has_schema_version_and_core_fields():
+    r = CapabilityResult(
+        capability_id="gesture.wave",
+        scenario_id="wave_1.5m_frontal",
+        run_id="run-abc",
+        timestamp="2026-05-31T12:00:00Z",
+        git_commit="deadbee",
+        expected_label="wave",
+        predicted_label="wave",
+        pass_fail="pass",
+        confidence=0.91,
+        distance_m=1.5,
+        latency_ms=120.0,
+    )
+    rec = r.to_record()
+    assert rec["schema_version"] == SCHEMA_VERSION
+    assert rec["capability_id"] == "gesture.wave"
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["distance_source"] == "manual_declared"
+    assert rec["failure_reason"] == ""
+
+
+def test_capability_meta_has_claim_and_risk_for_every_canonical_id():
+    # 每個 canonical capability 都要有靜態屬性（claim_level / risk_role / depth / dependency_role）
+    for cap, meta in CAPABILITY_META.items():
+        assert meta["claim_level"] in {"mainline", "studio_only", "future", "not_claimed"}
+        assert meta["risk_role"] in {
+            "safety_critical", "safety_support", "actuation", "convenience", "evidence_only",
+        }
+        assert meta["depth"] in {"deep", "thin", "future"}
+        # dependency_role（2026-06-01 新增）：每能力必標，供設計段 C / v0.2 chain-gating
+        assert meta["dependency_role"] in {
+            "trigger", "content", "safety_guard", "actuation", "evidence",
+        }
+    # nav 已拆成單一能力，不可有複合 id
+    assert "nav.safe_stop" in CAPABILITY_META
+    assert "nav.short_move" in CAPABILITY_META
+    assert "nav.short_move + nav.safe_stop" not in CAPABILITY_META
+    # dependency_role 與 risk_role 正交：safety_critical 能力的 dependency_role 是 safety_guard，非 evidence
+    assert CAPABILITY_META["nav.safe_stop"]["dependency_role"] == "safety_guard"
+    assert CAPABILITY_META["gesture.wave"]["dependency_role"] == "trigger"
+    assert CAPABILITY_META["face.recognition"]["dependency_role"] == "content"
+
+
+def test_run_meta_records_dual_sha_and_run_id():
+    meta = current_run_meta(
+        jetson_manifest={"git_sha_full": "abc123def", "when": "2026-05-31T10:00:00Z",
+                         "sync_method": "rsync", "dirty": False},
+        demo_profile_env={"REACTIVE_DANGER_M": "0.85", "MAP": "v9"},
+    )
+    assert meta["schema_version"] == SCHEMA_VERSION
+    assert "run_id" in meta and meta["run_id"]
+    assert meta["jetson_install_sha"] == "abc123def"
+    assert meta["jetson_deploy_ts"] == "2026-05-31T10:00:00Z"
+    assert meta["demo_profile_env"]["MAP"] == "v9"
+    # wsl_commit vs jetson_install_sha 不一致時要有 fail-closed 旗標
+    assert "version_mismatch" in meta
+
+
+def test_run_meta_without_manifest_flags_unknown_install():
+    meta = current_run_meta(jetson_manifest=None)
+    assert meta["jetson_install_sha"] is None
+    assert meta["version_mismatch"] is True  # 無 manifest = 無法確認 Jetson 跑的是哪版 → fail-closed
+    assert meta["manifest_exists"] is False
+
+
+def test_run_meta_flags_stale_manifest_by_age():
+    # 洞④：manifest 太舊（deploy 後沒重 deploy 就跑 baseline）→ version_stale=True（標註，非硬 block）
+    old = current_run_meta(
+        jetson_manifest={"git_sha_full": "abc123def", "when": "2020-01-01T00:00:00Z",
+                         "sync_method": "rsync", "dirty": False},
+        now_iso="2026-05-31T10:00:00Z", stale_after_h=6,
+    )
+    assert old["version_stale"] is True
+    fresh = current_run_meta(
+        jetson_manifest={"git_sha_full": "abc123def", "when": "2026-05-31T08:00:00Z",
+                         "sync_method": "rsync", "dirty": False},
+        now_iso="2026-05-31T10:00:00Z", stale_after_h=6,
+    )
+    assert fresh["version_stale"] is False
+
+
+def test_run_meta_records_dirty_and_branch():
+    meta = current_run_meta(jetson_manifest={"git_sha_full": "abc123def", "dirty": True})
+    assert "wsl_dirty" in meta and "branch" in meta and "manifest_exists" in meta
+    assert meta["jetson_dirty"] is True  # manifest 的 dirty 旗標要轉出來
+
+
+def test_run_meta_layer0_preflight_pass_marks_run_trusted():
+    # F2：preflight pass / pass_with_warnings → run_trusted=True
+    meta = current_run_meta(layer0_preflight={"status": "pass"})
+    assert meta["layer0_preflight_status"] == "pass"
+    assert meta["run_trusted"] is True
+    meta_w = current_run_meta(layer0_preflight={"status": "pass_with_warnings"})
+    assert meta_w["run_trusted"] is True
+
+
+def test_run_meta_layer0_preflight_fail_marks_untrusted():
+    # F2：preflight fail / 缺結果 → run_trusted=False（fail-closed，to_snapshot 會覆寫全 grade）
+    meta = current_run_meta(layer0_preflight={"status": "fail"})
+    assert meta["layer0_preflight_status"] == "fail"
+    assert meta["run_trusted"] is False
+    meta_none = current_run_meta()  # 沒跑 preflight = 不可信
+    assert meta_none["layer0_preflight_status"] == "unknown"
+    assert meta_none["run_trusted"] is False
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `python -m pytest benchmarks/test/test_scoreboard_schema.py -q`
+Expected: FAIL（`ModuleNotFoundError: benchmarks.core.scoreboard_schema`）
+
+- [ ] **Step 3: 實作 schema**
+
+```python
+# benchmarks/core/scoreboard_schema.py
+"""Capability baseline result schema + 靜態 capability metadata (v0.1)。
+
+一筆 JSONL record = 一次 scenario-run。claim_level / risk_role 是 capability 的「靜態屬性」，
+存 CAPABILITY_META，不進每筆 record（避免重複）。run-level meta 帶 version_snapshot 雙 sha
+（Jetson 無 .git，dev commit ≠ Jetson install）。
+"""
+from __future__ import annotations
+
+import subprocess
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+SCHEMA_VERSION = "scoreboard-0.1"
+
+# capability_id → 靜態屬性（claim_level/risk_role/dependency_role 是作者標的，不是量出來的）
+# dependency_role（2026-06-01 加）：fail 時依賴它的 demo skill 怎麼降級——
+#   trigger→不觸發該 skill；content→skill 觸發但內容降級；safety_guard→禁 motion；
+#   actuation→禁該動作；evidence→只影響 Studio 顯示。與 risk_role 正交。v0.1 不被 grader 消費（design-only）。
+CAPABILITY_META: dict[str, dict] = {
+    "face.recognition":     {"depth": "deep",  "claim_level": "mainline",    "risk_role": "evidence_only",   "dependency_role": "content"},
+    "voice.command":        {"depth": "deep",  "claim_level": "mainline",    "risk_role": "convenience",     "dependency_role": "trigger"},
+    "voice.stop":           {"depth": "deep",  "claim_level": "mainline",    "risk_role": "convenience",     "dependency_role": "trigger"},
+    "gesture.wave":         {"depth": "deep",  "claim_level": "mainline",    "risk_role": "convenience",     "dependency_role": "trigger"},
+    "object.cup":           {"depth": "deep",  "claim_level": "mainline",    "risk_role": "evidence_only",   "dependency_role": "content"},
+    "nav.safe_stop":        {"depth": "deep",  "claim_level": "mainline",    "risk_role": "safety_critical", "dependency_role": "safety_guard"},
+    "nav.no_auto_resume":   {"depth": "deep",  "claim_level": "mainline",    "risk_role": "safety_critical", "dependency_role": "safety_guard"},
+    "nav.short_move":       {"depth": "deep",  "claim_level": "mainline",    "risk_role": "actuation",       "dependency_role": "actuation"},
+    "nav.dynamic_avoidance":{"depth": "future","claim_level": "future",      "risk_role": "actuation",       "dependency_role": "actuation"},
+    "pose.basic":           {"depth": "thin",  "claim_level": "studio_only", "risk_role": "evidence_only",   "dependency_role": "content"},
+    "pose.fall":            {"depth": "future","claim_level": "future",      "risk_role": "evidence_only",   "dependency_role": "evidence"},
+    "brain.skill_gate":     {"depth": "deep",  "claim_level": "mainline",    "risk_role": "safety_critical", "dependency_role": "safety_guard"},
+    "brain.trace":          {"depth": "deep",  "claim_level": "mainline",    "risk_role": "evidence_only",   "dependency_role": "evidence"},
+    "studio.evidence":      {"depth": "deep",  "claim_level": "mainline",    "risk_role": "evidence_only",   "dependency_role": "evidence"},
+    "cli.readiness":        {"depth": "thin",  "claim_level": "not_claimed", "risk_role": "safety_support",  "dependency_role": "evidence"},
+}
+
+
+@dataclass
+class CapabilityResult:
+    # --- 識別 ---
+    capability_id: str            # 須在 CAPABILITY_META 內（單一能力，不可複合）
+    scenario_id: str              # 如 "wave_1.5m_frontal" / "idle_hand_60s"
+    run_id: str                   # 每個 baseline session 一個 uuid（caller 提供）
+    timestamp: str                # UTC ISO8601（caller 提供，真實來源）
+    git_commit: str               # WSL git rev-parse --short HEAD（caller 提供）
+    # --- 判定 ---
+    expected_label: str
+    predicted_label: str
+    pass_fail: str                # 單一 scenario 的 raw outcome："pass" | "fail"
+    confidence: Optional[float] = None
+    distance_m: Optional[float] = None
+    distance_source: str = "manual_declared"   # "d435_depth" | "manual_declared"
+    latency_ms: Optional[float] = None
+    frame_age_ms: Optional[float] = None
+    fps: Optional[float] = None
+    false_trigger: bool = False
+    stable_time_ms: Optional[float] = None
+    # --- 資源（reuse JetsonMonitor 後填；v0.1 可留 None）---
+    cpu_pct: Optional[float] = None
+    gpu_pct: Optional[float] = None
+    ram_mb: Optional[float] = None
+    failure_reason: str = ""
+
+    def to_record(self) -> dict:
+        rec = asdict(self)
+        rec["schema_version"] = SCHEMA_VERSION
+        return rec
+
+
+def _git(args: list[str]) -> str:
+    try:
+        return subprocess.check_output(["git", *args], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def _git_short() -> str:
+    return _git(["rev-parse", "--short", "HEAD"])
+
+
+def _is_stale(when_iso: Optional[str], now_iso: Optional[str], stale_after_h: float) -> bool:
+    """manifest deploy 時間距 now 超過 stale_after_h → stale（標註，非硬 block）。取不到時間 → 視為 stale。"""
+    if not when_iso:
+        return True
+    try:
+        now = datetime.fromisoformat((now_iso or datetime.now(timezone.utc).isoformat()).replace("Z", "+00:00"))
+        when = datetime.fromisoformat(when_iso.replace("Z", "+00:00"))
+        return (now - when).total_seconds() > stale_after_h * 3600
+    except Exception:
+        return True
+
+
+def current_run_meta(jetson_manifest: Optional[dict] = None,
+                     demo_profile_env: Optional[dict] = None,
+                     layer0_preflight: Optional[dict] = None,
+                     now_iso: Optional[str] = None,
+                     stale_after_h: float = 6.0) -> dict:
+    """run-level metadata。version_snapshot 雙 sha：dev commit + Jetson install sha。
+
+    jetson_manifest = 讀 Jetson 的 .pawai-last-deploy（runbook 用 pawai status / scp 取得）。
+    無 manifest 或與 dev commit 不符 → version_mismatch=True（fail-closed：不能把 dev 的
+    commit 當成 Jetson 上實際跑的版本）。manifest 太舊 → version_stale=True（標註，非硬 block；
+    裸 `~/sync once` 不更新 manifest → 由 `when` age 判）。
+
+    layer0_preflight = jetson-verify demo.yaml 跑完的結果 dict（runbook 提供，至少含 {"status": ...}）。
+    F2：status 非 pass/pass_with_warnings → run_trusted=False → to_snapshot() 全 grade 覆寫 insufficient_data
+    （fail-closed：preflight 不可信的 run 不准吐 pass/fail）。
+    """
+    m = jetson_manifest or {}
+    wsl_commit = _git_short()
+    wsl_dirty = bool(_git(["status", "--porcelain"]))  # 非空 = 有未 commit 變動
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"])
+    jetson_sha = m.get("git_sha_full")
+    manifest_exists = jetson_manifest is not None
+    # mismatch 判定：無 manifest，或 jetson sha 不以 wsl_commit 開頭（short vs full）
+    mismatch = (jetson_sha is None) or (not jetson_sha.startswith(wsl_commit) if wsl_commit != "unknown" else True)
+    pf_status = (layer0_preflight or {}).get("status", "unknown")
+    run_trusted = pf_status in ("pass", "pass_with_warnings")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "wsl_commit": wsl_commit,
+        "wsl_dirty": wsl_dirty,
+        "branch": branch,
+        "jetson_install_sha": jetson_sha,
+        "jetson_deploy_ts": m.get("when"),
+        "jetson_sync_method": m.get("sync_method"),
+        "jetson_dirty": bool(m.get("dirty")),
+        "manifest_exists": manifest_exists,
+        "version_mismatch": bool(mismatch),
+        "version_stale": _is_stale(m.get("when"), now_iso, stale_after_h),
+        "layer0_preflight_status": pf_status,
+        "run_trusted": run_trusted,
+        "demo_profile_env": demo_profile_env or {},
+    }
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `python -m pytest benchmarks/test/test_scoreboard_schema.py -q`
+Expected: PASS
+
+- [ ] **Step 5: commit**
+
+```bash
+git add benchmarks/core/scoreboard_schema.py benchmarks/test/test_scoreboard_schema.py
+git commit -m "feat(scoreboard): v0.1 schema + CAPABILITY_META + dual-sha run_meta"
+```
+
+---
+
+## Task 2: `grader.py`（四段 grade 純函式 + brain_allowed derive）
+
+**Files:**
+- Create: `benchmarks/core/grader.py`
+- Test: `benchmarks/test/test_grader.py`
+
+> 設計：grade 結合「門檻」與「樣本充足度」。`insufficient_data` = 0 樣本**或**缺 criteria（fail-closed，防 fail-open）；`pass` = 所有 metric 達 pass band **且** confirmed（sample_count ≥ confirm_min，預設 3）；`degraded` = 達 pass band 但樣本 1–2（provisional / 標黃）**或**落在 degraded band；`fail` = 任一 metric 低於 degraded band（fail-closed：任一 fail → fail）。`brain_allowed` = grade 與 claim_level 合成（claim_level 只能更嚴）。
+
+- [ ] **Step 1: 寫失敗測試**
+
+```python
+# benchmarks/test/test_grader.py
+from benchmarks.core.grader import (
+    Criterion, grade_capability, brain_allowed,
+    GRADE_PASS, GRADE_DEGRADED, GRADE_FAIL, GRADE_INSUFFICIENT,
+)
+
+HIGHER = Criterion(metric="success_rate", pass_min=0.90, degraded_min=0.80, higher_is_better=True)
+LOWER = Criterion(metric="false_trigger_rate", pass_min=0.10, degraded_min=0.30, higher_is_better=False)
+
+
+def test_zero_samples_is_insufficient():
+    assert grade_capability({"success_rate": 0.99}, [HIGHER], sample_count=0) == GRADE_INSUFFICIENT
+
+
+def test_empty_criteria_is_not_pass():
+    # 缺 criteria 無從判斷 → fail-closed，絕不可 pass
+    assert grade_capability({"success_rate": 0.99}, [], sample_count=5) == GRADE_INSUFFICIENT
+
+
+def test_all_pass_but_unconfirmed_is_degraded():
+    assert grade_capability({"success_rate": 0.95}, [HIGHER], sample_count=1) == GRADE_DEGRADED
+
+
+def test_all_pass_and_confirmed_is_pass():
+    assert grade_capability({"success_rate": 0.95}, [HIGHER], sample_count=3) == GRADE_PASS
+
+
+def test_any_metric_fail_is_fail():
+    metrics = {"success_rate": 0.95, "false_trigger_rate": 0.40}
+    assert grade_capability(metrics, [HIGHER, LOWER], sample_count=5) == GRADE_FAIL
+
+
+def test_lower_is_better_band():
+    assert grade_capability({"false_trigger_rate": 0.05}, [LOWER], sample_count=5) == GRADE_PASS
+    assert grade_capability({"false_trigger_rate": 0.20}, [LOWER], sample_count=5) == GRADE_DEGRADED
+
+
+def test_degraded_band_dominates_over_unconfirmed():
+    assert grade_capability({"success_rate": 0.85}, [HIGHER], sample_count=5) == GRADE_DEGRADED
+
+
+def test_brain_allowed_only_pass_and_mainline():
+    # claim_level 只能更嚴：pass 但 future → 不放行
+    assert brain_allowed(GRADE_PASS, "mainline") is True
+    assert brain_allowed(GRADE_PASS, "future") is False
+    assert brain_allowed(GRADE_PASS, "studio_only") is False
+    assert brain_allowed(GRADE_DEGRADED, "mainline") is False
+    assert brain_allowed(GRADE_FAIL, "mainline") is False
+    assert brain_allowed(GRADE_INSUFFICIENT, "mainline") is False
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `python -m pytest benchmarks/test/test_grader.py -q`
+Expected: FAIL（`ModuleNotFoundError`）
+
+- [ ] **Step 3: 實作 grader**
+
+```python
+# benchmarks/core/grader.py
+"""四段 capability grader (v0.1)。純函式、無 ROS 依賴。
+
+範式對齊 speech_processor/speech_processor/speech_test_observer.py 的 _compute_grade
+（PASS/MARGINAL/FAIL → 此處 pass/degraded/fail），擴成四段並加入「樣本充足度」維度 +
+brain_allowed（grade × claim_level，claim_level 只能更嚴）。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+GRADE_PASS = "pass"
+GRADE_DEGRADED = "degraded"
+GRADE_FAIL = "fail"
+GRADE_INSUFFICIENT = "insufficient_data"
+
+
+@dataclass
+class Criterion:
+    metric: str
+    pass_min: float
+    degraded_min: float
+    higher_is_better: bool = True
+
+
+def grade_one(value: Optional[float], crit: Criterion) -> str:
+    """單一 metric → pass/degraded/fail。None 視為 fail（保守）。"""
+    if value is None:
+        return GRADE_FAIL
+    if crit.higher_is_better:
+        if value >= crit.pass_min:
+            return GRADE_PASS
+        if value >= crit.degraded_min:
+            return GRADE_DEGRADED
+        return GRADE_FAIL
+    else:  # lower is better（誤觸率 / latency）
+        if value <= crit.pass_min:
+            return GRADE_PASS
+        if value <= crit.degraded_min:
+            return GRADE_DEGRADED
+        return GRADE_FAIL
+
+
+def grade_capability(metrics: dict, criteria: list[Criterion], sample_count: int,
+                     confirm_min: int = 3) -> str:
+    """結合門檻 + 樣本充足度的四段 grade。fail-closed：任一 metric fail → fail；缺 criteria → insufficient。"""
+    if sample_count <= 0:
+        return GRADE_INSUFFICIENT
+    if not criteria:
+        return GRADE_INSUFFICIENT  # 防 fail-open
+    grades = [grade_one(metrics.get(c.metric), c) for c in criteria]
+    if GRADE_FAIL in grades:
+        return GRADE_FAIL
+    if GRADE_DEGRADED in grades:
+        return GRADE_DEGRADED
+    if sample_count < confirm_min:
+        return GRADE_DEGRADED  # provisional / 標黃
+    return GRADE_PASS
+
+
+def brain_allowed(grade: str, claim_level: str) -> bool:
+    """Brain 主線放行 = grade==pass AND claim_level==mainline。claim_level 只能更嚴、不放寬。"""
+    return grade == GRADE_PASS and claim_level == "mainline"
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `python -m pytest benchmarks/test/test_grader.py -q`
+Expected: PASS（8 個測試全綠）
+
+- [ ] **Step 5: commit**
+
+```bash
+git add benchmarks/core/grader.py benchmarks/test/test_grader.py
+git commit -m "feat(scoreboard): v0.1 four-tier grader + brain_allowed gate derive"
+```
+
+---
+
+## Task 3: `scoreboard.py`（聚合器 → snapshot，附 claim_level/brain_allowed）
+
+**Files:**
+- Create: `benchmarks/core/scoreboard.py`
+- Test: `benchmarks/test/test_scoreboard.py`
+
+> 讀 JSONL → 按 capability_id 分組 → 算 latest grade + success_rate + false_trigger_rate + latency P50/P90 + sample_count → snapshot 每能力附 `CAPABILITY_META`（claim_level/risk_role/depth）+ derived `brain_allowed`。**不接 Brain runtime**（v0.2）。
+
+- [ ] **Step 1: 寫失敗測試**
+
+```python
+# benchmarks/test/test_scoreboard.py
+from benchmarks.core.scoreboard import aggregate, to_snapshot
+from benchmarks.core.grader import Criterion, GRADE_PASS, GRADE_FAIL
+
+CRIT = {
+    "gesture.wave": [
+        Criterion("success_rate", 0.90, 0.80, higher_is_better=True),
+        Criterion("false_trigger_rate", 0.10, 0.30, higher_is_better=False),
+    ],
+}
+
+
+def _rec(cap, ok, ft=False, lat=100.0, kind="positive"):
+    return {"capability_id": cap, "pass_fail": "pass" if ok else "fail",
+            "false_trigger": ft, "latency_ms": lat, "scenario_kind": kind}
+
+
+def test_aggregate_success_rate_and_grade():
+    recs = [_rec("gesture.wave", True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    s = scores["gesture.wave"]
+    assert s.sample_count == 4
+    assert s.success_rate == 1.0
+    assert s.false_trigger_rate == 0.0
+    assert s.confirmed is True
+    assert s.grade == GRADE_PASS
+
+
+def test_aggregate_false_trigger_forces_fail():
+    recs = [_rec("gesture.wave", True, ft=True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    assert scores["gesture.wave"].grade == GRADE_FAIL
+
+
+def test_aggregate_separates_recall_from_false_accept():
+    # F2：known/unknown 不混算。3 positive 全中 + 2 idle 其中 1 誤接
+    recs = [
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", False, ft=True, kind="idle"),   # 陌生人被誤接
+        _rec("face.recognition", True, kind="idle"),             # 陌生人正確 reject
+    ]
+    s = aggregate(recs, {}, confirm_min=3)["face.recognition"]
+    assert s.positive_count == 3 and s.idle_count == 2
+    assert s.registered_recall == 1.0          # 3/3 positive 命中（不被 idle 稀釋）
+    assert s.unknown_false_accept_rate == 0.5  # 1/2 idle 誤接（不被 positive 稀釋）
+    assert s.wrong_person_count == 0           # positive round 無誤觸
+
+
+def test_aggregate_wrong_person_counted_on_positive_round():
+    # 該認出 roy 卻誤觸（認成別人）= wrong_person，計在 positive round
+    recs = [
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", False, ft=True, kind="positive"),  # 認錯人
+    ]
+    s = aggregate(recs, {}, confirm_min=3)["face.recognition"]
+    assert s.wrong_person_count == 1
+    assert s.registered_recall == 0.5
+
+
+def test_snapshot_carries_claim_level_and_brain_allowed():
+    recs = [_rec("gesture.wave", True, lat=v) for v in (50, 100, 150, 200)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    # run_trusted=True：模擬 preflight 已通過（fail-closed 預設為 False，trusted case 須明確傳）
+    snap = to_snapshot(scores, {"git_commit": "abc", "timestamp": "2026-05-31T00:00:00Z",
+                                "run_trusted": True})
+    assert snap["git_commit"] == "abc"
+    cap = snap["capabilities"]["gesture.wave"]
+    assert cap["latency_p50"] is not None and cap["latency_p90"] is not None
+    # 靜態屬性 + derived gate 入 snapshot
+    assert cap["claim_level"] == "mainline"
+    assert cap["risk_role"] == "convenience"
+    assert cap["dependency_role"] == "trigger"   # F5：降級語意入 snapshot
+    assert cap["brain_allowed"] is True  # pass + mainline
+
+
+def test_future_capability_not_brain_allowed_even_if_pass():
+    recs = [_rec("nav.dynamic_avoidance", True) for _ in range(4)]
+    crit = {"nav.dynamic_avoidance": [Criterion("success_rate", 0.9, 0.8)]}
+    scores = aggregate(recs, crit, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": True})  # trusted：隔離 future-gate 與 fail-closed
+    cap = snap["capabilities"]["nav.dynamic_avoidance"]
+    # 即使量到 pass，claim_level=future → 不放行
+    assert cap["brain_allowed"] is False
+
+
+def test_snapshot_always_lists_all_15_capabilities():
+    # F1：只測到 1 個能力，snapshot 仍列出全部 15，未測者 insufficient_data + sample_count=0
+    recs = [_rec("gesture.wave", True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": True})  # trusted：未測=insufficient 來自零樣本，非 fail-closed
+    assert len(snap["capabilities"]) == 15
+    untested = snap["capabilities"]["face.recognition"]
+    assert untested["grade"] == "insufficient_data"
+    assert untested["sample_count"] == 0
+    assert untested["success_rate"] is None      # None=未測，非 0.0
+    assert untested["brain_allowed"] is False
+    assert untested["dependency_role"] == "content"   # 未測也帶靜態屬性
+    # trusted 下已測能力維持原 grade（隔離：未測 insufficient ≠ fail-closed 全 insufficient）
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "pass"
+
+
+def test_missing_run_trusted_defaults_failclosed():
+    # F2 fail-open 防護：caller 漏帶 run_trusted（沒跑 preflight / 手刻 run_meta）→ 預設不可信 → 全 insufficient
+    recs = [_rec("gesture.wave", True) for _ in range(5)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc"})   # 故意不帶 run_trusted
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "insufficient_data"
+    assert all(c["grade"] == "insufficient_data" for c in snap["capabilities"].values())
+
+
+def test_layer0_preflight_fail_forces_all_insufficient():
+    # F2：run_trusted=False（preflight fail）→ 連量到 pass 的能力也覆寫 insufficient_data（fail-closed）
+    recs = [_rec("gesture.wave", True) for _ in range(5)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    assert scores["gesture.wave"].grade == "pass"   # 原本量到 pass
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": False,
+                                "layer0_preflight_status": "fail"})
+    cap = snap["capabilities"]["gesture.wave"]
+    assert cap["grade"] == "insufficient_data"       # 被覆寫
+    assert cap["brain_allowed"] is False
+    assert cap["failure_reason"] == "layer0_preflight=fail"
+    assert cap["success_rate"] is not None           # raw metrics 保留（可 debug）
+    # 全部 15 能力都 insufficient
+    assert all(c["grade"] == "insufficient_data" for c in snap["capabilities"].values())
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `python -m pytest benchmarks/test/test_scoreboard.py -q`
+Expected: FAIL（`ModuleNotFoundError`）
+
+- [ ] **Step 3: 實作聚合器**
+
+```python
+# benchmarks/core/scoreboard.py
+"""聚合 baseline JSONL → 每能力 scoreboard snapshot (v0.1)。
+
+snapshot 每能力附 CAPABILITY_META（claim_level/risk_role/depth）+ derived brain_allowed，
+供人判斷哪些能力允許進 demo 主線。不接 Brain runtime（v0.2 才在 effective_status 補
+capability_health）。
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+from .grader import grade_capability, brain_allowed, Criterion, GRADE_INSUFFICIENT
+from .scoreboard_schema import CAPABILITY_META
+
+
+@dataclass
+class CapabilityScore:
+    capability_id: str
+    grade: str
+    sample_count: int
+    success_rate: float
+    false_trigger_rate: float
+    latency_p50: Optional[float]
+    latency_p90: Optional[float]
+    confirmed: bool
+    # F2（2026-06-01）：scenario_kind-aware 分離指標。positive round 算 recall、idle round 算 false-accept，
+    # 不混算（否則 face 的 unknown 誤認會被 known 成功率稀釋）。非 face 能力這些可為 None / 0。
+    positive_count: int = 0          # scenario_kind=="positive" 的 round 數
+    idle_count: int = 0              # scenario_kind=="idle" 的 round 數
+    registered_recall: Optional[float] = None        # = positive round 的 pass 率（face: 認出註冊者）
+    unknown_false_accept_rate: Optional[float] = None  # = idle round 的 false_trigger 率（face: 誤認陌生人）
+    wrong_person_count: int = 0      # 認錯人（false_trigger 且非 idle）的次數
+
+
+def _pctl(values, p: float) -> Optional[float]:
+    xs = sorted(v for v in values if v is not None)
+    if not xs:
+        return None
+    k = int(round((p / 100.0) * (len(xs) - 1)))
+    k = max(0, min(len(xs) - 1, k))
+    return xs[k]
+
+
+def load_results(path: str) -> list[dict]:
+    out: list[dict] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                out.append(json.loads(line))
+    return out
+
+
+def _kind(r: dict) -> str:
+    """record 的 scenario_kind：positive（預期命中）/ idle（預期零事件，量誤觸）。預設 positive。"""
+    return r.get("scenario_kind", "positive")
+
+
+def aggregate(records: list[dict], criteria_by_capability: dict[str, list[Criterion]],
+              confirm_min: int = 3) -> dict[str, CapabilityScore]:
+    """F2（2026-06-01）：按 (capability_id, scenario_kind) 分離算指標，避免 known/unknown 混算稀釋。
+
+    每能力同時輸出：
+      - success_rate / false_trigger_rate：全 round（向後相容，gesture/object 仍用）
+      - registered_recall = positive round 的 pass 率
+      - unknown_false_accept_rate = idle round 的 false_trigger 率
+      - wrong_person_count = 非 idle round 卻 false_trigger（認錯人/誤接）的次數
+    grader 的 Criterion.metric 可指向上述任一 key（face 用 registered_recall + unknown_false_accept_rate；
+    gesture/object 用 success_rate + false_trigger_rate）。
+    """
+    by_cap: dict[str, list[dict]] = {}
+    for r in records:
+        by_cap.setdefault(r["capability_id"], []).append(r)
+
+    scores: dict[str, CapabilityScore] = {}
+    for cap, recs in by_cap.items():
+        n = len(recs)
+        pos = [r for r in recs if _kind(r) == "positive"]
+        idle = [r for r in recs if _kind(r) == "idle"]
+        succ = sum(1 for r in recs if r.get("pass_fail") == "pass") / n
+        ft = sum(1 for r in recs if r.get("false_trigger")) / n
+        lat = [r.get("latency_ms") for r in recs]
+        reg_recall = (sum(1 for r in pos if r.get("pass_fail") == "pass") / len(pos)) if pos else None
+        ufa = (sum(1 for r in idle if r.get("false_trigger")) / len(idle)) if idle else None
+        wrong = sum(1 for r in pos if r.get("false_trigger"))  # positive round 卻誤觸 = 認錯人/誤接
+        metrics = {
+            "success_rate": succ, "false_trigger_rate": ft, "latency_p50": _pctl(lat, 50),
+            "registered_recall": reg_recall, "unknown_false_accept_rate": ufa,
+            "wrong_person_count": wrong,
+        }
+        g = grade_capability(metrics, criteria_by_capability.get(cap, []), n, confirm_min)
+        scores[cap] = CapabilityScore(
+            capability_id=cap, grade=g, sample_count=n,
+            success_rate=round(succ, 3), false_trigger_rate=round(ft, 3),
+            latency_p50=_pctl(lat, 50), latency_p90=_pctl(lat, 90),
+            confirmed=(n >= confirm_min),
+            positive_count=len(pos), idle_count=len(idle),
+            registered_recall=(round(reg_recall, 3) if reg_recall is not None else None),
+            unknown_false_accept_rate=(round(ufa, 3) if ufa is not None else None),
+            wrong_person_count=wrong,
+        )
+    return scores
+
+
+def _empty_score_dict(cap_id: str) -> dict:
+    """零樣本能力的骨架（F1：snapshot 永遠列出全部 15 能力，未測者 insufficient_data）。"""
+    return {
+        "capability_id": cap_id,
+        "grade": GRADE_INSUFFICIENT,
+        "sample_count": 0,
+        "success_rate": None,        # None = 未測（非 0.0，避免誤讀成「0% 成功」）
+        "false_trigger_rate": None,
+        "latency_p50": None,
+        "latency_p90": None,
+        "confirmed": False,
+    }
+
+
+def to_snapshot(scores: dict[str, CapabilityScore], run_meta: dict) -> dict:
+    """聚合 → snapshot。三個校正（2026-06-01）：
+    F1：遍歷 CAPABILITY_META 全鍵（非 scores），未測能力補 insufficient_data 骨架——snapshot 永遠 15 列。
+    F2：run_meta.run_trusted==False（Layer-0 preflight fail）→ 全 capability grade 覆寫 insufficient_data，
+        但保留 raw metrics（可 debug），附 failure_reason。fail-closed：不可信的 run 不吐 pass/fail。
+    F5：每能力附 dependency_role（供 v0.2 chain-gating / Studio 顯示降級語意）。
+    """
+    # fail-closed 預設：caller 漏帶 run_trusted（=沒跑 preflight / 手刻 run_meta）→ 視為不可信。
+    # 正規路徑 build_scoreboard 一律經 current_run_meta()，永遠帶 run_trusted（preflight 缺→False）。
+    run_trusted = bool(run_meta.get("run_trusted", False))
+    caps = {}
+    for cap_id, meta in CAPABILITY_META.items():
+        if cap_id in scores:
+            d = asdict(scores[cap_id])
+        else:
+            d = _empty_score_dict(cap_id)
+        # F2：preflight fail → 覆寫 grade（保留 raw），fail-closed
+        if not run_trusted:
+            d["grade"] = GRADE_INSUFFICIENT
+            d["failure_reason"] = f"layer0_preflight={run_meta.get('layer0_preflight_status', 'unknown')}"
+        d["claim_level"] = meta["claim_level"]
+        d["risk_role"] = meta["risk_role"]
+        d["depth"] = meta["depth"]
+        d["dependency_role"] = meta["dependency_role"]   # F5
+        d["brain_allowed"] = brain_allowed(d["grade"], meta["claim_level"])
+        caps[cap_id] = d
+    return {"schema_version": "scoreboard-0.1", **run_meta, "capabilities": caps}
+
+
+def write_snapshot(scores, run_meta, out_path: str) -> None:
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(to_snapshot(scores, run_meta), f, ensure_ascii=False, indent=2)
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `python -m pytest benchmarks/test/test_scoreboard.py -q`
+Expected: PASS
+
+- [ ] **Step 5: commit**
+
+```bash
+git add benchmarks/core/scoreboard.py benchmarks/test/test_scoreboard.py
+git commit -m "feat(scoreboard): v0.1 aggregator (scenario-kind aware + claim_level + brain_allowed)"
+```
+
+---
+
+## Task 3b: `build_scoreboard.py`（CLI thin wrapper，runbook step4 用）
+
+**Files:**
+- Create: `benchmarks/core/build_scoreboard.py`
+- Test: `benchmarks/test/test_build_scoreboard.py`
+
+> runbook step4 唯一工具：讀 `baseline_result.jsonl` + `--manifest`（Jetson `.pawai-last-deploy`，可缺）+ `--preflight`（jetson-verify demo.yaml 結果，可缺）→ `current_run_meta` → `aggregate` → `write_snapshot`。
+> **fail-closed**：`--preflight` 缺或非 pass → `run_trusted=False` → snapshot 全 grade insufficient_data（對齊 to_snapshot F2）。criteria 缺省用 spec 的 provisional 門檻（`DEFAULT_CRITERIA`）。
+
+- [ ] **Step 1: 寫失敗測試**
+
+```python
+# benchmarks/test/test_build_scoreboard.py
+import json
+from benchmarks.core.build_scoreboard import build_scoreboard, DEFAULT_CRITERIA
+
+
+def _write_jsonl(path, rows):
+    with open(path, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+
+def test_build_scoreboard_preflight_pass_produces_snapshot(tmp_path):
+    jsonl = tmp_path / "baseline_result.jsonl"
+    _write_jsonl(jsonl, [
+        {"capability_id": "gesture.wave", "pass_fail": "pass", "false_trigger": False,
+         "latency_ms": 100, "scenario_kind": "positive"} for _ in range(3)
+    ])
+    pf = tmp_path / "preflight.json"; pf.write_text(json.dumps({"status": "pass"}))
+    out = tmp_path / "snap.json"
+    build_scoreboard(str(jsonl), preflight_path=str(pf), out_path=str(out))
+    snap = json.loads(out.read_text())
+    assert snap["run_trusted"] is True
+    assert len(snap["capabilities"]) == 15            # F1：永遠 15 列
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "pass"
+
+
+def test_build_scoreboard_missing_preflight_is_failclosed(tmp_path):
+    jsonl = tmp_path / "baseline_result.jsonl"
+    _write_jsonl(jsonl, [
+        {"capability_id": "gesture.wave", "pass_fail": "pass", "false_trigger": False,
+         "latency_ms": 100, "scenario_kind": "positive"} for _ in range(3)
+    ])
+    out = tmp_path / "snap.json"
+    build_scoreboard(str(jsonl), preflight_path=None, out_path=str(out))   # 不帶 preflight
+    snap = json.loads(out.read_text())
+    assert snap["run_trusted"] is False
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "insufficient_data"
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `python -m pytest benchmarks/test/test_build_scoreboard.py -q`
+Expected: FAIL（`ModuleNotFoundError`）
+
+- [ ] **Step 3: 實作 CLI wrapper**
+
+```python
+# benchmarks/core/build_scoreboard.py
+"""Runbook step4 工具：baseline_result.jsonl → scoreboard snapshot。
+
+  python -m benchmarks.core.build_scoreboard RESULT.jsonl \
+         [--manifest .pawai-last-deploy.json] [--preflight preflight.json] \
+         [--criteria criteria.json] [--out snapshot.json]
+
+fail-closed：--preflight 缺/非 pass → run_trusted=False → 全 grade insufficient_data。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Optional
+
+from .grader import Criterion
+from .scoreboard import load_results, aggregate, write_snapshot
+from .scoreboard_schema import current_run_meta
+
+# spec 的 provisional 門檻（門檻數字真相源在 Capability Baseline Spec；此為執行預設）
+DEFAULT_CRITERIA: dict[str, list[Criterion]] = {
+    "face.recognition": [
+        Criterion("registered_recall", 0.80, 0.60, higher_is_better=True),
+        Criterion("unknown_false_accept_rate", 0.03, 0.10, higher_is_better=False),
+        Criterion("wrong_person_count", 0, 0, higher_is_better=False),
+    ],
+    "voice.command": [
+        Criterion("success_rate", 0.80, 0.70, higher_is_better=True),
+    ],
+    "gesture.wave": [
+        Criterion("success_rate", 0.90, 0.80, higher_is_better=True),
+        Criterion("unknown_false_accept_rate", 0.10, 0.30, higher_is_better=False),
+    ],
+    "object.cup": [
+        Criterion("success_rate", 0.80, 0.60, higher_is_better=True),
+        Criterion("unknown_false_accept_rate", 0.01, 0.10, higher_is_better=False),
+    ],
+}
+
+
+def _load_json(path: Optional[str]) -> Optional[dict]:
+    if not path:
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_scoreboard(jsonl_path: str, manifest_path: Optional[str] = None,
+                     preflight_path: Optional[str] = None,
+                     criteria: Optional[dict] = None,
+                     out_path: str = "artifacts/baseline/baseline_snapshot.json") -> str:
+    records = load_results(jsonl_path)
+    run_meta = current_run_meta(
+        jetson_manifest=_load_json(manifest_path),
+        layer0_preflight=_load_json(preflight_path),   # 缺 → run_trusted=False（fail-closed）
+    )
+    scores = aggregate(records, criteria or DEFAULT_CRITERIA)
+    write_snapshot(scores, run_meta, out_path)
+    return out_path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("jsonl")
+    ap.add_argument("--manifest")
+    ap.add_argument("--preflight")
+    ap.add_argument("--criteria")
+    ap.add_argument("--out", default="artifacts/baseline/baseline_snapshot.json")
+    a = ap.parse_args()
+    crit = None
+    if a.criteria:
+        raw = _load_json(a.criteria)
+        crit = {k: [Criterion(**c) for c in v] for k, v in raw.items()}
+    path = build_scoreboard(a.jsonl, a.manifest, a.preflight, crit, a.out)
+    print(f"snapshot → {path}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `python -m pytest benchmarks/test/test_build_scoreboard.py -q`
+Expected: PASS
+
+- [ ] **Step 5: commit**
+
+```bash
+git add benchmarks/core/build_scoreboard.py benchmarks/test/test_build_scoreboard.py
+git commit -m "feat(scoreboard): v0.1 build_scoreboard CLI (fail-closed on missing preflight)"
+```
+
+---
+
+## Task 4: `perception_baseline_observer.py`（選項 B：通用 perception observer）
+
+**Files:**
+- Create: `benchmarks/core/perception_baseline_observer.py`
+- Test: `benchmarks/test/test_perception_baseline_observer.py`
+
+> **為什麼要**：recon 證實 face/gesture/object 的 event topic 不帶 accuracy/false_trigger/latency，且 `verification_observer.py` 只計數無判定。沒有這個 observer，第一張 scoreboard 視覺三能力全 insufficient_data。
+> **設計**：純比對邏輯（`evaluate_round` / `count_false_triggers`）dev-機 TDD；薄 ROS node（Jetson 跑）把三個 event topic 正規化成 `(label, confidence, ts)` 餵純函式。**不改模型、不修辨識、不接 Brain**。
+> **2026-06-01 校正（F3，code 證實）**：本 Task 4 **只負責 gesture / object（event-only）**。**face 拆到 Task 4b 獨立 `face_baseline_observer`（state-based）**——因 `/event/face_identity` 只在 stable transition 才發（face_identity_node.py:561），**從不發 unknown**，event-only 量不出 `unknown-false-accept`、多臉、距離；face 必須吃 `/state/perception/face` 連續流。gesture/object 無 state topic、本就只能 event，維持不變。
+> **observation 正規化規則**（Task 4 ROS node 端，僅 gesture/object）：`/event/gesture_detected → (gesture, confidence, stamp)`；`/event/object_detected → 每個 objects[]: (class_name, confidence, stamp)`。**face 不在此**（見 Task 4b）。
+
+- [ ] **Step 1: 寫失敗測試**
+
+```python
+# benchmarks/test/test_perception_baseline_observer.py
+from benchmarks.core.perception_baseline_observer import (
+    RoundMeta, evaluate_round, count_false_triggers,
+)
+
+
+def test_idle_round_no_observation_is_pass_no_false_trigger():
+    meta = RoundMeta("gesture.wave", "idle_hand_60s", expected_label="none", window_start_ts=100.0)
+    rec = evaluate_round(meta, observations=[])
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["predicted_label"] == "none"
+
+
+def test_idle_round_with_observation_is_false_trigger_fail():
+    meta = RoundMeta("gesture.wave", "idle_hand_60s", expected_label="none", window_start_ts=100.0)
+    rec = evaluate_round(meta, observations=[("wave", 1.0, 103.0)])
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is True
+    assert rec["predicted_label"] == "wave"
+
+
+def test_positive_round_matched_is_pass_with_latency():
+    meta = RoundMeta("gesture.wave", "wave_1.5m", expected_label="wave",
+                     distance_m=1.5, window_start_ts=100.0)
+    rec = evaluate_round(meta, observations=[("wave", 1.0, 100.4)])
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["predicted_label"] == "wave"
+    assert abs(rec["latency_ms"] - 400.0) < 1e-6
+    assert rec["distance_m"] == 1.5
+
+
+def test_positive_round_no_observation_is_miss_not_false_trigger():
+    meta = RoundMeta("object.cup", "cup_1.5m", expected_label="cup", window_start_ts=0.0)
+    rec = evaluate_round(meta, observations=[])
+    assert rec["pass_fail"] == "fail"          # miss
+    assert rec["false_trigger"] is False       # 漏報不是誤觸
+    assert rec["predicted_label"] == "none"
+
+
+def test_positive_round_wrong_label_is_miss_not_false_trigger():
+    meta = RoundMeta("object.cup", "cup_1.5m", expected_label="cup", window_start_ts=0.0)
+    rec = evaluate_round(meta, observations=[("bottle", 0.7, 1.0)])
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is False       # 認錯類別算 miss，誤觸只用於 idle round
+    assert rec["predicted_label"] == "bottle"
+
+
+def test_count_false_triggers_over_idle_rounds():
+    rounds = [
+        evaluate_round(RoundMeta("gesture.wave", "idle", "none", window_start_ts=0.0),
+                       observations=[]),
+        evaluate_round(RoundMeta("gesture.wave", "idle", "none", window_start_ts=0.0),
+                       observations=[("point", 0.8, 1.0)]),
+    ]
+    assert count_false_triggers(rounds) == 1
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `python -m pytest benchmarks/test/test_perception_baseline_observer.py -q`
+Expected: FAIL（`ModuleNotFoundError`）
+
+- [ ] **Step 3: 實作純比對邏輯（+ 薄 ROS node sketch）**
+
+```python
+# benchmarks/core/perception_baseline_observer.py
+"""通用 perception baseline observer (v0.1, 選項 B)。
+
+純比對邏輯（dev-機 TDD）：把 operator 宣告的 round_meta（expected_label/scenario/distance）
+與該 round 內觀測到的 (label, confidence, ts) 比對，產一筆 CapabilityResult-shaped dict。
+idle round（expected_label in {"none",""}）：任何觀測 = false_trigger。
+positive round：observed 含 expected → pass（latency=首個命中相對 window_start）；否則 miss（fail）。
+
+ROS node wrapper（Jetson 跑，不在 CI）：訂 /event/{gesture_detected,object_detected}（face 見 Task 4b），
+依 round_meta 檔（operator 宣告每 round 的 capability/scenario/expected/window）切窗，
+把每 topic 正規化成 (label, confidence, ts) → evaluate_round → append JSONL。
+
+idle 切窗規則（spec §4/§5）：idle round 以**固定長度窗**為單位各生一筆 record（gesture=60s×10 段、
+object=60s/窗），每窗 `scenario_kind="idle"`、`false_trigger`=該窗內有無誤報；aggregator 的
+unknown_false_accept_rate = 誤觸窗數/總窗數。positive round 則每次「擺好→宣告→觀測」生一筆。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+_IDLE_LABELS = {"none", "idle", ""}
+
+
+@dataclass
+class RoundMeta:
+    capability_id: str
+    scenario_id: str
+    expected_label: str            # "none"/"" = idle round（預期零事件）
+    distance_m: Optional[float] = None
+    distance_source: str = "manual_declared"
+    window_start_ts: float = 0.0
+
+
+def evaluate_round(meta: RoundMeta, observations: list) -> dict:
+    """observations: list[(label:str, confidence:float|None, ts:float)]，限定該 round 窗內。"""
+    is_idle = meta.expected_label in _IDLE_LABELS
+
+    if is_idle:
+        ft = len(observations) > 0
+        predicted = observations[0][0] if observations else "none"
+        return _record(meta, predicted_label=predicted,
+                       pass_fail=("fail" if ft else "pass"),
+                       false_trigger=ft, confidence=None, latency_ms=None)
+
+    # positive round
+    matches = [o for o in observations if o[0] == meta.expected_label]
+    if matches:
+        label, conf, ts = matches[0]
+        return _record(meta, predicted_label=label, pass_fail="pass", false_trigger=False,
+                       confidence=conf, latency_ms=(ts - meta.window_start_ts) * 1000.0)
+    # miss（沒看到 expected）：認錯或沒看到都算 miss，不是 false_trigger
+    predicted = observations[0][0] if observations else "none"
+    return _record(meta, predicted_label=predicted, pass_fail="fail", false_trigger=False,
+                   confidence=None, latency_ms=None)
+
+
+def _record(meta: RoundMeta, *, predicted_label: str, pass_fail: str,
+            false_trigger: bool, confidence: Optional[float], latency_ms: Optional[float]) -> dict:
+    return {
+        "capability_id": meta.capability_id,
+        "scenario_id": meta.scenario_id,
+        # F2：scenario_kind 供 aggregate 分離算 recall vs false-accept（idle round=預期零事件）
+        "scenario_kind": "idle" if meta.expected_label in _IDLE_LABELS else "positive",
+        "expected_label": meta.expected_label,
+        "predicted_label": predicted_label,
+        "pass_fail": pass_fail,
+        "false_trigger": false_trigger,
+        "confidence": confidence,
+        "latency_ms": latency_ms,
+        "distance_m": meta.distance_m,
+        "distance_source": meta.distance_source,
+    }
+
+
+def count_false_triggers(round_records: list[dict]) -> int:
+    return sum(1 for r in round_records if r.get("false_trigger"))
+
+
+# --- ROS node wrapper（Jetson 跑，v0.1 不在 CI；保持薄）---
+# class PerceptionBaselineObserver(Node):
+#   - 訂 /event/gesture_detected, /event/object_detected（face 見 Task 4b）
+#   - _normalize(topic, msg) -> list[(label, confidence, ts)]
+#   - 依 round_meta 檔（operator 宣告 capability/scenario/expected/window_start/window_end）切窗
+#   - round 結束時 evaluate_round(meta, obs) → 補 run_id/timestamp/git_commit（current_run_meta）
+#     → CapabilityResult(...).to_record() → append baseline_result.jsonl
+#   * 不改任何感知 node、不接 Brain。
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `python -m pytest benchmarks/test/test_perception_baseline_observer.py -q`
+Expected: PASS（6 個測試全綠）
+
+- [ ] **Step 5: 全套 + commit**
+
+Run: `python -m pytest benchmarks/test -q`
+Expected: 全綠（4 檔）
+
+```bash
+git add benchmarks/core/perception_baseline_observer.py benchmarks/test/test_perception_baseline_observer.py
+git commit -m "feat(scoreboard): v0.1 perception observer (gesture/object event round matching)"
+```
+
+---
+
+## Task 4b: `face_baseline_observer.py`（F3：face 走 /state/perception/face 連續流，與 gesture/object 分流）
+
+**Files:**
+- Create: `benchmarks/core/face_baseline_observer.py`
+- Test: `benchmarks/test/test_face_baseline_observer.py`
+
+> **為什麼獨立**（2026-06-01 F3，code 證實）：`/event/face_identity` 只在 stable transition 才發（`face_identity_node.py:561` `if old_stable_name != new_stable_name`），**從不發 `stable_name=="unknown"`** → event-only **量不出** `unknown-false-accept`、多臉競爭、距離分桶。`/state/perception/face` 每 tick 發**全部 tracks**（`face_identity_node.py:634-641`，含 `track_id/stable_name/sim/distance_m/bbox/mode/face_count`）→ face baseline 必須吃連續 state 流。gesture/object 無 state topic、維持 Task 4 event 模型；故 **face 拆獨立 observer，不污染 Task 4 的 event 純邏輯**。
+
+- [ ] **Step 1: 寫失敗測試**
+
+```python
+# benchmarks/test/test_face_baseline_observer.py
+from benchmarks.core.face_baseline_observer import (
+    FaceStateSnapshot, FaceRoundMeta, evaluate_face_round,
+)
+
+
+def _snap(ts, tracks):
+    return FaceStateSnapshot(ts=ts, tracks=tracks)
+
+
+def test_idle_round_with_known_person_is_false_trigger():
+    # idle（預期沒有"已知人被穩定辨識"）：出現已知人 = false_trigger
+    meta = FaceRoundMeta("face.recognition", "idle_unknown_1.5m",
+                         expected_label="unknown", distance_m=1.5, window_start_ts=100.0)
+    snaps = [_snap(101.0, [{"track_id": 1, "stable_name": "roy", "sim": 0.9,
+                            "distance_m": 1.5, "mode": "stable"}])]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is True
+    assert rec["predicted_label"] == "roy"
+
+
+def test_idle_round_only_unknown_tracks_is_pass():
+    # 有人但全 unknown（沒誤認成註冊者）→ pass、非 false_trigger
+    meta = FaceRoundMeta("face.recognition", "idle_unknown_1.5m",
+                         expected_label="unknown", window_start_ts=100.0)
+    snaps = [_snap(101.0, [{"track_id": 1, "stable_name": "unknown", "sim": 0.2,
+                            "distance_m": 1.5, "mode": "hold"}])]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+
+
+def test_positive_round_correct_match_is_pass_with_distance():
+    meta = FaceRoundMeta("face.recognition", "known_roy_1.5m",
+                         expected_label="roy", distance_m=1.5, window_start_ts=100.0)
+    snaps = [_snap(100.5, [{"track_id": 1, "stable_name": "roy", "sim": 0.92,
+                            "distance_m": 1.48, "mode": "stable"}])]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["confidence"] == 0.92
+    assert rec["distance_m"] == 1.48
+    assert rec["distance_source"] == "d435_depth"   # face state 帶真實深度
+
+
+def test_positive_round_miss_is_fail_not_false_trigger():
+    meta = FaceRoundMeta("face.recognition", "known_roy_3m",
+                         expected_label="roy", distance_m=3.0, window_start_ts=100.0)
+    snaps = [_snap(101.0, [{"track_id": 1, "stable_name": "unknown", "sim": 0.3,
+                            "distance_m": 3.0, "mode": "hold"}])]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "fail"      # 沒認出 = miss
+    assert rec["false_trigger"] is False   # 漏報非誤觸
+
+
+def test_positive_round_wrong_person_is_false_accept():
+    # 該是 roy 卻穩定辨識成 alice = 誤接（unknown-false-accept 的嚴重型）
+    meta = FaceRoundMeta("face.recognition", "known_roy_1.5m",
+                         expected_label="roy", distance_m=1.5, window_start_ts=100.0)
+    snaps = [_snap(101.0, [{"track_id": 1, "stable_name": "alice", "sim": 0.88,
+                            "distance_m": 1.5, "mode": "stable"}])]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is True    # 認錯人比漏認嚴重，計 false_trigger
+    assert rec["predicted_label"] == "alice"
+```
+
+- [ ] **Step 2: 跑測試確認失敗**
+
+Run: `python -m pytest benchmarks/test/test_face_baseline_observer.py -q`
+Expected: FAIL（`ModuleNotFoundError`）
+
+- [ ] **Step 3: 實作 face state 純邏輯**
+
+```python
+# benchmarks/core/face_baseline_observer.py
+"""Face baseline observer (v0.1, F3) — 吃 /state/perception/face 連續狀態流。
+
+與 perception_baseline_observer（gesture/object，event-only）分流：face 因 /event/face_identity
+從不發 unknown、且無多臉/距離維度，必須走每-tick 全 tracks 的 /state/perception/face。
+純邏輯 dev-機 TDD；ROS node wrapper（Jetson 跑）依 round window 累積 snapshots → evaluate_face_round。
+
+判定規則：
+- idle round（expected_label in {"unknown","none","idle",""}）：任一 snapshot 內有 track 被穩定辨識成
+  「某個註冊者（stable_name 非 unknown）」→ false_trigger（誤把陌生人/環境認成註冊者）。全 unknown = pass。
+- positive round（expected_label=註冊者名）：window 內出現該名 stable track → pass（confidence=該 track sim，
+  distance 取 track 真實深度）；只出現別的註冊者名 → false_trigger（認錯人，比漏認嚴重）；
+  只 unknown / 沒 track → miss（fail，但非 false_trigger）。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+_IDLE_LABELS = {"unknown", "none", "idle", ""}
+
+
+@dataclass
+class FaceStateSnapshot:
+    ts: float
+    tracks: list = field(default_factory=list)   # 每個: {track_id, stable_name, sim, distance_m, mode}
+
+
+@dataclass
+class FaceRoundMeta:
+    capability_id: str
+    scenario_id: str
+    expected_label: str            # 註冊者名 / "unknown"(idle)
+    distance_m: Optional[float] = None
+    distance_source: str = "manual_declared"
+    window_start_ts: float = 0.0
+
+
+def _known_tracks(snap: FaceStateSnapshot) -> list:
+    return [t for t in snap.tracks if t.get("stable_name", "unknown") != "unknown"]
+
+
+def evaluate_face_round(meta: FaceRoundMeta, snapshots: list) -> dict:
+    is_idle = meta.expected_label in _IDLE_LABELS
+
+    if is_idle:
+        for snap in snapshots:
+            known = _known_tracks(snap)
+            if known:   # 任一被穩定辨識成註冊者 = 誤接
+                t = known[0]
+                return _face_record(meta, predicted_label=t["stable_name"], pass_fail="fail",
+                                    false_trigger=True, confidence=t.get("sim"),
+                                    distance_m=t.get("distance_m"))
+        return _face_record(meta, predicted_label="unknown", pass_fail="pass",
+                            false_trigger=False, confidence=None, distance_m=None)
+
+    # positive round：找 expected 名的 stable track（取最早出現）
+    for snap in snapshots:
+        for t in snap.tracks:
+            if t.get("stable_name") == meta.expected_label:
+                return _face_record(meta, predicted_label=meta.expected_label, pass_fail="pass",
+                                    false_trigger=False, confidence=t.get("sim"),
+                                    distance_m=t.get("distance_m"),
+                                    latency_ms=(snap.ts - meta.window_start_ts) * 1000.0)
+    # 沒看到 expected：若出現別的註冊者 → 認錯人（false_accept）；否則 miss
+    for snap in snapshots:
+        known = _known_tracks(snap)
+        if known:
+            t = known[0]
+            return _face_record(meta, predicted_label=t["stable_name"], pass_fail="fail",
+                                false_trigger=True, confidence=t.get("sim"),
+                                distance_m=t.get("distance_m"))
+    return _face_record(meta, predicted_label="unknown", pass_fail="fail",
+                        false_trigger=False, confidence=None, distance_m=None)
+
+
+def _face_record(meta: FaceRoundMeta, *, predicted_label: str, pass_fail: str,
+                 false_trigger: bool, confidence: Optional[float],
+                 distance_m: Optional[float], latency_ms: Optional[float] = None) -> dict:
+    return {
+        "capability_id": meta.capability_id,
+        "scenario_id": meta.scenario_id,
+        # F2：idle round（expected="unknown"/"none"）→ 算 unknown_false_accept；positive → 算 registered_recall
+        "scenario_kind": "idle" if meta.expected_label in _IDLE_LABELS else "positive",
+        "expected_label": meta.expected_label,
+        "predicted_label": predicted_label,
+        "pass_fail": pass_fail,
+        "false_trigger": false_trigger,
+        "confidence": round(confidence, 4) if confidence is not None else None,
+        "latency_ms": latency_ms,
+        "distance_m": distance_m if distance_m is not None else meta.distance_m,
+        # face state 帶 D435 真實深度（≠ gesture/object 的人工宣告）
+        "distance_source": "d435_depth" if distance_m is not None else meta.distance_source,
+    }
+
+
+# --- ROS node wrapper（Jetson 跑，v0.1 不在 CI；保持薄）---
+# class FaceBaselineObserver(Node):
+#   - 訂 /state/perception/face（連續 ~20Hz），parse JSON → FaceStateSnapshot(ts, tracks)
+#   - 依 round_meta（operator 宣告 capability=face.recognition / expected / distance / window）切窗
+#   - round 結束時 evaluate_face_round(meta, window 內 snapshots) → 補 run_id/timestamp/git_commit
+#     → CapabilityResult(...).to_record() → append baseline_result.jsonl（與 gesture/object 同一檔）
+#   * 不改 face_identity_node、不接 Brain。
+```
+
+- [ ] **Step 4: 跑測試確認通過**
+
+Run: `python -m pytest benchmarks/test/test_face_baseline_observer.py -q`
+Expected: PASS（5 個測試全綠）
+
+- [ ] **Step 5: commit**
+
+```bash
+git add benchmarks/core/face_baseline_observer.py benchmarks/test/test_face_baseline_observer.py
+git commit -m "feat(scoreboard): v0.1 face baseline observer (state-stream, unknown-false-accept aware)"
+```
+
+---
+

--- a/docs/pawai-brain/plans/2026-06-02-baseline-issues-draft.md
+++ b/docs/pawai-brain/plans/2026-06-02-baseline-issues-draft.md
@@ -1,0 +1,744 @@
+# Capability Baseline & Scoreboard — GitHub Issues 草稿（2026-06-02）
+
+> **draft-only**：本文件為草稿，review 通過才轉 GitHub Issue，現階段不開 issue、不建分支、不動 code。
+
+## 14-child 總表
+
+| # | Title | Type | 6/18? | Blocked by |
+|---|---|---|:---:|---|
+| #1 | `scoreboard_schema.py`：14 欄 `CapabilityResult` + `CAPABILITY_META`(15 能力含 dependency_role) + `current_run_meta`(雙-sha + layer0→run_trusted) | AFK | ✅ | none |
+| #2 | `grader.py`：四段 grade 純函式 (`pass/degraded/fail/insufficient_data`) + `brain_allowed(grade, claim_level)` derive | AFK | ✅ | none |
+| #3 | `scoreboard.py` aggregator + `build_scoreboard.py` CLI（Task 3b）：JSONL→snapshot / zero-sample 也列全 15 能力(F1) / preflight fail→全 insufficient_data(F2) / 預設 `--out artifacts/baseline/baseline_snapshot.json` | AFK | ✅ | #1, #2 |
+| #4 | `demo.yaml` Layer-0 Preflight gate：填 demo.yaml 的 Layer-0 checks（現為 `checks: []`；以 smoke.yaml 現有 9 checks 為候選來源挑適用 subset + 補 Layer-0 專屬項，不綁固定數字）→ top-level fail-closed gate，產 `preflight_result.json` | HITL | ✅ | none |
+| #5 | `perception_baseline_observer.py`：gesture / object（event-only）round 比對邏輯 + 薄 ROS node wrapper | AFK | ✅ | none |
+| #6 | `face_baseline_observer.py`：吃 `/state/perception/face` 連續流（recall / unknown-false-accept / wrong-person） | AFK | ✅ | none |
+| #7 | voice baseline run：`speech_test_observer`→record(A2) + voice.stop 拆「停」專項(FN=0) + **mic_stop endpoint** | HITL | ✅ | #1, #2, #3, #4 |
+| #8 | face baseline run：registered/stranger × 1m/2m，量 recall / false-accept / wrong-person | HITL | ✅ | #1, #2, #3, #4, #6 |
+| #9 | gesture (`gesture.wave`) + object (`object.cup`) baseline run：wave recall/idle 誤觸硬 gate + cup recall/idle false-positive | HITL | ✅ | #1, #2, #3, #4, #5 |
+| #10 | pose (`pose.basic`) baseline run（studio_only 薄測）；`pose.fall` 不測（future） | HITL | **optional / P2** | #1, #2, #3, #4, #5 |
+| #11 | nav baseline run：safe_stop / no_auto_resume (insufficient_data) + short_move (dry-run) + dynamic_avoidance (future) | HITL | ✅ | #1, #2, #3, #4 |
+| #12 | `studio.evidence`：provenance label (live/mock/frozen/missing) + Brain trace display + read-only frozen scoreboard chip (`GET /api/scoreboard`) | AFK | ✅ | none |
+| #13 | `cli.readiness`：`pawai readiness` / `--json` fail-closed 真值表（sha mismatch 硬擋 / 缺檔→not_ready）+ freeze mechanism | AFK + 1 HITL smoke | ✅ | 實作:#3；freeze:#4+#7/#8/#9/#11；optional:#10 |
+| #14 | Brain capability health gate（v0.2）：`compute_effective_status` 加 grade 分支 + IE 第二道 gate + allowlist single source | AFK | **v0.2（不擋 6/18）** | #2, #3, #4 |
+
+> **編號對齊說明**：drafter 內部表的舊編號（observer #4/#6、voice #7、nav 拆 #8/#9/#11 等）已重排為下方連續 #1..#14。Blocked-by 一律指本表編號。
+
+---
+
+## Tracking Issue：Capability Baseline & Scoreboard
+
+**目標（一句）**：量化 15 個 capability（pass / degraded / fail / insufficient_data），產生 frozen snapshot，供 **CLI readiness 與 Studio evidence** 決定 demo 主線；**runtime gate 接入另在 #14 v0.2，不在 6/18 範圍**。讓「沒 baseline 證據的能力不准進 6/18 demo」。
+
+**真相源**：
+- Master Plan `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md`（架構 / 三軸 / canonical 15 能力表 / 設計段 C-D）
+- Spec `docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md`（門檻數字）
+- Implementation `docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md`（6 deliverable TDD）
+- Runbook `docs/runbook/2026-06-18-baseline-runbook.md`（上機流程）
+
+**v0.1 成功定義**：不是「Brain 已自動 gate 所有能力」，而是「已有可信 baseline 數據，可決定哪些能力允許進 demo 主線」（Master Plan:22）。
+
+### 依賴關係
+
+- **核心鏈（6/18 主線）**：#1（schema）→ #2（grader）→ #3（aggregator / build_scoreboard）→ 餵所有量測 issue（#7 #8 #9 #11 #12 #13）。
+- **observer**：#5（gesture/object）+ #6（face state 流）+ #7（voice）+ #11（nav safety）→ append 同一 `baseline_result.jsonl` → #3 產 `baseline_snapshot.json`。
+- **preflight gate**：#4（demo.yaml）是 top-level fail-closed gate（`run_trusted`），#3 / #13 / #14 都依賴它的可信判定。
+- **nav 跑序鐵律**：#11 內 short_move 依賴同 issue 的 safe_stop + no_auto_resume 先 pass（或人工 override）才放行真實 motion；未達前只 dry-run（Spec §6c:248-249、Runbook:22-24）。
+- **brain.trace 拆兩處**：#12 負責 6/18「trace 看得到、非 mock、有 reason」；#14 負責 v0.2「grade 真的接進 runtime gate」。**#14 不重寫 trace 展示。**
+- **post-baseline**：#14 依賴 #2 + #3 + #4（grade / snapshot / run_trusted 都要先有），是 v0.2 deliverable，**不擋 6/18**；6/18 `brain.skill_gate` 維持 insufficient_data 為 acceptable。
+
+### overclaim 防線（鎖定）
+
+- `brain.skill_gate`：grade 接進 gate 前一律 `insufficient_data`，**不可寫「6/18 要做到 gate enforce」**（Spec §7a:288/294）。
+- `nav.safe_stop / nav.no_auto_resume / nav.short_move`：baseline pass 前一律 `insufficient_data`，不可寫 pass（Spec §6:202、§6a:219、§6c:249）。
+- `nav.short_move`：safety 未 pass 前只 dry-run（Spec §6c:248、Runbook:24）。
+- `studio.evidence`：Studio 是 evidence 不是 authority，不可宣稱「IE 第二道 gate 已吃 scoreboard / runtime 全層已 enforce」（Spec §8:350，該 enforcement = #14 v0.2 待補）。
+
+---
+
+## Issue #1：Scoreboard schema — `CapabilityResult` + `CAPABILITY_META` + `current_run_meta`
+
+- **Title**：Scoreboard schema：14-field `CapabilityResult` record + 15-capability `CAPABILITY_META` + dual-sha `current_run_meta`
+- **Type**：AFK（純 Python dataclass + dict + pytest，dev 機可跑、無 ROS 依賴；IMPL Task 1 全程在 `benchmarks/` dev-machine TDD，IMPL:21-303）
+- **Blocked by**：none（IMPL 建議實作序第一個，IMPL:13）
+
+**What to build**
+`benchmarks/core/scoreboard_schema.py`：(1) `CapabilityResult` dataclass，`to_record()` 吐一筆 JSONL record 並打上 `SCHEMA_VERSION`；(2) `CAPABILITY_META` dict — 15 個 canonical capability，每個帶 4 個靜態屬性 `depth / claim_level / risk_role / dependency_role`；(3) `current_run_meta()` — run-level metadata，含 version_snapshot 雙 sha（WSL commit + Jetson install sha）+ Layer-0 preflight → `run_trusted`。
+
+**Acceptance criteria**
+- `CapabilityResult.to_record()` 帶 `schema_version == SCHEMA_VERSION`（`SCHEMA_VERSION = "scoreboard-0.1"`），核心欄位齊（`capability_id / scenario_id / run_id / timestamp / git_commit / expected_label / predicted_label / pass_fail / confidence / distance_m / latency_ms`），預設值 `false_trigger is False`、`distance_source == "manual_declared"`、`failure_reason == ""`（IMPL:36-56, :167, :192-221）。
+- record 為 14 欄資料 + 識別欄（dataclass 欄位列 IMPL:194-216：識別 5 + 判定 / 觀測欄 + 資源欄 cpu/gpu/ram 可為 None + failure_reason）。
+- `CAPABILITY_META` 含全 15 canonical capability，鍵與 MASTER canonical 表逐列一致（MASTER:63-78：face.recognition / voice.command / voice.stop / gesture.wave / object.cup / nav.safe_stop / nav.no_auto_resume / nav.short_move / nav.dynamic_avoidance / pose.basic / pose.fall / brain.skill_gate / brain.trace / studio.evidence / cli.readiness）。
+- 每能力 `claim_level ∈ {mainline, studio_only, future, not_claimed}`、`risk_role ∈ {safety_critical, safety_support, actuation, convenience, evidence_only}`、`depth ∈ {deep, thin, future}`、`dependency_role ∈ {trigger, content, safety_guard, actuation, evidence}`（IMPL:59-78；列舉值真相源 IMPL `CAPABILITY_META`:173-189）。
+- nav 已拆單一能力：`nav.safe_stop` 與 `nav.short_move` 各自存在，**無** `"nav.short_move + nav.safe_stop"` 複合鍵（IMPL:71-74；MASTER:40）。
+- `dependency_role` 與 `risk_role` 正交且對齊 SPEC 逐功能：`nav.safe_stop.dependency_role == "safety_guard"`（SPEC:211）、`gesture.wave.dependency_role == "trigger"`（SPEC:171）、`face.recognition.dependency_role == "content"`（SPEC:37）；voice.command/voice.stop = trigger（SPEC:74, :91）、object.cup = content（SPEC:190）、nav.no_auto_resume = safety_guard（SPEC:211 / MASTER:70）、brain.skill_gate = safety_guard（SPEC:296）、brain.trace/studio.evidence/cli.readiness = evidence（SPEC:314, :341, :369）、pose.basic = content / pose.fall = evidence（SPEC:137, :152）。
+- `current_run_meta()` 帶 `run_id`（uuid 非空）+ `jetson_install_sha`（來自 manifest `git_sha_full`）+ `jetson_deploy_ts`（manifest `when`）+ `demo_profile_env` + `version_mismatch`（IMPL:81-94）。
+- 無 manifest → `jetson_install_sha is None`、`version_mismatch is True`、`manifest_exists is False`（fail-closed：無法確認 Jetson 跑哪版，IMPL:96-101；MASTER:39, :116）。
+- manifest `when` age > `stale_after_h`（預設 6h）→ `version_stale is True`；未逾期 → False（IMPL:103-116；MASTER:31, :101）。
+- 帶 `wsl_dirty / branch / manifest_exists`；manifest `dirty:True` → `jetson_dirty is True`（IMPL:119-122）。
+- Layer-0 preflight：`status ∈ {pass, pass_with_warnings}` → `layer0_preflight_status` 對應 + `run_trusted is True`；`status == fail` 或未跑（缺）→ `layer0_preflight_status` 為 `fail`/`unknown` 且 `run_trusted is False`（fail-closed，IMPL:125-141；MASTER Layer-0 段:89）。
+
+**Files / modules likely touched**
+- NEW `benchmarks/core/scoreboard_schema.py`（IMPL Task 1，code:152-291）
+- NEW `benchmarks/test/test_scoreboard_schema.py`（IMPL:30-142；repo 測試目錄 `benchmarks/test/` 已確認 IMPL:15）
+
+**Test / verification**
+`python -m pytest benchmarks/test/test_scoreboard_schema.py -q`（先 red：`ModuleNotFoundError`，後全綠 — IMPL:144-147, :293-296）。涵蓋 8 個測試：to_record / CAPABILITY_META enum + nav 拆分 + dependency_role 正交 / dual-sha + run_id / no-manifest fail-closed / stale-by-age / dirty+branch / preflight pass→trusted / preflight fail→untrusted。`_git` 在非 git 環境須降級 `"unknown"` 不爆（MASTER:235）。
+
+**Output artifact**
+`benchmarks/core/scoreboard_schema.py`（提供 `CapabilityResult / SCHEMA_VERSION / CAPABILITY_META / current_run_meta`，給 #2 grader 的 claim_level、#3 aggregator 的 `to_snapshot` 遍歷 import）。一筆 `to_record()` = 一行 baseline JSONL；`current_run_meta()` = snapshot 的 run-level header。
+
+**Out of scope**
+- 不接 Brain runtime / 不消費 `dependency_role` 做 gate — v0.1 `dependency_role` 是 design-only static 屬性（IMPL:172 末句「v0.1 不被 grader 消費」；MASTER:60）。
+- 不做 grade 計算（屬 #2）、不做聚合 / snapshot（屬 #3）。
+- 資源欄 `cpu_pct/gpu_pct/ram_mb` v0.1 可留 None，JetsonMonitor 整合屬 runbook 手動填、不在本 issue（IMPL:212；MASTER:239）。
+- 不把 `claim_level/risk_role/dependency_role` 寫進每筆 record（是 CAPABILITY_META 靜態屬性，aggregator 才附到 snapshot — MASTER:80）。
+
+---
+
+## Issue #2：Grader — four-tier grade pure function + `brain_allowed` gate derive
+
+- **Title**：Grader：`pass / degraded / fail / insufficient_data` four-tier pure function + `brain_allowed = (pass AND mainline)`
+- **Type**：AFK（純函式、無 ROS、dev 機 TDD；IMPL Task 2:307-453）
+- **Blocked by**：none（grader 不 import schema；但 #3 aggregator import 它，故 #3 blocked by #2）
+
+**What to build**
+`benchmarks/core/grader.py`：(1) `Criterion` dataclass（`metric / pass_min / degraded_min / higher_is_better`）；(2) `grade_one()` 單 metric → pass/degraded/fail；(3) `grade_capability()` 結合「門檻 band」與「樣本充足度」吐四段 grade；(4) `brain_allowed(grade, claim_level)` 純 derive。
+
+**Acceptance criteria**
+- 暴露 4 個 grade 常數 `GRADE_PASS="pass" / GRADE_DEGRADED="degraded" / GRADE_FAIL="fail" / GRADE_INSUFFICIENT="insufficient_data"`（IMPL:389-392）。
+- `sample_count <= 0` → `insufficient_data`（IMPL:328-329, :424-425）。
+- `criteria` 為空 → `insufficient_data`（fail-closed，防 fail-open；缺判據絕不可 pass — IMPL:332-334, :426-427；SPEC 對齊 fail-closed 結構鎖:26）。
+- 所有 metric 達 pass band 但 `sample_count < confirm_min`（預設 3）→ `degraded`（provisional / 標黃 — IMPL:337-338, :433-434；MASTER provisional≥1 標黃 vs confirmed≥3:51）。
+- 所有 metric 達 pass band 且 `sample_count >= confirm_min` → `pass`（IMPL:341-342, :435）。
+- 任一 metric fail → `fail`（fail-closed：fail 蓋過一切 — IMPL:345-347, :429-430）。
+- `higher_is_better=False` 的 lower-is-better band 正確（誤觸率 / latency：≤pass_min→pass、≤degraded_min→degraded、否則 fail — IMPL:350-352, :413-418）；對齊 SPEC 不對稱門檻語意（face `unknown_false_accept_rate` ≤3%/3-10%/>10% SPEC:41, :52；gesture idle 誤觸硬 gate SPEC:175；object idle false-positive SPEC:194）。
+- degraded band 蓋過 unconfirmed：metric 落在 degraded band 即使樣本足 → `degraded`（IMPL:355-356, :431-432）。
+- `grade_one(None, crit)` → `fail`（None 視為保守 fail — IMPL:404-405）。
+- `brain_allowed(grade, claim_level)` 僅 `grade == pass AND claim_level == "mainline"` 為 True；`pass + future`、`pass + studio_only`、`degraded + mainline`、`fail + mainline`、`insufficient_data + mainline` 全 False（claim_level 只能更嚴、不放寬 — IMPL:359-366, :438-440；SayCan affordance-gating 語意 SPEC:286；MASTER:38, :198-199）。
+
+**Files / modules likely touched**
+- NEW `benchmarks/core/grader.py`（IMPL Task 2 code:377-440）
+- NEW `benchmarks/test/test_grader.py`（IMPL:318-367）
+- 範式對齊（讀，不改）：`speech_processor/speech_processor/speech_test_observer.py` 的 `_compute_grade`（PASS/MARGINAL/FAIL，IMPL:380-382）
+
+**Test / verification**
+`python -m pytest benchmarks/test/test_grader.py -q`（先 red `ModuleNotFoundError`、後 8 測試全綠 — IMPL:369-372, :443-446）：zero-sample / empty-criteria / pass-but-unconfirmed→degraded / pass-confirmed→pass / any-fail→fail / lower-is-better band / degraded-dominates-unconfirmed / brain_allowed only-pass-and-mainline。
+
+**Output artifact**
+`benchmarks/core/grader.py`（提供 `Criterion / grade_capability / brain_allowed / GRADE_* 常數`，給 #3 aggregator import — IMPL:617）。
+
+**Out of scope**
+- 不定義各能力的門檻數字 — pass_min/degraded_min 一律由 Capability Baseline Spec 取（provisional until baseline；IMPL:17「門檻數字不在本檔」；SPEC:22, :26 真相源）。執行預設門檻 `DEFAULT_CRITERIA` 屬 #3 的 build_scoreboard，不在本 issue。
+- 不讀 JSONL、不分組、不算 success_rate/percentile（屬 #3 aggregator）。
+- 不接 Brain runtime gate — `brain_allowed` v0.1 只是 derive 函式，`compute_effective_status()` 接 grade 是 v0.2（MASTER 設計段 D:165-200；SPEC §7a:284, :303 brain.skill_gate grade 未接前一律 insufficient_data，不可寫「6/18 gate enforce」）。
+
+---
+
+## Issue #3：Scoreboard aggregator + `build_scoreboard` CLI
+
+- **Title**：Scoreboard aggregator (`scoreboard.py` + Task 3b `build_scoreboard.py` CLI)：JSONL → 15-capability snapshot, scenario-kind aware, fail-closed
+- **Type**：AFK（純 Python 聚合 + argparse CLI，dev 機 TDD（`tmp_path` fixture），無 ROS；IMPL Task 3:457-768 + Task 3b:772-922）
+- **Blocked by**：#1（import `CAPABILITY_META` / `current_run_meta`，IMPL:618, :848）、#2（import `grade_capability / brain_allowed / Criterion / GRADE_INSUFFICIENT`，IMPL:617, :846）
+
+**What to build**
+(1) `benchmarks/core/scoreboard.py`：`aggregate()` 讀 record list → 按 `(capability_id, scenario_kind)` 分離算指標 → `CapabilityScore`；`to_snapshot()` 遍歷 `CAPABILITY_META` 全 15 鍵附 claim_level/risk_role/depth/dependency_role + derive brain_allowed；`load_results` / `write_snapshot`。(2) `benchmarks/core/build_scoreboard.py`（Task 3b 薄殼）：runbook step4 唯一 CLI，`baseline_result.jsonl` + `--manifest` + `--preflight` → `current_run_meta` → `aggregate` → `write_snapshot`，含 `DEFAULT_CRITERIA`。
+
+**Acceptance criteria**
+
+*aggregator（`scoreboard.py`）*
+- `aggregate()` 算 `sample_count / success_rate / false_trigger_rate / latency_p50 / latency_p90 / confirmed`，false_trigger 強制 fail（IMPL:485-499）。
+- **scenario_kind 分離**（Roy lock + SPEC face 不對稱量法）：按 `scenario_kind` 分組吐 `positive_count / idle_count / registered_recall（positive round pass 率）/ unknown_false_accept_rate（idle round false_trigger 率）/ wrong_person_count（positive round 卻 false_trigger）`，known/unknown 不混算稀釋（IMPL:502-527, :631-637, :683-706；SPEC face Criterion 映射:47-55、object 計算規則:193-194）。
+- **(LOCK 1) JSONL → snapshot**：`build_scoreboard` 讀 `baseline_result.jsonl` → `aggregate` → `write_snapshot` 產 JSON（IMPL:802-807；RUNBOOK step4:27）。
+- **(LOCK 2) zero-sample 也列出全 15 能力**：`to_snapshot` 遍歷 `CAPABILITY_META` 全鍵（非 scores），未測能力補 `grade="insufficient_data" / sample_count=0 / success_rate=None（非 0.0）/ brain_allowed=False`，且仍帶靜態屬性（`dependency_role` 等）；snapshot 永遠 15 列（IMPL F1:555-568, :710-721, :726-728, :735-739）。
+- snapshot 每能力附 `claim_level / risk_role / depth / dependency_role` + derived `brain_allowed`；`gesture.wave → brain_allowed True`(pass+mainline)、`nav.dynamic_avoidance` 即使量到 pass 因 claim_level=future → `brain_allowed False`（IMPL:529-552, :744-748）。
+- **(LOCK 3) preflight fail → 全 insufficient_data**：`run_meta.run_trusted == False`（含 caller 漏帶 → 預設 fail-closed）→ 覆寫全 15 能力 `grade="insufficient_data"` + `brain_allowed=False` + `failure_reason="layer0_preflight={status}"`，但保留 raw metrics 可 debug（IMPL F2:571-593, :731-743；MASTER Layer-0:89, :182；RUNBOOK:37）。
+
+*build_scoreboard CLI（Task 3b）*
+- **(LOCK 4) 預設 `--out artifacts/baseline/baseline_snapshot.json`**（IMPL:881, :898；SPEC §9 working snapshot 路徑:415；RUNBOOK:27, :35）。
+- `--preflight` pass → `run_trusted True`、snapshot 15 列、已測能力維持原 grade（IMPL:795-807）。
+- `--preflight` 缺 / 非 pass → `run_trusted False` → 全 grade insufficient_data（fail-closed，對齊 to_snapshot F2 — IMPL:810-820；SPEC §9 fail-closed 規則:392-401；RUNBOOK「必須帶 `--preflight`」:27）。
+- `DEFAULT_CRITERIA` 用 SPEC provisional 門檻：face（registered_recall 0.80/0.60、unknown_false_accept_rate 0.03/0.10、wrong_person_count 0/0 — SPEC:48-53）、voice.command（success_rate 0.80/0.70 — SPEC:78）、gesture.wave（success_rate 0.90/0.80 — SPEC:175）、object.cup（SPEC:194）；門檻真相源在 Spec、CLI 只是執行預設（IMPL:850-868）。
+- CLI 可由 `python -m benchmarks.core.build_scoreboard RESULT.jsonl [--manifest] [--preflight] [--criteria] [--out]` 跑（IMPL:834-836, :892-905）。
+
+**Files / modules likely touched**
+- NEW `benchmarks/core/scoreboard.py`（IMPL Task 3 code:604-755）
+- NEW `benchmarks/test/test_scoreboard.py`（IMPL:468-594）
+- NEW `benchmarks/core/build_scoreboard.py`（IMPL Task 3b code:831-909）
+- NEW `benchmarks/test/test_build_scoreboard.py`（IMPL:784-820）
+- import 依賴：`benchmarks/core/scoreboard_schema.py`(#1)、`benchmarks/core/grader.py`(#2)
+
+**Test / verification**
+`python -m pytest benchmarks/test/test_scoreboard.py benchmarks/test/test_build_scoreboard.py -q`（先 red、後全綠 — IMPL:596-599, :758-761, :823-825, :912-915）。scoreboard.py 涵蓋 11 測試：success_rate+grade / false_trigger→fail / recall-vs-false-accept 分離 / wrong_person on positive / claim_level+brain_allowed / future-not-allowed / always-15 / missing-run_trusted-failclosed / preflight-fail-all-insufficient。build_scoreboard 涵蓋 2 測試（`tmp_path`）：preflight pass→snapshot(15 列)、missing preflight→failclosed。
+
+**Output artifact**
+`benchmarks/core/scoreboard.py`（`aggregate / to_snapshot / write_snapshot / load_results`）+ `benchmarks/core/build_scoreboard.py`（CLI + `DEFAULT_CRITERIA`）。執行產出 = `artifacts/baseline/baseline_snapshot.json`（15 能力 grade + brain_allowed + 靜態屬性 + run_meta header；給 §8 `/api/scoreboard`、§9 `pawai readiness` 唯讀 — SPEC:415-421）。
+
+**Out of scope**
+- 不接 Brain runtime / 不接 `effective_status.py` — aggregator 只產 snapshot 供人判讀，capability_health 接 runtime gate 是 v0.2（IMPL:463 末句「不接 Brain runtime（v0.2）」；MASTER 設計段 D:165-200、scope:47）。
+- 不寫 `pawai readiness` 子命令 / freeze 機制 / `PAWAI_SCOREBOARD_PATH` env / `/api/scoreboard` endpoint（屬 #13 cli.readiness 與 #12 studio.evidence；SPEC §9:425、§8:357）。
+- 不產 ROS observer 記錄（gesture/object → #5 perception observer；face → #6 face observer；IMPL Task 4:926、Task 4b）。
+- overclaim 防線：nav.safe_stop / nav.no_auto_resume / nav.short_move 在 baseline pass 前由 aggregator 吐 insufficient_data（recorder BD-7 no-op、BD-8 行為衝突、3 blocker），不可在 snapshot 顯示為 pass（SPEC:212, :219, :234, :249；MASTER:69-71, :213）；brain.skill_gate 在 grade 接進 gate 前一律 insufficient_data，不寫「6/18 gate enforce」（SPEC:288, :294；MASTER:83）。
+
+---
+
+## Issue #4：Layer-0 Preflight gate — 填 `demo.yaml` profile，fail-closed → all insufficient_data，產 `preflight_result.json`
+
+- **Title**：Layer-0 Preflight gate（填 `jetson-verify` demo.yaml profile，fail-closed → 全能力 insufficient_data，產 preflight_result.json）
+- **Type**：HITL — preflight 的本質是上機驗 demo stack / Jetson / Go2 是否就緒（`jetson.ssh_reachable` / `go2.ethernet_ping` / `ros.runtime_started` / `demo.entrypoint_started` 全要真實 Jetson + demo session 才能判，MASTER:92-101）。profile 是 YAML，但驗收要在 Jetson 上跑出 pass / fail 結果。
+- **Blocked by**：none（profile 與 manifest 讀取自成一體；snapshot 端的 fail-closed 消費在 #1/#3 已實作，本 issue 只負責「產出 preflight_result + 餵 build_scoreboard」）
+
+**What to build**
+把 `jetson-verify` 目前 stub 的 `demo.yaml` profile（`checks: []` → `verify.py sys.exit(2)`，MASTER:90）填成 Layer-0 Preflight checks（對齊 MASTER:92-101 表）：**以 `smoke.yaml` 現有 9 checks 為候選來源挑適用 subset + 補 Layer-0 專屬項**（node-count gate / go2 webrtc subscriber / version_snapshot 讀 `.pawai-last-deploy`），**不以固定數字綁死**；跑完輸出 `artifacts/baseline/preflight_result.json`（至少含 `{"status": ...}`），作為 RUNBOOK step 0 的前置 gate。
+
+**Acceptance criteria**
+- profile canonical 路徑 = `.claude/skills/jetson-verify/profiles/demo.yaml`（git-tracked；`.agents/` 是未追蹤舊鏡像，F4，MASTER:143）。
+- 8 項 check 對齊 MASTER:92-101 表：`jetson.ssh_reachable`(hard-blocker 全域) / `go2.ethernet_ping` / `ros.runtime_started`(lane-aware node set，MASTER:103-112) / `demo.entrypoint_started`(走 demo script，非裸 `ros2 run`，Q3 鐵律 RUNBOOK:8) / `go2.driver_alive`(capability-conditional) / `topic_contract_ok` / `resource_idle_snapshot`(RAM headroom ≥0.8GB & temp<70°C) / `version_snapshot`（MASTER:101）。
+- 三級判定：全 hard-blocker pass → `status="pass"`；off-path WARN（如 `/state/executive/brain` planned、`/executive/status` legacy）→ `status="pass_with_warnings"` = GO（MASTER:114）；任一 hard-blocker fail → `status="fail"`。
+- **fail-closed 串接（核心）**：preflight fail / 缺結果 → `run_trusted=False` → snapshot 全 15 能力 grade 覆寫 `insufficient_data`（MASTER:89, RUNBOOK:14, RUNBOOK:27, RUNBOOK:37）。此行為由 `current_run_meta(layer0_preflight=...)`（IMPL:271-272, :287-288）+ `to_snapshot` F2（IMPL:740-743）消費，本 issue 只需保證輸出的 `preflight_result.json` 能被 `build_scoreboard --preflight` 正確讀成 `run_trusted`（IMPL:818-820 `test_build_scoreboard_missing_preflight_is_failclosed`）。
+- `version_snapshot` 讀 `.pawai-last-deploy`（`status.py:11`）：無 manifest → `version_mismatch=True`（fail 才 block）；manifest age>6h → `version_stale=True`（標註不 block，MASTER:101, IMPL:103-116）。
+
+**Files / modules likely touched**
+- `.claude/skills/jetson-verify/profiles/demo.yaml` — 目前 stub（`checks: []`），填 8 check（MASTER:143 canonical 路徑；MASTER:90 現況 stub）。
+- `.claude/skills/jetson-verify/profiles/smoke.yaml` — 候選來源（現有 **9 checks**，挑 demo preflight 適用 subset 參考；MASTER:32, :90）。**讀取 / 參考，不改**。
+- `verify.py`（jetson-verify runner）— 需確認能輸出結果 dict 落地成 `artifacts/baseline/preflight_result.json`；若 runner 無寫檔能力則 NEW 薄 wrapper（預定 `benchmarks/scripts/run_preflight.py`，呼叫 verify runner → dump json）。
+- 消費端（**不在本 issue 改，僅對齊**）：`benchmarks/core/scoreboard_schema.py` `current_run_meta`（IMPL:247-290）、`benchmarks/core/build_scoreboard.py`（IMPL:878-889）。
+
+**Test / verification**
+- Jetson smoke：起 demo entrypoint（`start_full_demo_tmux.sh` / lane 腳本）→ 跑 demo.yaml → 確認 `preflight_result.json` 產出且 `status` 正確。
+- 反向驗證（fail-closed）：故意不起 demo session / 斷 Go2 ethernet → preflight `status="fail"` → `build_scoreboard --preflight <fail>.json` → snapshot 全 15 能力 `insufficient_data`（對齊 IMPL:580-593 `test_layer0_preflight_fail_forces_all_insufficient`，但以真實 preflight 輸出驅動）。
+- 缺檔驗證：`build_scoreboard` 不帶 `--preflight` → `run_trusted=False` → 全 insufficient（IMPL:810-820 已有單測，本 issue 確認真實 `preflight_result.json` 路徑被 RUNBOOK step4 `--preflight artifacts/baseline/preflight_result.json` 帶上，RUNBOOK:27）。
+
+**Output artifact**
+`artifacts/baseline/preflight_result.json`（含 `status` ∈ {pass, pass_with_warnings, fail} + `version_snapshot` 欄位）；填好的 `.claude/skills/jetson-verify/profiles/demo.yaml`。
+
+**Out of scope**
+- **不自寫 check runner** — 複用 `jetson-verify` YAML-driven runner（MASTER:37, :90）。
+- 不接 Brain runtime gate、不做 Studio health panel、不換模型（v0.2/v0.3，MASTER:47-49）。
+- Known Findings 的 contract 2 WARN 清理、cli CI 缺口、demo-preflight skill 指向不存在的 `scripts/preflight.py` 等一律「baseline fail 後才開修」，不在本 issue 修（MASTER:215-217）。
+- 不在本 issue 改 snapshot fail-closed 邏輯本身（已由 #1/#3 的 `current_run_meta` + `to_snapshot` F2 實作）。
+
+---
+
+## Issue #5：Perception baseline observer — `gesture.wave` / `object.cup`，event-only，scenario_kind 分流
+
+- **Title**：Perception baseline observer（`perception_baseline_observer.py`，gesture/object event-only，每 round 標 scenario_kind）
+- **Type**：AFK（純比對邏輯 `evaluate_round` / `count_false_triggers` dev 機 TDD，無 ROS 依賴，IMPL:933, :1004）。注意：ROS node wrapper 真正上機量測屬 RUNBOOK step 3，但 wrapper 本身保持薄、不在 CI（IMPL:1086-1093）；本 issue 的可驗收 deliverable = 純函式 + 單測。
+- **Blocked by**：none（純函式產 record dict，aggregator/schema 端 key 已由 #1/#2/#3 定義；本 issue 只需對齊欄位）
+
+**What to build**
+新 `benchmarks/core/perception_baseline_observer.py`：純比對邏輯把 operator 宣告的 `RoundMeta`（capability/scenario/expected_label/distance/window_start）與該 round 觀測到的 `(label, confidence, ts)` 比對，產一筆 CapabilityResult-shaped dict；idle round（expected ∈ {none,idle,""}）任何觀測 = false_trigger，positive round 命中 expected → pass(latency=首中相對 window_start)、否則 miss(fail，非 false_trigger)。**只負責 gesture / object（event-only）；face 不在此**（F3，face 走 #6，IMPL:934-935）。
+
+**Acceptance criteria**
+- `evaluate_round` 五種行為正確（IMPL:946-997 六個單測）：idle 無觀測 → pass/non-FT；idle 有觀測 → fail/FT；positive 命中 → pass + latency_ms（`(ts-window_start)*1000`）+ distance_m；positive 無觀測 → miss(fail, 非 FT)；positive 認錯類別（如 cup round 看到 bottle）→ miss(fail, 非 FT，SPEC §5:193「wrong class → 傷 cup_recall 不算 false-positive」）。
+- 每筆 record 帶 `scenario_kind`（idle / positive，IMPL:1070），供 aggregator 分離算 recall vs false-accept（不混算，IMPL:660-661, MASTER §F2）。
+- `count_false_triggers` 數 idle round 誤觸數（IMPL:989-996）。
+- record 欄位為 `CapabilityResult` 子集且與 aggregator 讀的 key 對齊：`capability_id/scenario_id/scenario_kind/expected_label/predicted_label/pass_fail/false_trigger/confidence/latency_ms/distance_m/distance_source`（IMPL:1066-1079）。
+- `distance_source` 對 gesture/object = `"manual_declared"`（人工宣告，非 D435 深度，MASTER:51, SPEC §1:40 對照 face 才是 d435_depth）。
+- 對齊 SPEC 門檻語意（門檻數字在 spec / DEFAULT_CRITERIA，本 observer 只產 raw record）：gesture idle false_trigger 是硬 gate（SPEC §4:175 ≤1/10min=pass）；object idle round = 1 個 60s 窗生一筆 record，`false_trigger`=窗內有無誤報 cup（SPEC §5:194）。
+
+**Files / modules likely touched**
+- `benchmarks/core/perception_baseline_observer.py` — **NEW**（IMPL:929，預定路徑已定）。
+- `benchmarks/test/test_perception_baseline_observer.py` — **NEW**（IMPL:930, :940-997 測試已寫好可照抄）。
+- ROS node wrapper（**保持薄、不在 CI、Jetson 跑**）：訂 `/event/gesture_detected` + `/event/object_detected`，正規化 `/event/gesture_detected → (gesture, confidence, stamp)`、`/event/object_detected → 每 objects[]: (class_name, confidence, stamp)`（IMPL:935, :1086-1093）。event schema 接地：`object_perception_node.py:365,416`（SPEC §5:198）、wave confidence hardcode 1.0（`vision_perception_node.py:414`，SPEC §4:172）。
+
+**Test / verification**
+- dev 機 pytest：`python -m pytest benchmarks/test/test_perception_baseline_observer.py -q` → 6 測試全綠（IMPL:1098-1099），再 `python -m pytest benchmarks/test -q` 全綠（IMPL:1103）。
+- 上機（RUNBOOK step 3，HITL，非本 issue 的 CI 驗收）：起感知 lane demo entrypoint，**object 必須先起 `object_perception`**（現無 consumer 訂 `/event/object_detected`，SPEC §5:191, RUNBOOK:20）、**gesture 必走 recognizer backend**（demo 真實 backend，非壓測 mediapipe，SPEC §4:172, RUNBOOK:20），operator 宣告 round_meta + 人工 ground-truth → JSONL。
+
+**Output artifact**
+`benchmarks/core/perception_baseline_observer.py`；逐 round append 進共用 `baseline_result.jsonl`（face/gesture/object/voice/nav 共用同檔，RUNBOOK:34）。
+
+**Out of scope**
+- **不跑 face**（event-only 量不出 unknown-false-accept / 多臉 / 距離，face 拆 #6 `face_baseline_observer` 吃 state 流，F3，IMPL:934, SPEC §1:38）。
+- 不改任何感知 node、不修辨識、不接 Brain（IMPL:933）。
+- 不主張 static gesture（ok/thumbs/palm 全不主張，只 wave；SPEC §4:168）、不主張 object.bottle/wallet/key/`object.general`/VLM（全 future，SPEC §5:187）。
+- 不改 object whitelist、不修 gesture score-floor、不調 WaveDetector 超參 — 這些是「baseline fail 後才開修」的 Known Findings（MASTER:210-211, SPEC §4:177, §5:196）。
+- ROS node wrapper 不進 CI、不做厚邏輯（保持薄，IMPL:1086, MASTER:233）。
+
+---
+
+## Issue #6：Face baseline observer — `/state/perception/face` 連續流，unknown-false-accept aware
+
+- **Title**：Face baseline observer（`face_baseline_observer.py`，吃 `/state/perception/face` 連續狀態流，量得出 unknown-false-accept）
+- **Type**：AFK（純邏輯 `evaluate_face_round` dev 機 TDD，無 ROS 依賴，IMPL:1205）。ROS node wrapper 上機量測屬 RUNBOOK step 3、保持薄不在 CI（IMPL:1296-1302）；本 issue 可驗收 deliverable = 純函式 + 單測。
+- **Blocked by**：none（與 #5 並行；獨立檔，aggregator/schema key 已由 #1/#3 定義）
+
+**What to build**
+新 `benchmarks/core/face_baseline_observer.py`：純邏輯把 `FaceRoundMeta`（expected=註冊者名 / "unknown"(idle) / distance / window）與 window 內累積的 `FaceStateSnapshot(ts, tracks)`（每 tick 全 tracks）比對，產一筆 CapabilityResult-shaped dict。**face 必須吃 `/state/perception/face` 連續流，不可用 #5 的 event observer** — 因 `/event/face_identity` 只在 stable transition 發、**從不發 unknown**（`face_identity_node.py:561`），event-only 量不出 unknown-false-accept / 多臉 / 距離分桶（F3，IMPL:1119, SPEC §1:38, :59）。
+
+**Acceptance criteria**
+- `evaluate_face_round` 五種行為正確（IMPL:1134-1189 五個單測）：idle round 出現被穩定辨識成註冊者的 track → fail/FT（誤把陌生人叫成註冊者）；idle 全 unknown track → pass/non-FT；positive 命中 expected 名 → pass + confidence(=track sim) + distance(=track 真實深度) + `distance_source="d435_depth"`；positive 只 unknown/無 track → miss(fail，非 FT)；positive 卻穩定辨識成別的註冊者 → fail/FT（認錯人，比漏認嚴重，SPEC §1:52 硬規則）。
+- 每筆 record 帶 `scenario_kind`（idle=expected ∈ {unknown,none,idle,""} / positive，IMPL:1283），供 aggregator 算 `registered_recall`(positive pass 率) / `unknown_false_accept_rate`(idle FT 率) / `wrong_person_count`(positive 卻 FT)（SPEC §1:55, IMPL:688-690）。
+- `distance_source` = `"d435_depth"` when track 帶真實深度（face state 帶 D435 深度，≠ gesture/object 的人工宣告，IMPL:1167, :1291-1292, SPEC §1:40）。
+- record 欄位與 aggregator/schema key 對齊：`capability_id/scenario_id/scenario_kind/expected_label/predicted_label/pass_fail/false_trigger/confidence/latency_ms/distance_m/distance_source`（IMPL:1279-1293）。
+- 對齊 SPEC 門檻（門檻數字在 spec / DEFAULT_CRITERIA，本 observer 只產 raw record）：`registered_recall` ≥80%/60-80%/<60%、`unknown_false_accept_rate` ≤3%/3-10%/>10%、`wrong_person_count`≥1 且小樣本 → 不得 pass（SPEC §1:41, :50-53）。
+
+**Files / modules likely touched**
+- `benchmarks/core/face_baseline_observer.py` — **NEW**（IMPL:1116，預定路徑已定）。
+- `benchmarks/test/test_face_baseline_observer.py` — **NEW**（IMPL:1117, :1124-1189 測試已寫好可照抄）。
+- ROS node wrapper（**保持薄、不在 CI、Jetson 跑**）：訂 `/state/perception/face`（連續 ~20Hz），parse JSON → `FaceStateSnapshot(ts, tracks)`，依 round window 累積 → `evaluate_face_round`（IMPL:1296-1302）。state schema 接地：`face_identity_node.py:634-641`（含 track_id/stable_name/sim/distance_m/bbox/mode/face_count，SPEC §1:59）。
+
+**Test / verification**
+- dev 機 pytest：`python -m pytest benchmarks/test/test_face_baseline_observer.py -q` → 5 測試全綠（IMPL:1307-1308）。
+- 上機（RUNBOOK step 3，HITL，非本 issue 的 CI 驗收）：跑 `face_baseline_observer` 吃 `/state/perception/face`，operator 宣告 `FaceRoundMeta`（expected 註冊者名 / "unknown"(idle) / distance / window，每 round 標 scenario_kind）→ JSONL。scenario 距離 1m/2m（3m optional、drop 0.5m）、註冊者 1-2 人 + 陌生人 2-3 人（SPEC §1:39, RUNBOOK:21）。**勿用 `perception_baseline_observer` 跑 face**（RUNBOOK:21）。
+
+**Output artifact**
+`benchmarks/core/face_baseline_observer.py`；逐 round append 進共用 `baseline_result.jsonl`（與 gesture/object 同一檔，IMPL:1301, RUNBOOK:34）。
+
+**Out of scope**
+- 不改 `face_identity_node`、不修辨識、不接 Brain（IMPL:1302）。
+- 不調 `sim_threshold`(現 0.40)、不重 enroll face_db、不換 YuNet/SFace — 這些是「`unknown_false_accept_rate` fail 才考慮」的 v0.3 修法，不在本 issue（SPEC §1:43, MASTER:206-208）。
+- 不主張守護 / 陌生人警報（North Star §5 禁止；陌生人=泛稱不點名不警報，SPEC §1:45）。
+- 不做 Studio evidence chip 展示（屬 #12 studio.evidence，SPEC §1:57）。
+- ROS node wrapper 不進 CI、保持薄（IMPL:1296, MASTER:233）。
+
+---
+
+## Issue #7：Voice baseline run — voice.command + voice.stop + mic_stop endpoint（HITL）
+
+- **Title**：Voice baseline run — voice.command + voice.stop on Jetson, with mic_stop manual-boundary endpoint
+- **Type**：HITL（上機跑 baseline 需人在 Jetson 對麥克風講固定指令 /「停」並錄 round；mic_stop endpoint 的 code 部分為 AFK 前置，但量測本身 HITL）
+- **Blocked by**：#1 schema、#2 grader、#3 build_scoreboard（aggregator 薄殼）、#4 preflight（run_trusted）— baseline JSONL→**可信** snapshot 需這四者就位才能判讀 trusted grade；mic_stop endpoint code 本身無 issue 依賴
+
+**What to build**
+1. 接 `mic_stop` 訊號流（demo-blocking 前置）：Studio `use-audio-recorder.ts` stopRecording → WebSocket `mic_stop` event → 發 `/event/mic_boundary`；`stt_intent_node` 訂閱後立即 finalize + 解 echo gate（SPEC §2:108）。
+2. 把現成 `speech_test_observer` 的 CSV 結果轉成 baseline record（A2：補 `capability_id=voice.command` / `voice.stop`）寫進共用 `baseline_result.jsonl`。
+3. 上機走 demo entrypoint 跑 voice.command（6-8 固定指令各 ≥3 輪）+ voice.stop（「停」專項 N 輪含噪音）。
+
+**Acceptance criteria**
+- voice.command：fixed `accuracy ≥80% pass / 70-80% degraded / <70% fail`（SPEC:78；對齊 `speech_test_observer.py:247` `fixed_accuracy_ge_80pct`）；`e2e_median ≤3.5s`（SPEC:78；`speech_test_observer.py:248`）；`play_ok ≥80%`（SPEC:78；`speech_test_observer.py:250`）；**TTS TTFA p90 ≤2s / 2-4s degraded / >4s fail**（SPEC:78）。ASR/intent/TTS 為 sub-metric，任一 fail 則 row fail（SPEC:77）。
+- voice.stop：**FN（漏聽）硬性 = 0**，任一漏聽 = fail，不平均（SPEC:95）。含噪音段（SPEC:93）。
+- mic_stop endpoint：baseline 走 **manual mic boundary**（`energy_vad.enabled=False`），latency **雙記錄** — 新 `e2e_latency_ms` 從 `mic_stop_ts` 起算、舊 `speech_start_ts` 欄位保留改名對照，報告標「metric v2（mic_stop 起算）」（SPEC:108-109；RUNBOOK:19）。echo gate 在 manual mic_stop 時立即解（SPEC:110）。
+- 沒接 mic_stop 訊號流就量不到 manual mic boundary，latency 仍是 VAD 舊世界 → 此項為 demo-blocking 前置，必須先驗 `/event/mic_boundary` 通（SPEC:108；RUNBOOK:19）。
+- aggregator 預設門檻一致：`voice.command` criteria = `Criterion("success_rate", 0.80, 0.70, higher_is_better=True)`（IMPL:857-859）。
+- 每 round 走 demo entrypoint，不裸 `ros2 run`（拿錯 mic_gain/whisper device）（RUNBOOK 鐵律:8）。
+
+**Files / modules likely touched**
+- `pawai-studio/frontend/hooks/use-audio-recorder.ts`（existing；加 stopRecording → WS `mic_stop` event，SPEC:108）
+- `speech_processor/speech_processor/stt_intent_node.py`（existing；訂閱 `/event/mic_boundary` → finalize + 解 echo gate，~10-15 行 SPEC:108）
+- `speech_processor/speech_processor/speech_test_observer.py`（existing；A2 record 轉換，現 PASS_CRITERIA:246-250 + CSV_FIELDS:238-242 在，但**無 `capability_id`/`to_record`/jsonl 輸出** → 需補）
+- `benchmarks/core/scoreboard_schema.py`（NEW，Task 1；record schema voice 用）
+- Studio gateway WS handler（existing path；`mic_stop` event 路由，SPEC:108）
+- `scripts/run_speech_test.sh`（existing；baseline orchestration 入口，RUNBOOK:19）
+- baseline JSONL：`baseline_result.jsonl`（NEW；voice/face/gesture/object/nav 共用，RUNBOOK:34）
+- code 接地：`safety_gate.py:11` `SAFETY_KEYWORDS=("停","stop","暫停","煞車","緊急")` → `:23` `stop_move`（現成 fast path 雛形，SPEC:100）；`intent_classifier.py:16` SUPPORTED_INTENTS（SPEC:82）
+
+**Test / verification**
+- mic_stop 訊號流：`ros2 topic echo /event/mic_boundary`（按 Studio stop 後應收到 event）；確認 `stt_intent_node` 立即 finalize（不等 VAD timeout）。
+- baseline 量測：`bash scripts/run_speech_test.sh --skip-driver --skip-build` → `speech_test_observer` CSV → A2 轉 JSONL（每筆帶 `capability_id`）。
+- snapshot 判讀：`build_scoreboard.py baseline_result.jsonl --preflight ...` → voice.command/voice.stop grade（IMPL Task 3b:878-889）。
+- voice.stop FN 驗證：N 輪「停」全命中（grep JSONL `voice.stop` 無 miss round）。
+- pytest（mic_stop finalize 邏輯若拆純函式可加單測）。
+
+**Output artifact**
+- `/event/mic_boundary` topic（新訊號流）
+- `speech_test_*.csv`（observer 原輸出，含 `mic_stop_ts` + 舊 `speech_start_ts` 雙欄位）
+- `baseline_result.jsonl` 中 `capability_id=voice.command` / `voice.stop` 的 round records
+- snapshot 內 voice.command + voice.stop 的 grade + brain_allowed
+
+**Out of scope**
+- **fast_router / System1-System2 fast path 不做**（另線 Voice Latency Improvement，go/no-go = baseline fail，SPEC:112-115）。
+- Piper fast TTS cache / canned first-feedback / LLM-VLM slow path orchestration（另線，SPEC:114）。
+- diffusion action model = 明確 future（SPEC:116）。
+- voice.stop **不主張為安全機制**，是互動便利（operator_abort）；motion 安全由 reactive_stop + 物理 e-stop 保證，**不在任何 skill 安全依賴鏈**（SPEC:88,99-100；MASTER:66）。
+- 換 ElevenLabs（TTS）只在 TTFA fail >4s **且** edge_tts fallback 也 fail 才談，本 issue 不評估換模型（SPEC:80）。
+- 報告不可寫「快了 2 秒」— metric v2 是量法變非系統變快（SPEC:109）。
+
+---
+
+## Issue #8：Face baseline run — registered/stranger × 1m/2m（HITL）
+
+- **Title**：Face baseline run — registered vs stranger at 1m/2m, measure recall / false-accept / wrong-person on Jetson
+- **Type**：HITL（需人在 Jetson 前以註冊者 / 陌生人在 1m/2m 站位走 round，operator 宣告 FaceRoundMeta）
+- **Blocked by**：#6（`face_baseline_observer` Task 4b，吃 `/state/perception/face` 連續流；目前 `benchmarks/core/face_baseline_observer.py` 不存在 = NEW）；判讀可信 snapshot 另需 #1 schema、#2 grader、#3 build_scoreboard、#4 preflight（run_trusted）
+
+**What to build**
+上機跑 face baseline：註冊者 1-2 人 + 陌生人 2-3 人 × 距離 1m / 2m，用 `face_baseline_observer`（Task 4b）吃 `/state/perception/face` 連續流，operator 每 round 宣告 `FaceRoundMeta`（expected 註冊者名 / "unknown"(idle) / distance / window）並標 `scenario_kind`（positive / idle），逐 round append `baseline_result.jsonl`。
+
+**Acceptance criteria**
+- 量三個指標：`registered_recall` ≥80% pass / 60-80% degraded / <60% fail；`unknown_false_accept_rate` ≤3% pass / 3-10% degraded / >10% fail（SPEC:41，**不對稱門檻**）。
+- **硬規則：`wrong_person_count` ≥1（小樣本）→ 不得 pass，只能 degraded/fail**（SPEC:41,52）；認錯人 / 把陌生人叫成註冊者皆計 false_accept（SPEC:41）。criteria 對齊 `Criterion("wrong_person_count", pass_min=0, degraded_min=0, higher_is_better=False)`（SPEC:52；IMPL build_scoreboard:855）。
+- 每 round 須標 `scenario_kind`（positive=已知人出場 / idle=只陌生人或無人）（SPEC:55；observer record key `scenario_kind` IMPL:1283）。
+- 距離分桶 1m / 2m（3m optional stress、drop 0.5m）；多人同框只驗「會不會把 unknown 叫成註冊者」（SPEC:39）。
+- 必走 `face_baseline_observer`（state 流），**勿用 `perception_baseline_observer`**（event-only 量不出 unknown-false-accept，因 `/event/face_identity` 從不發 unknown）（SPEC:38,59；RUNBOOK:21；IMPL:1119）。
+- aggregate 分組 by (capability_id, scenario_kind)：`registered_recall`=positive round pass 率、`unknown_false_accept_rate`=idle round false_trigger 率、`wrong_person_count`=positive round 卻 false_trigger（認錯人）次數（SPEC:55）。
+- 必走 demo entrypoint（感知 lane 腳本），不裸 `ros2 run`（RUNBOOK 鐵律:8,21）。
+
+**Files / modules likely touched**
+- `benchmarks/core/face_baseline_observer.py`（NEW，Task 4b；`FaceStateSnapshot` / `FaceRoundMeta` / `evaluate_face_round` + ROS node wrapper 訂 `/state/perception/face`，IMPL:1200-1302）— **由 #6 交付**，本 issue 是上機 run
+- `benchmarks/test/test_face_baseline_observer.py`（NEW；5 測試，IMPL:1124-1190）
+- `benchmarks/core/scoreboard_schema.py`（NEW，Task 1；`to_record` + `CAPABILITY_META` face 屬性）
+- `baseline_result.jsonl`（face round 與 gesture/object 同檔，RUNBOOK:34；IMPL:1301）
+- code 接地（不改 node）：`face_identity_node.py:634-641` 每 tick 發全 tracks（track_id/stable_name/sim/distance_m/bbox/mode/face_count）；`:561` `/event/face_identity` 只在 stable transition 發、**從不發 unknown**（SPEC:59）；`face_perception/config/face_perception.yaml:23` `sim_threshold_upper:0.40` / `:24` lower:0.22 / `:17` stable_hits:2 / `:30` max_faces:5（SPEC:59）
+
+**Test / verification**
+- 先 `python -m pytest benchmarks/test/test_face_baseline_observer.py -q`（5 綠，#6 交付物，IMPL:1307）。
+- 上機：起感知 lane → `face_baseline_observer` 訂 `/state/perception/face`（~20Hz，RUNBOOK:17 實機 19.97Hz）→ operator 逐 round 宣告 FaceRoundMeta → JSONL append。
+- 判讀：`build_scoreboard.py baseline_result.jsonl --preflight artifacts/baseline/preflight_result.json` → face.recognition grade（缺 `--preflight` → 全 insufficient_data，RUNBOOK:27）。
+- 驗 wrong-person 硬規則：JSONL 中任一 positive round `false_trigger=True`（認錯人）→ snapshot grade 必非 pass。
+
+**Output artifact**
+- `baseline_result.jsonl` 中 `capability_id=face.recognition` 的 round records（含 `scenario_kind` / `predicted_label` / `false_trigger` / `confidence` / `distance_m` / `distance_source=d435_depth`，IMPL:1283-1292）
+- snapshot 內 face.recognition grade + brain_allowed + `registered_recall` / `unknown_false_accept_rate` / `wrong_person_count`
+
+**Out of scope**
+- **不主張守護 / 陌生人警報**：North Star §5 禁；`stranger_alert` 已 5/27 改 silent（`text=""`）→ 陌生人=泛稱不點名、不警報（SPEC:45）。
+- **不觸發 motion**：face risk_role=evidence_only / dependency_role=content，fail→不叫名仍可互動，degraded/fail 都不觸發 motion（SPEC:42；MASTER:64）。
+- 棄 TAR@FAR（小樣本不可理解），改 recall/false-accept/wrong-person（SPEC:40）。
+- 換 YuNet/SFace 只在 `unknown_false_accept_rate` fail（>10%）才考慮，**且先試零成本手段**（調高 `sim_threshold` / 重 enroll face_db）；recall fail 單獨不換（SPEC:43）。本 issue 不換模型。
+- `time_to_stable_ms` 為觀測欄、**非 gating criterion**（SPEC:55）。
+- 不改 `face_identity_node`、不接 Brain（IMPL:1302）。
+
+---
+
+## Issue #9：Gesture (`gesture.wave`) + Object (`object.cup`) baseline run（HITL）
+
+- **Title**：Gesture (`gesture.wave`) + Object (`object.cup`) baseline run — wave recall/idle 誤觸硬 gate + cup recall/idle false-positive
+- **Type**：HITL（必須在 Jetson 上機、真人比手勢 + 拿 demo 杯子，operator 宣告 round_meta + 人工 ground-truth；無法 AFK）
+- **Blocked by**：#5（`perception_baseline_observer`，Task 4 event-only 純比對邏輯；SPEC §4 observer:172、§5 observer:191；IMPL Task 4:926-997）；判讀可信 snapshot 另需 #1 schema、#2 grader、#3 build_scoreboard、#4 preflight（run_trusted）
+
+**What to build**
+跑 `gesture.wave` 與 `object.cup` 兩個 mainline 視覺能力的 as-is baseline：起感知 lane（demo entrypoint，**gesture 必走 `recognizer` backend、object 必須真起 `object_perception`**），operator 逐 round 宣告 `scenario_kind`（positive / idle）+ 人工確認命中，透過 `perception_baseline_observer` 產 JSONL 餵 aggregator。不改模型、不修辨識、不接 Brain。
+
+**Acceptance criteria**
+- gesture round 涵蓋：real wave 1m/2m 各 ≥10 次（positive）+ person-present idle 60s×10=10min（idle，人在框內手自然放鬆，**非 idle-EMPTY**）+ natural hand motion；對齊 SPEC:174。
+- gesture grade 門檻對齊 SPEC:175：recall ≥90%/80-90%/<80%；**idle 誤觸是硬 gate（權重 > recall）：≤1/10min=pass / 1-3=degraded / >3=fail，不管 recall**。
+- gesture 必走 demo recognizer backend + 人工 ground-truth，**不可用壓測 mediapipe backend 的 idle 結果當 baseline**（wave confidence hardcode 1.0 無鑑別力，SPEC:172、:179；RUNBOOK:20）。
+- object round 涵蓋：cup 放桌上 1m/2m 各 ≥5 次含背景干擾（positive）+ 空場景 / 無 cup 連續 60s 量 false-positive（idle）；**不測地上 / 人手拿**；對齊 SPEC:192。
+- object 計算規則對齊 SPEC:193-194：positive round cup detected=pass、no detection=miss、wrong class=傷 `cup_recall` 不算 false-positive；idle no-cup round 任何 cup 事件=false_positive；1 idle round=1 個 60s 窗，單窗 0=pass/1=degraded/>1=fail。
+- object grade 門檻對齊 SPEC:194：cup recall ≥80%/60-80%/<60%；`unknown_false_accept_rate`=誤觸窗數 / 總窗數。
+- 每 round JSONL record 帶 `scenario_kind`（positive/idle）供 aggregator 分組（IMPL aggregate by (capability_id, scenario_kind):664-707）。
+
+**Files / modules likely touched**
+- `benchmarks/core/perception_baseline_observer.py`（#5 產出，本 issue 使用其 ROS node wrapper 餵 `evaluate_round`；IMPL:1004-1022）
+- gesture lane 啟動：`scripts/start_stress_test_tmux.sh` / `vision_perception` launch，**改 `gesture_backend:=recognizer`**（demo backend，非壓測 mediapipe）— RUNBOOK:20
+- object lane 啟動：`object_perception` launch，whitelist `[41,999]`（cup-only，SPEC code 接地:198 `object_perception.yaml:20`）
+- 訂閱 `/event/gesture_detected`、`/event/object_detected`（IMPL observation 正規化規則:935）
+- append 共用 `baseline_result.jsonl`（RUNBOOK:34）
+
+**Test / verification**
+- 前置（dev 機）：#5 的 `python -m pytest benchmarks/test/test_perception_baseline_observer.py -q` 全綠（idle/positive/miss/wrong-label/count_false_triggers，IMPL:946-996）。
+- Jetson smoke：`ros2 topic hz /perception/object/debug_image`（~6-8 Hz）+ `ros2 topic echo /event/object_detected --once` 確認 cup 事件會發；gesture 確認 recognizer backend 真實揮手會發 `/event/gesture_detected`。
+- 上機跑序遵 RUNBOOK step 3 gesture/object（required baseline step，demo entrypoint，operator 宣告 round_meta + 人工確認 → JSONL；RUNBOOK:20）。
+
+**Output artifact**
+- 逐 round append `baseline_result.jsonl`（含 `gesture.wave` / `object.cup` records，帶 `scenario_kind`）
+- 餵 `build_scoreboard.py` 後 snapshot 中 `gesture.wave` / `object.cup` 兩能力的 grade + recall + idle false-trigger rate（非 insufficient_data）
+
+**Out of scope**
+- static gesture（ok/thumbs/palm）全不主張、不測（SPEC:168）。
+- object：bottle/wallet/key/denture/`object.general`/VLM 場景描述、顏色辨識全 future、不測（SPEC:184、:196；無 color detection code）。
+- 不測 object 地上 / 人手拿（SPEC:192）。
+- 不改模型、不調超參、不換 backend score-floor、不動 whitelist — baseline fail 後才開修，屬 v0.3（MASTER Known Findings:210-211；SPEC 修法順序:177、:196）。
+- 不接 Brain runtime gate（v0.2）。
+
+---
+
+## Issue #10：Pose (`pose.basic`) baseline run（optional / P2，非 6/18 blocker）
+
+- **Title**：Pose (`pose.basic`) baseline run（studio_only 薄測，optional/P2）— `pose.fall` 不測（future）
+- **Type**：HITL（需真人在 Jetson 前擺姿勢、operator 宣告 + 人工確認；但 **optional/P2，非 6/18 blocker**）
+- **Blocked by**：#5（`perception_baseline_observer`，Task 4 event-only；IMPL:926-997）；判讀可信 snapshot 另需 #1 schema、#2 grader、#3 build_scoreboard、#4 preflight（同 #9）
+
+> **非 6/18 blocker**：`pose.basic` claim_level=`studio_only`、6/18 不進 Brain 主線（SPEC:134）；canonical 結構鎖定 #10 = optional/P2。可在 6/18 主線跑完後補。
+
+**What to build**
+跑 `pose.basic`（standing/sitting/crouching/bending 單幀 2D 幾何分類）的薄 baseline：起感知 lane（demo entrypoint），operator 擺各姿勢，`perception_baseline_observer` 量各姿勢 recall，**只 observe 不觸發 motion、不進 Brain**。`pose.fall` 本輪明確不測。
+
+**Acceptance criteria**
+- 場景對齊 SPEC:139：standing/sitting（+crouching/bending）各 ≥3 次 recall，只 observe 不觸發 motion。
+- grade 用寬門檻（studio_only）對齊 SPEC:141：recall ≥70% 可顯 / <70% 連 studio 也不信；akimbo/knee_kneel 不穩、不主張。
+- `pose.fall` **不產任何 baseline record**，snapshot 維持 `insufficient_data`（SPEC:156 標 insufficient_data；:154 幻覺未解不測）。
+- record 帶 `scenario_kind`（pose recall 為 positive）；JSONL append 共用 `baseline_result.jsonl`。
+- 明確標註本 issue 為 optional/P2，pose.basic fail **只降級為 unknown / 不顯示姿勢**，不觸發換模型工作（SPEC:143）。
+
+**Files / modules likely touched**
+- `benchmarks/core/perception_baseline_observer.py`（#5 產出；event-only，訂 `/event/pose_detected`）
+- pose lane 啟動：`vision_perception` launch（`pose_backend:=mediapipe`，demo entrypoint，RUNBOOK 鐵律:8）
+- append 共用 `baseline_result.jsonl`
+
+**Test / verification**
+- 前置（dev 機）：#5 `python -m pytest benchmarks/test/test_perception_baseline_observer.py -q` 全綠。
+- Jetson smoke：`ros2 topic echo /event/pose_detected` 確認 sitting/standing 真人可觸發。
+- 上機走 demo entrypoint（非裸 `ros2 run`，RUNBOOK:8）。
+
+**Output artifact**
+- `baseline_result.jsonl` 中 `pose.basic` records（各姿勢 recall）；snapshot 中 `pose.basic` grade（studio_only 寬門檻）、`pose.fall` 維持 `insufficient_data`。
+
+**Out of scope**
+- `pose.fall` 不測、不評（SPEC:149 claim_level=future；:154 不測；:156 insufficient_data；North Star §5 禁說跌倒可靠）。fallen TTS 永靜音、不停車、不進 Brain（SPEC:157）。
+- akimbo/knee_kneel 不主張、不測（SPEC:141）。
+- pose 不進 Brain 決策、不觸發 motion（SPEC:142）。
+- 不換模型（6/18 前不換；recall fail 只降為 unknown，不觸發 RTMPose/PINTO 升級 — 避免 P2 功能偷偷變 P0，SPEC:143）。
+- 非 6/18 blocker，不可因此卡主線 baseline。
+
+---
+
+## Issue #11：Nav baseline — safe_stop / no_auto_resume (insufficient_data) + short_move (dry-run) + dynamic_avoidance (future)（HITL，安全先於移動）
+
+- **Title**：Nav baseline run — safe_stop/no_auto_resume insufficient_data（等 BD-7/BD-8）+ short_move dry-run（safety pass 前不放行 motion）+ dynamic_avoidance future
+- **Type**：HITL（需在 Jetson + Go2 上機；safety 兩項待行為重設計，short_move 僅 dry-run / action-path check，**不讓 Go2 實際走**）
+- **Blocked by**：#1 schema、#2 grader、#3 build_scoreboard、#4 preflight（判讀可信 snapshot 需這四者）；外部依賴 nav recorder BD-7/BD-8（行為重設計，非本 issue）。本輪三能力**不需** #5 perception observer（safe_stop/no_auto_resume 走 reactive_stop recorder、short_move 走 `/event/nav/mission` action-path；屬 nav workstream）
+
+> **安全先於移動寫死**：`nav.safe_stop` + `nav.no_auto_resume` **pass（或明確人工安全 override）前，不允許跑 motion**，順序不可顛倒（RUNBOOK 跑序鐵律:22；SPEC §6 紀律:202）。
+
+**What to build**
+本輪 nav baseline 在「安全先於移動」鐵律下執行：(a) `nav.safe_stop` / `nav.no_auto_resume` 本輪標 `insufficient_data`（recorder BD-7 未接 + no_auto_resume 行為衝突待 BD-8 重設計）；(b) `nav.short_move` 在 safety 兩項未 pass 前**只做 dry-run / action-path check**（手動發 `/nav/goto_relative` 驗 action server 鏈路通、量 `/event/nav/mission`，不讓 Go2 實際走）；(c) `nav.dynamic_avoidance` future、不主張、標 insufficient_data。
+
+**Acceptance criteria**
+- `nav.safe_stop`：本輪標 `insufficient_data`，**不可寫 pass** — recorder `_cb_reactive_status` no-op（BD-7 未接，SPEC:212、:219）。硬 fail 結構先鎖：`collision_count` 任一次=fail、`stop_margin_m` pass 需 ≥0.10m（SPEC:215，數字 calibrate-from-run-1）。
+- `nav.no_auto_resume`：本輪標 `insufficient_data` + 標明「**行為待重定義（BD-8）**」 — 現行 `reactive_stop_node.py:307 _maybe_call_nav_pause` 是 auto-resume，與語意相反（SPEC:234；RUNBOOK:23「還需 BD-8 行為重設計，非只接 recorder」）。正確行為先鎖：stop 後不自動 resume 原 goal，須 operator/Brain 發新命令才動（SPEC:232）。
+- `nav.short_move`：safety 兩項 pass 前**只 dry-run**，手動發 goto_relative 驗 action server 鏈路通 + 量 `/event/nav/mission`（outcome_code/actual_distance），**不讓 Go2 實際走**（RUNBOOK:24；SPEC:248 需 safe_stop+no_auto_resume 先 pass）。本輪 short_move 標 `insufficient_data`，記錄 3 blocker（IE:278 dispatch stub / F7 未定位 / 0.85 profile 無實機 motion 證據，SPEC:249）。
+- `nav.dynamic_avoidance`：不主張、標 `insufficient_data`（非 fail；架構 stop-only 不繞障，SPEC:256-259）。
+- 跑序遵 RUNBOOK step 3 nav 鐵律：safety pass / 人工 override 前不跑 motion，順序不可顛倒（RUNBOOK:22-24）。
+- D435 fusion shadow test 屬 spike、不主張：若跑，**必須 `target_frame:=base_link` 且先驗 TF**、height filter 0.05-0.50、同錄 `/scan_rplidar`、**不可沿用舊 detour script**，且**不可先宣稱 fusion 已可靠**（SPEC §6e:267、:273）。
+
+**Files / modules likely touched**
+- `scripts/start_nav_capability_demo_tmux.sh`（demo entrypoint，nav lane；short_move action-path）
+- 手動發 action：`ros2 action send_goal /nav/goto_relative go2_interfaces/action/GotoRelative`（dry-run 驗鏈路）
+- 訂閱 `/event/nav/mission`（outcome_code/actual_distance；SPEC:244）
+- recorder `recorder_node` `_cb_reactive_status` / `_cb_depth_safety`（BD-7 待接；MASTER Known Findings:213）— 本輪不在此 issue 修，僅標 insufficient_data 依據
+- `reactive_stop_node.py:307`（no_auto_resume 行為衝突點，BD-8 重設計依據，**本輪不改**，SPEC:234）
+- D435 shadow（若跑 spike）：`pointcloud_to_laserscan` → `/scan_d435_shadow`，`target_frame:=base_link`（SPEC:267）
+- append 共用 `baseline_result.jsonl`
+
+**Test / verification**
+- short_move dry-run：手動發 goto_relative，確認 action server 接 goal + 發 `/event/nav/mission`，**Go2 不動**（safety 未 pass）。
+- 跑前確認 RUNBOOK step 3 nav 鐵律順序（RUNBOOK:22）+ CLAUDE.md 已知陷阱（reactive_stop `safety_only=true` mux 模式、cmd_vel=0 不停車 StopMove 路徑）。
+- snapshot 驗：`nav.safe_stop` / `nav.no_auto_resume` / `nav.short_move` / `nav.dynamic_avoidance` 四能力 grade 皆 `insufficient_data`（aggregator 對 0 樣本 / 未接 observer 的 fail-closed 行為，IMPL:555-565）。
+
+**Output artifact**
+- `baseline_result.jsonl`：short_move dry-run 的 action-path check 記錄（如有 `/event/nav/mission` outcome）。
+- snapshot 中 nav 四能力 grade = `insufficient_data` + reason（safe_stop=BD-7 未接 / no_auto_resume=BD-8 行為待重定義 / short_move=3 blocker / dynamic_avoidance=future）。
+- 若跑 D435 shadow spike：`/scan_d435_shadow` + `/scan_rplidar` 同錄 bag（「RPLIDAR 漏掉而 D435 補到的比例」記錄，不主張）。
+
+**Out of scope**
+- **不寫 `safe_stop 已完成` / `no_auto_resume pass`**（SPEC:219；MASTER:70）。
+- safety 兩項 pass / 人工 override 前**不跑真實 0.3/0.5m motion**（SPEC:248；RUNBOOK:24）。
+- `nav.dynamic_avoidance` 不主張、不測 — ComposableNode + velocity_smoother 是 Phase 11+ future（SPEC:260）。
+- 本輪不修 recorder BD-7、不做 no_auto_resume BD-8 行為重設計、不定位 F7 — 屬獨立 nav workstream，非 capability spec grill 範圍（SPEC:275；MASTER:213）。
+- D435 fusion 不主張為可靠、不接 safe_stop / Nav2 obstacle layer（spike 過了才升級，SPEC:267、:273）；不復活舊 detour script。
+- Go2 內建 LiDAR / `range_obstacle[4]` / onboard avoidance（api 1004）皆 spike/future、不進 6/18 主宣稱（SPEC §6e:264-271）。
+
+---
+
+## Issue #12：Studio evidence — provenance label + Brain trace display + frozen scoreboard chip
+
+- **Title**：Studio evidence：provenance label (live/mock/frozen/missing) + Brain trace display + read-only frozen scoreboard chip
+- **Type**：AFK（純前端 / gateway code，本機可開發；可用 `backend/mock_server.py` + 一份 fixture snapshot 在 dev 機完成。Jetson live smoke 在上機輪驗收，不阻 AFK 開發）
+- **Blocked by**：none（read-only 讀 frozen snapshot；snapshot 產出鏈在 #3 build_scoreboard / #13 freeze，但本 issue 可先用 `pawai_brain/test/fixtures/baseline_snapshot.example.json` 做 chip 開發，git-tracked 穩定樣本，SPEC §9:417；不擋 6/18）
+
+**What to build**
+1. 在既有 Studio dashboard 加「誠實層」provenance 標籤 `live/mock/frozen/missing`，**mock server 跑時 UI 必須明顯標 `mock`、不得偽裝 live**，並修預設 `start.sh` 跑 mock 卻看不出來的問題（SPEC §8:334, :358）。
+2. 確認 Brain trace drawer 渲染真實 `/brain/conversation_trace`（非 mock），可看出 stage/status/reason 與四態（proposed/blocked/needs_confirm/rejected_not_allowed）（SPEC §8:343-345 c、§7b:318 d）。
+3. 新增 `GET /api/scoreboard` 唯讀 endpoint + 前端 chip：讀 frozen `baseline_snapshot.json`（path 由 `PAWAI_SCOREBOARD_PATH` 控制），顯 `capability_id/grade/reason/last_tested_at`（SPEC §8:345 (4), :352；owner = Studio gateway/frontend team，§9:421）。
+
+**Acceptance criteria**（對齊 SPEC §8:345 的 pass 5 條 + degraded/fail）
+- [ ] 前端對每個資料來源明確標 `live / mock / frozen / missing` 四態之一（SPEC §8:345 (1)）。
+- [ ] 跑 mock server（`backend/mock_server.py`，port 8080）時 UI 明顯顯 `mock`，**不得偽裝成 live**；mock 與 live envelope 一字不差是已知坑，標籤必須來自連線後端身分而非 envelope 內容（SPEC §8:345 (2), :356）。
+- [ ] 預設 `start.sh`（現 `start.sh:44-46` 預設 mock，port 8080）不再讓 demo 畫面看似真資料 —— 或顯著標 mock、或 demo 切 `start-live.sh --live`（SPEC §8:358）。
+- [ ] `/brain/conversation_trace` 在 trace drawer 顯 stage / status / detail(reason)；proposed / blocked / needs_confirm / rejected_not_allowed 四態可辨（SPEC §8:345 (3)、§7b:318；trace 已在 gateway forward，`studio_gateway.py:81`）。
+- [ ] frozen scoreboard chip 顯 `capability_id / grade / reason(failure_reason) / last_tested_at` 四欄齊全（SPEC §8:345 (4)）。
+- [ ] `blocked / insufficient_data` 必帶 reason，不准只顯 `fail`；斷某來源顯 `missing` 非空白（SPEC §8:343 (e), :345 (5)）。
+- [ ] chip 只讀 frozen snapshot，欄位語意對齊 snapshot 結構（`capabilities[id].grade / failure_reason`，IMPL `to_snapshot`:744-748；`brain_allowed` derive:748）。
+- [ ] **overclaim 防線**：UI 不得宣稱「IE 第二道 gate 已吃 scoreboard / runtime 全層 enforce」；gate blocked 顯示只反映 pawai_brain 那層，IE scoreboard-aware enforcement 標 v0.2 待補（SPEC §8:350）。
+
+**Files / modules likely touched**
+- `pawai-studio/gateway/studio_gateway.py`（NEW endpoint `GET /api/scoreboard`；現 `/api/capability` 在 `studio_gateway.py:268, 538-541` 只回 Nav/Depth Bool tri-state，**非** baseline grade → 需新 endpoint，SPEC §8:357；trace forward 已存在 `:81`）
+- `pawai-studio/frontend/components/`（NEW/修改 provenance badge + scoreboard chip 元件；面板已齊 face/gesture/pose/object/speech/chat/navigation/live，SPEC §8:355）
+- `pawai-studio/frontend/.../contracts/types.ts`（現 `source` 欄位是感知模態非資料真偽，`types.ts:25,59,95,118,155` → NEW provenance 欄位，SPEC §8:356）
+- `pawai-studio/frontend/.../use-websocket.ts`（連同一 `/ws/events`，分不出 gateway vs mock → NEW 後端身分標記，SPEC §8:356）
+- `pawai-studio/start.sh`（line 44-46 預設 mock；NEW 標 mock 或調整預設）
+- `pawai-studio/backend/mock_server.py`（envelope 與 live 一字不差，NEW mock 身分標記，SPEC §8:356）
+- fixture（讀）：`pawai_brain/test/fixtures/baseline_snapshot.example.json`（NEW，git-tracked，SPEC §9:417）
+
+**Test / verification**（對齊 SPEC §8:342-343 scenario）
+- gateway live smoke：起 live gateway → 驗 UI 標 `live`；起 mock server → 驗 UI 標 `mock`（不偽裝）。
+- replay 一段對話 → 驗 trace drawer 顯 stage/status/reason（§7b code path 由 scenario replay 獨立驗，trace 是否真實顯示在此驗）。
+- 載入一份 `baseline_snapshot.json`（fixture）→ 驗 chip 顯 capability/grade/reason/timestamp 四欄；斷某來源 → 驗顯 `missing`。
+- `/api/*` check：`curl GET /api/scoreboard` 回 frozen snapshot 內容；`PAWAI_SCOREBOARD_PATH` 切換不同檔可生效。
+- frontend source-label smoke（跑 live 看 `live` / 跑 mock 看 `mock`）+ screenshot（SPEC §8:342）。
+
+**Output artifact**
+- `GET /api/scoreboard` JSON 回應（讀 frozen `baseline_snapshot.json`）
+- 前端 provenance badge + scoreboard chip（截圖證據）
+- trace drawer 渲染 `/brain/conversation_trace` 的畫面
+
+**Out of scope**（SPEC §8:338, :350, :352 scope guard）
+- **不接 runtime gate**：chip 只讀 frozen snapshot，不接 Brain runtime / IE enforcement（v0.2，SPEC §8:350；§7b/#14 才負責「grade 真的接進 runtime gate」）。
+- **不 live recompute**：不在 demo 中即時重算 grade（避免 grade 抖動，SPEC §8:352, §9:421）。
+- **不做 health monitor / full observability dashboard**：超出唯讀 chip 範圍的 Studio health panel / runtime monitor 仍砍（SPEC §8:338, :352；MASTER:231 例外限「唯讀、不 live recompute、不接 runtime gate、只讀 frozen snapshot」）。
+- **不重寫 trace 展示給 v0.2**：本 issue 只做 6/18「trace 看得到、非 mock、有 reason」展示面；scoreboard grade 接進 runtime gate 是 #14（不在此重做）。
+- chip owner = Studio team，snapshot 的「產出 + freeze」是 #13/#3，不在本 issue 做。
+
+---
+
+## Issue #13：CLI readiness + freeze mechanism
+
+- **Title**：CLI readiness + freeze mechanism — `pawai readiness`（demo readiness authority, fail-closed --json truth table）+ freeze mechanism（凍結 demo snapshot 到 artifacts/baseline/frozen/）
+- **Type**：AFK 為主（`pawai readiness` 子命令 + 真值表 pytest 純 code，本機可寫）；**含 1 次 HITL Jetson smoke**（真 snapshot 上機跑 `pawai readiness` + `--json` 格式驗證，SPEC §9:370-371）。建議拆：AFK 寫命令 + 真值表先綠，Jetson smoke 上機輪補。
+- **Blocked by**：**implementation（`pawai readiness` 命令 + freeze mechanism + 真值表）blocked by #3**（build_scoreboard.py 產 `baseline_snapshot.json`，IMPL Task 3b:772-922）── 可先用 fixture / 合成 snapshot 寫，不必等真 baseline run。**但 actual demo freeze blocked by #4（preflight→run_trusted）+ completed required baseline runs #7 / #8 / #9 / #11** ── **#10 pose 為 optional/P2，缺它應讓 `pose.basic`/`pose.fall` 維持 insufficient_data、不擋 freeze**（可有就收）。required baseline 沒跑完，frozen 的只會是空殼 / 全 insufficient_data，不是可信 demo snapshot。
+
+**What to build**
+1. 新 `pawai readiness` / `pawai readiness --json` 子命令，**與 `doctor` 分開**（doctor 可呼叫顯摘要，但不塞進 doctor 主邏輯）：以 frozen baseline snapshot + deploy manifest（`.pawai-last-deploy`）+ preflight metadata 做 **fail-closed** demo readiness 判定（SPEC §9:362, :366, :377）。
+2. freeze demo snapshot 機制：把 working `artifacts/baseline/baseline_snapshot.json` 凍進 `artifacts/baseline/frozen/2026-06-18/baseline_snapshot.json`（SPEC §9:416；RUNBOOK:36 demo 當天用 frozen）。
+
+**Acceptance criteria**（對齊 SPEC §9:373 capability grade 定義 + :391-403 fail-closed 表）
+- [ ] fail-closed 真值表全綠：snapshot 缺檔 / schema invalid / `run_trusted == false` / `layer0_preflight` fail / `snapshot.git_sha != deploy sha`（sha mismatch）/ capability list 不全 / mainline 能力缺 grade-reason → verdict `not_ready`；全通過 → `ready`（SPEC §9:371, :391-401）。
+- [ ] sha mismatch 是硬 stale 訊號（snapshot.git_sha != 當前 deploy sha → `not_ready`，:397, :403）；snapshot age **只警告不擋** verdict：`>3 days → warning`、`>7 days → strong warning`（SPEC §9:386, :403）。
+- [ ] `fail_open_count = 0`（無「該 not_ready 卻 ready」）；scoreboard 評的是 readiness **機制本身**正確性（capability grade），非單次 runtime verdict（SPEC §9:372-373 (a)/(b) 兩層別混）。
+- [ ] `--json` 輸出格式正確（真值表 verdict + 各 check 結果）；readiness 機制本身壞 → 對自己也 fail-closed（當 not_ready），任何不確定 = not_ready（SPEC §9:374, :391）。
+- [ ] override 軟可硬不可、且留痕：`--accept-warnings`/`--force-ready` 只能 override 軟條件（age warning / missing optional notes / preflight `pass_with_warnings`）；硬條件（snapshot missing / schema invalid / run_trusted=False / layer0_preflight fail / **sha mismatch** / capability list 不全）**不可** override；override 蓋進輸出 `{override, operator, reason, timestamp}`（SPEC §9:406-409）。
+- [ ] checks 涵蓋最小檢查表 8 項：snapshot 存在 / schema version / run_trusted / layer0_preflight pass|pass_with_warnings / sha 對 deploy manifest / age advisory / 15 capability 全列 / mainline 能力皆有 grade+reason（SPEC §9:380-389）。
+- [ ] snapshot path 用 env `PAWAI_SCOREBOARD_PATH` 可覆寫（預設 working 路徑 `artifacts/baseline/baseline_snapshot.json`）；WSL 跑 readiness 經 SSH 讀 Jetson 路徑（沿用 `status.py:88 cat {jetson_repo}/.pawai-last-deploy`，SPEC §9:419）。
+- [ ] **概念不混**：deploy manifest `stale_after_h=6h`（檢查部署記錄新舊，IMPL `current_run_meta`:251）與 snapshot age 3d/7d advisory（檢查 baseline snapshot 新舊）是不同概念，各自為政（SPEC §9:404）。
+- [ ] freeze 後 `artifacts/baseline/frozen/2026-06-18/baseline_snapshot.json` 即 §8 `/api/scoreboard` 唯讀的那份（demo 當天用 frozen 不重算，SPEC §9:421, §8:352）。
+- [ ] **overclaim 防線**：readiness 是 demo readiness authority，但 Brain v0.1 不即時消費它（v0.2 才接 runtime gate，SPEC §9:362）；不可寫成「readiness 已接進 Brain gate」。
+
+**Files / modules likely touched**
+- `pawai_cli/.../readiness.py`（NEW 子命令 — recon 確認 greenfield，SPEC §9:425）
+- `pawai_cli/.../main.py`（NEW 註冊 click 命令；現 doctor/status 命令齊 `main.py:95` 構造 `.pawai-last-deploy`、`main.py:643` 寫 Jetson、`main.py:348` SSH echo，SPEC §9:424）
+- `pawai_cli/.../status.py`（reuse 讀 manifest `status.py:11/12/88`、sha mismatch 範本 `status.py:286-296`，MASTER:116）
+- test：`pawai_cli/test/test_readiness.py`（NEW 真值表 pytest，SPEC §9:370）
+- fixture：`pawai_brain/test/fixtures/baseline_snapshot.example.json`（NEW git-tracked 穩定樣本，SPEC §9:417）
+- snapshot 路徑（讀/freeze）：`artifacts/baseline/baseline_snapshot.json`（working，`.gitignore` 加 `artifacts/`）→ `artifacts/baseline/frozen/2026-06-18/baseline_snapshot.json`（frozen，SPEC §9:415-416）
+- env：`PAWAI_SCOREBOARD_PATH`（NEW，SPEC §9:419, :421）
+- 依賴產出：`benchmarks/core/build_scoreboard.py`（#3 / IMPL Task 3b，`--out` 預設 `artifacts/baseline/baseline_snapshot.json` IMPL:881；freeze 凍它的產物）
+
+**Test / verification**（對齊 SPEC §9:370-371 observer）
+- pytest 真值表窮舉（fail-open 是失敗模式，採樣測不到）：snapshot 缺檔 / schema 錯 / run_trusted=False / preflight fail / sha mismatch / capability list 不全 / age 過舊 / 全通過 → 預期 verdict（SPEC §9:371）。
+- 失敗模式 = 「該說不可信卻說 ready」(fail-open)，真值表覆蓋數 ÷ 應覆蓋數 + `fail_open_count` 為 metric（SPEC §9:372）。
+- 1 次 Jetson smoke（HITL）：真 snapshot → `pawai readiness` 跑得出 + `--json` 格式正確（SPEC §9:371）。
+- override 留痕驗證：軟條件 `--accept-warnings` 可過且輸出含 override 區塊；硬條件（如 sha mismatch）即使加 `--force-ready` 仍 `not_ready`（SPEC §9:408-409）。
+- grep / fixture：用 `baseline_snapshot.example.json` 跑全真值表分支。
+
+**Output artifact**
+- `pawai readiness` 終端輸出（verdict `ready / not_ready` + 各 check）
+- `pawai readiness --json`（機器可讀真值表 + override 留痕欄位）
+- freeze command / readiness output（本 issue 交付的是 freeze command/mechanism + readiness verdict）；actual `artifacts/baseline/frozen/2026-06-18/baseline_snapshot.json` 在 #4 + required baseline runs #7/#8/#9/#11 跑完後才產得出（#10 pose optional；非本 issue 完成即有）
+
+**Out of scope**（SPEC §9 + MASTER scope guard，防 scope creep）
+- **不塞進 doctor**：readiness 與 doctor 分開 —— doctor = 系統現在能不能跑（環境/網路/lock/driver）；readiness = baseline snapshot 可不可信，兩者不混（SPEC §9:362, :377）。
+- **不接 Brain runtime gate**：Brain v0.1 不即時消費 readiness；runtime gate enforce 是 v0.2（SPEC §9:362；overclaim 防線：grade 接進 `compute_effective_status` 是 #14 / MASTER 設計段 D，不在此做）。
+- **不設武斷 TTL 硬擋**：age 只 advisory（3d/7d warning），硬 stale 只認 sha mismatch（SPEC §9:403）。
+- **不重算 grade**：readiness 只讀 frozen snapshot 判可信度，不重跑 aggregator / 不改 grade（grade 計算是 #2/#3 grader+build_scoreboard）。
+- override 不萬能：硬條件不可 override（SPEC §9:408）。
+- `/api/scoreboard` endpoint 本體 owner = Studio team（#12），本 issue 只負責產 + freeze 它讀的那份 snapshot（SPEC §9:421）。
+
+---
+
+## Issue #14：Brain capability health gate（v0.2，grade 接進 runtime gate）
+
+- **Title**：Brain capability health gate — `compute_effective_status` 加 grade 分支 + IE 第二道 gate + allowlist single source（v0.2）
+- **Type**：AFK（純 code：擴 `compute_effective_status` 純函式 + IE executor gate + pytest 真值表，dev 機可跑、無 ROS / Jetson 依賴）
+- **Blocked by**：#2（grader：`brain_allowed(grade, claim_level)`）、#3（aggregator/build_scoreboard：產 `baseline_snapshot.json` 含每能力 `grade` / `claim_level` / `dependency_role` / `brain_allowed`）、#4（demo.yaml preflight：`run_trusted` fail-closed → snapshot grade 來源可信）。**不 block 6/18**（post-baseline，明確標 v0.2）
+
+**What to build**
+把 baseline scoreboard 的 `grade` / `claim_level` / `dependency_role` 接進 PawAI Brain 的 runtime gate —— 在 `compute_effective_status()` 既有 first-match 鏈插一個 grade 分支（SayCan affordance-gating），再於 IE executor 補第二道 gate（`brain_node.py:505` 吃 grade），並把 allowlist 收斂成 single source of truth（`skill_policy_gate.py:18` 與 `brain_node.py:574` 收斂），全部用 pytest 真值表覆蓋。snapshot grade 為唯一 capability-health 來源（demo-day 用 frozen），不重算。
+
+**Acceptance criteria**（對齊 SPEC §7a row 10 / MASTER 設計段 D）
+- [ ] grade 分支插在 SPEC 指定位置：`disabled / studio_only / explain_only / demo_guide / static_enabled / enabled_when / cooldown` 判定**之後**、physical-block（`tts_playing / obstacle / nav_safe`）判定**之前**（SPEC §7a:303；MASTER:184；現有鏈見 `effective_status.py:38-70`）。
+- [ ] 分支邏輯逐條對齊 MASTER 偽碼（MASTER:187-199）：依賴 grade==fail 時 `trigger→disabled` / `safety_guard→blocked(禁 motion/nav)` / `actuation→blocked(禁該動作)` / `content→放行內容降級` / `evidence→放行`；grade∈{degraded,insufficient_data} 時 `safety_guard|actuation→blocked` / `trigger→disabled` / `content|evidence→放行(only say/表情/顯示，不 motion)`。
+- [ ] **不覆蓋 skill-level hard disable**：`disabled / studio_only / explain_only` 是 skill 層硬約束，capability grade 不得翻案（SPEC:303「不可覆蓋 skill-level hard disable」、MASTER:198-199）。需有 test 證明「skill baseline=disabled + capability grade=pass → 仍 disabled」。
+- [ ] `brain_allowed = (grade==pass AND claim_level==mainline)`：`claim_level∈{future,studio_only,not_claimed}` 即使 grade==pass 也不進 mainline（MASTER:199、grader `brain_allowed` 簽名 IMPL:438-440）。
+- [ ] reason 帶 baseline provenance（`{cap} FAIL/未達 pass，...` 形式，MASTER:189-197）；blocked / disabled 必帶 reason（SPEC §8:345 對 reason 的要求一致）。
+- [ ] IE 第二道 gate：`brain_node.py:505` executor 在 dispatch 前查 effective_status / grade（SPEC §8:350 點名 P1-1「`brain_node.py:505-533` executor 不查 grade/effective_status」尚未修，此 issue 修它）。
+- [ ] allowlist single source of truth：`skill_policy_gate.py:18` 與 `brain_node.py:574` 兩處 allowlist 收斂為一份（避免兩層各標各的 drift，對齊 MASTER 設計段 D「四欄不雙真相源」:171-180）。
+- [ ] `brain.skill_gate` 真值表 pass 條件全部成立（SPEC §7a:301）：(a) `unsafe_allowed_count=0`；(b) grade≠pass 的依賴 skill 全被擋；(c) future/not_claimed 永不進 mainline；(d) insufficient_data 對 motion/nav 必 fail-closed。窮舉 (claim_level × grade × dependency_role/risk_role) 組合（SPEC §7a:299）。
+- [ ] fail-closed 預設：缺 grade / snapshot 不可信（`run_trusted=False`）→ 全當 insufficient_data → 擋（SPEC §7a:302）。
+
+**Files / modules likely touched**
+- `pawai_brain/pawai_brain/capability/effective_status.py:26`（`compute_effective_status` 加 grade 分支；現 first-match 鏈:38-70，無 grade 分支 — SPEC §7a:284 確認）
+- `pawai_brain/pawai_brain/capability/effective_status.py`（`WorldFlags` 或新 `CapabilityHealth` 入參加 `capability_grade / brain_allowed / failure_reason` — MASTER 設計段 D:167-169）
+- `pawai_brain/pawai_brain/brain_node.py:505`（executor 第二道 gate，吃 grade；P1-1 SPEC §8:350）
+- `pawai_brain/pawai_brain/brain_node.py:574`（allowlist 收斂端）
+- `interaction_executive/interaction_executive/skill_policy_gate.py:18`（allowlist single source；`normalize_proposal_v2` 分流見 :88 — SPEC §7b code 接地:325）
+- NEW：`pawai_brain/test/test_capability_health_gate.py`（grade 分支真值表，預定路徑）
+- 讀（不改）：`benchmarks/core/grader.py`（`brain_allowed`）、`benchmarks/core/scoreboard_schema.py`（`CAPABILITY_META` dependency_role）、`artifacts/baseline/baseline_snapshot.json`（frozen grade 來源，SPEC §9:415）
+
+**Test / verification**
+- `python -m pytest pawai_brain/test/test_capability_health_gate.py -q`：grade 分支真值表（SayCan affordance-gating，非上機採樣 — SPEC §7a:298「pytest 真值表，非上機採樣」）。
+- 回歸：現有 340 offline tests（Skill Policy Gate 層，SPEC §7a:283）插分支後須仍全綠（grade 分支不得破壞既有 8 態 first-match）。
+- 真值表須覆蓋角落 case：`grade=insufficient_data + risk_role=safety_critical` → fail-closed（SPEC §7a:298 指出採樣永遠測不到此角落）。
+- allowlist 收斂後：兩處引用同一份的 grep / import 檢查。
+
+**Output artifact**
+改寫的 `effective_status.py`（含 grade 分支）+ `brain_node.py`（IE 第二道 gate）+ 收斂後 single-source allowlist + `test_capability_health_gate.py`（真值表全綠）。`brain.skill_gate` 真值表覆蓋報告（covered ÷ should-cover，SPEC §7a:300）。
+
+**Out of scope**
+- **6/18 不要求接完**：`brain.skill_gate` 維持 `insufficient_data` 是 acceptable 的 6/18 狀態（SPEC §7a:288「grade 沒接進 gate 之前一律 insufficient_data」、:294「grade 未接進 gate 前 = insufficient_data，不可寫 pass」）。本 issue 是 v0.2 deliverable，**不擋 6/18**。
+- **不重寫 trace 展示**：`brain.trace` 的 6/18「trace 看得到 / 非 mock / 有 reason」由 #12 Studio evidence 負責；本 issue 只做 grade-consuming gate，不碰 trace drawer / Studio 顯示（SPEC §7b:322 §7b/§8 邊界）。
+- 不改 `demo_status_baseline`（skill 層）/ `claim_level`（capability 層）的標註；本 issue 只**合成**四欄判定，不新增真相源（MASTER 設計段 D:171-180「不可雙真相源」）。
+- 不造平行 gate：擴既有 `compute_effective_status`，不另寫平行 capability_health gate（MASTER:169「不另造平行 gate」）。
+- 不接 fast_router 繞 gate：fast path 不得繞過 capability_health gate / nav safety（SPEC §7:329 硬邊界）。
+- snapshot demo-day 用 frozen、不即時重算（MASTER:202、RUNBOOK:36）。
+
+---
+
+# Dev Workflow Meta Issues（獨立 tracking，**非 baseline 完成條件**）
+
+> **兩層 tracking（Roy 鎖定）**：`Capability Baseline & Scoreboard` tracking 只掛 #1-#14；這 3 個 meta issue 屬另一條 tracking `Development Workflow Hardening`（或同 milestone），**不放進「完成 baseline」的 checklist** ── 它們是讓未來 `/goal → branch → PR → CI → review → merge` 跑得穩的流程護欄，不是 demo 功能。
+> **關鍵紀律**：meta issue **不得 block #1-#3 core**（baseline core 可先跑）。
+
+## Tracking Issue（第二條）：Development Workflow Hardening
+
+**目標（一句）**：補齊 PR template / CI fast-gate / HITL 驗證協定三道流程護欄，讓 17 個 issue 的 agent 開發品質一致、evidence 可稽核。掛 Meta-A / Meta-B / Meta-C。**與 baseline 完成度脫鉤**。
+
+| # | Title | Type | 6/18? | Blocked by |
+|---|---|---|:---:|---|
+| Meta-A | Add PR template + issue execution checklist | AFK | 先做（最高優先，低成本） | none |
+| Meta-B | Expand Fast Gate CI（Phase 1 純 Python → Phase 2 ROS Tier-2） | AFK | Phase 1 先做（與 #1-#3 平行，**不 block 它們**） | none |
+| Meta-C | Jetson/Go2 HITL verification protocol + artifact versioning | AFK（doc/schema）+ HITL（上機） | #7-#11 baseline run **之前**完成 | 與 #4 demo.yaml 部分重疊（見下） |
+
+**建立 / 執行順序（Roy 鎖定）**：
+```text
+1. Meta-A 先做（PR template）
+2. #1 #2 #3 baseline core 開始（meta 不擋）
+3. Meta-B Phase 1 與 #1-#3 平行
+4. #5 #6 #7-#11 跟上
+5. Meta-C 在 #7-#11 之前完成
+6. #12 #13 收 evidence / freeze
+7. #14 留 v0.2
+```
+
+---
+
+## Issue Meta-A：Add PR template + issue execution checklist
+
+- **Title**：Add `.github/pull_request_template.md`（linked issue / test / hardware / evidence / out-of-scope 五欄）
+- **Type**：AFK（純文件，無 code）
+- **Blocked by**：none。**最高優先**（其餘 PR 要靠它才一致）
+- **What to build**：兩部分 ──
+  - **(a) PR template** `.github/pull_request_template.md`，強迫每個 PR 填：(1) linked issue #；(2) test command + 輸出；(3) hardware needed = `none / Jetson / Go2`；(4) evidence（screenshot / log / snapshot / readiness output 連結）；(5) out of scope（本 PR 不碰什麼）。
+  - **(b) issue execution checklist /「`/goal` 執行規格」模板**（讓 agent 穩定開工，存進 workflow doc `docs/agents/issue-development-workflow.md` 供 `/goal` 套用）：每個 `/goal` 須含 `Branch: codex/issue-X-short-name` / `Scope: 只做 #X，不碰 #Y/#Z` / `Hardware: none / Jetson / Go2 motion` / `Required tests:` / `Required artifact:` / `Required evidence:` / `Out of scope:` ── 直接吃 issue 的 Out-of-scope 欄當「不准改」清單。
+- **Acceptance criteria**：PR template 在 GitHub PR 編輯器正確 render；5 欄齊；hardware 欄是 `none/Jetson/Go2` 三選；reviewer 能一眼看出要不要 HITL 驗證。
+- **Files / modules likely touched**：Create `.github/pull_request_template.md`（現只有 `.github/ISSUE_TEMPLATE/your-question.md`，無 PR template ── 已驗）。
+- **Test / verification**：開一個 test/draft PR，確認 5 欄出現在編輯器。
+- **Output artifact**：`.github/pull_request_template.md`。
+- **Out of scope**：CI 自動 reject 空欄（未來 Meta-B 的 gate enhancement）；**非 baseline 完成條件**。
+
+## Issue Meta-B：Expand Fast Gate CI（Phase 1 純 Python → Phase 2 ROS Tier-2）
+
+- **Title**：擴充既有 `ros_build.yaml` Fast Gate ── 加新 package 純 Python tests + flake8 只擋新 code
+- **Type**：AFK（CI 設定）
+- **Blocked by**：none。**Phase 1 與 #1-#3 平行，不得 block #1-#3**
+- **What to build**：
+  - **Phase 1（6/18 先做）**：把 `benchmarks/core`（含 **scoreboard schema / grader / aggregator** test）、`tools/pawai_cli`(5 test，含 **readiness CLI** test)、`pawai_brain`(18 test)、`pawai_nav_metrics`(1 test) 的**純 Python test** 加進**既有** Fast Gate pytest 清單（`ros_build.yaml:31-55`，**不是從零搭 CI** ── Fast Gate job 已存在 :14）；flake8 **只對新 code blocking**（`git diff` filter，新增檔才 `--exit-1`；至少針對 `benchmarks/core/*` / `tools/pawai_cli/*` / `pawai_brain/*`），legacy 維持 `--exit-zero`（:30）；`studio-ci.yml` backend 加 `pytest test_mock_text_input.py`。
+  - **Phase 2（sprint B，後做）**：Tier-2 colcon（:110）加 `interaction_executive`(9 ROS test) / `pawai_brain` / `nav_capability`(1 integration)。
+- **Acceptance criteria**：Phase 1 ── 新增 ~32 純 Python test 在 Fast Gate <1-2 min 全綠；flake8 只擋新 code lint、不動 legacy；CI green。**不一次把所有 ROS package 丟進去（會因 heavy deps 爆）**。
+- **Files / modules likely touched**：Modify `.github/workflows/ros_build.yaml`（Fast Gate pytest list ~:31-55、flake8 ~:27-30、Tier-2 ~:110）、`.github/workflows/studio-ci.yml`（backend pytest）。
+- **Test / verification**：push 含新 test 的 branch → Fast Gate ~1 min 跑得到並 green；故意加一個 lint-fail 的新檔 → flake8 擋；改 legacy 檔 lint → 不擋。
+- **Output artifact**：CI workflow logs（Fast Gate test 數從 15 → ~47 全綠）+ coverage report。
+- **Out of scope**：Phase 2 ROS Tier-2 / heavy deps（go2_robot_sdk needs nav2/PCL）；benchmarks model-load test（需 model cache）；T3/T4 硬體 CI；**非 baseline 完成條件**。
+
+## Issue Meta-C：Jetson/Go2 HITL verification protocol + artifact versioning
+
+- **Title**：定義 HITL 驗證協定 + artifact 版本化（`artifacts/baseline/` schema + motion sign-off）
+- **Type**：AFK（doc / schema）+ HITL（上機驗）
+- **Blocked by**：與 **#4 demo.yaml 部分重疊**（#4 填 demo.yaml 的 preflight checks + run_trusted；本 issue **不重填 demo.yaml**，只定**協定 + artifact schema + sign-off**，引用 #4）。應在 **#7-#11 baseline run 之前**完成（baseline 要照這個 artifact 規範產出）。
+- **What to build**：(1) HITL 驗證協定文件（`docs/agents/hitl-verification-protocol.md`）：何時需 Jetson smoke / 何時需 Go2 motion，含**逐能力硬體對照**（voice→Jetson+mic、face→D435、gesture/object→camera、nav→Go2+安全場地）；(2) artifact schema：`artifacts/baseline/{preflight_result.json, baseline_result.jsonl, baseline_snapshot.json, logs/, screenshots/}`（對齊 SPEC §9 路徑表）；(3) **Go2 motion sign-off 機制**：`artifacts/baseline/motion_sign_offs.jsonl`（append-only，每筆含 **operator / timestamp / trial_id / commit_sha / safety_checks_passed / video_sha**）── 回答你說的「誰簽、何時簽、在哪個 commit 簽」；(4) snapshot 帶 `git_sha + deploy_version`（接 #1 `current_run_meta` / #13 freeze）。
+- **Acceptance criteria**：協定 doc 存在且涵蓋 Jetson/Go2 觸發條件；artifact schema 定義清楚；`motion_sign_offs.jsonl` 為 append-only 且必含 commit_sha；與 #4 demo.yaml + #13 freeze 對齊不重複。
+- **Files / modules likely touched**：Create `docs/agents/hitl-verification-protocol.md`、`.claude/schemas/{preflight_result,baseline_snapshot,motion_sign_off}.schema.json`（NEW）；引用（不重寫）#4 `demo.yaml`、#13 freeze、SPEC §9 路徑表。
+- **Test / verification**：dry-run 產一份 sample `preflight_result.json` + `baseline_snapshot.json`；手動 append 一筆 `motion_sign_off` → 驗 schema + commit_sha 欄位在。
+- **Output artifact**：HITL 協定 doc + 3 個 schema + sample `motion_sign_offs.jsonl`。
+- **Out of scope**：T3/T4 自動 CI gate（6/18 用手動 checklist，不做 Actions blocker）；artifact dashboard / web UI（post-demo）；demo.yaml 的 check 內容（屬 #4）；**非 baseline 完成條件**。

--- a/docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md
+++ b/docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md
@@ -1,0 +1,429 @@
+# Capability Baseline Spec（6/18 逐功能規格）
+
+> **性質**：15 個 capability 的逐功能 baseline 規格（9+1 問）。這份是「**每個能力怎麼量、怎樣算 pass**」的**唯一真相源**。
+> **不放**：架構決策（見 Master Plan）、code skeleton（見 Implementation Plan）、上機步驟（見 Runbook）。
+> **關係**：
+> - 總控 / 架構決策 / 三軸定義 / 15 能力 index → `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md`（Master Plan）
+> - TDD 實作 → `docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md`
+> - 上機跑 baseline → `docs/runbook/2026-06-18-baseline-runbook.md`
+> **狀態**：逐功能 grill **全收**（2026-06-01）。15 能力全拍定：face ✅、voice(command+stop) ✅、pose(basic+fall) ✅、gesture.wave ✅、object.cup ✅、nav×4 ✅、brain(skill_gate+trace) ✅、studio.evidence ✅、cli.readiness ✅。下一步：四份 baseline docs 整體 review → 另開 fast/slow plan。
+
+---
+
+## 9+1 問框架（每個 capability 一律回答這 10 項）
+
+1. **6/18 是否主張**
+2. **`claim_level`**：mainline / studio_only / future / not_claimed
+3. **`risk_role`**：safety_critical / safety_support / actuation / convenience / evidence_only
+4. **`dependency_role`**：trigger / content / safety_guard / actuation / evidence（fail 時依賴它的 skill 怎麼降級）
+5. **observer 狀態**：現成 / 要新 / 卡住（誰產可評分記錄，附 file:line）
+6. **baseline scenario**：怎麼跑（距離 / 輪數 / idle 段）
+7. **metrics**：量哪些指標
+8. **pass / degraded / fail 門檻**（provisional，數字 calibrate-from-run-1；硬性 fail 結構先鎖）
+9. **fail / degraded fallback**：Brain 怎麼降級
+10. **換模型條件**：什麼 baseline 數據才允許評估換模型
+
+> 門檻一律 **provisional until baseline**；硬性 fail 結構（如 nav collision=0、face wrong-person、voice.stop FN=0）先鎖、數字上機校準。
+
+---
+
+## 1. `face.recognition` ✅（2026-06-01 拍定）
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——只主張「註冊者辨識 + 問候」 |
+| 2 | claim_level | mainline |
+| 3 | risk_role | evidence_only |
+| 4 | dependency_role | **content**（fail→不叫名字，仍可互動）|
+| 5 | observer | ❌ 要新 `face_baseline_observer`（吃 `/state/perception/face` 連續流，Task 4b；**勿用 event-only observer**）|
+| 6 | scenario | 距離 **1m / 2m**（3m optional stress、**drop 0.5m**）；註冊者 1-2 人 + 陌生人 2-3 人；多人同框只驗「會不會把 unknown 叫成註冊者」 |
+| 7 | metrics | `registered_recall` / `unknown_false_accept_rate` / `wrong_person_count` / `time_to_stable_ms`（**棄 TAR@FAR**，小樣本可理解指標）|
+| 8 | pass/deg/fail | **不對稱門檻**：`registered_recall` ≥80% / 60-80% / <60%；`unknown_false_accept_rate` ≤3% / 3-10% / >10%。**硬規則：`wrong_person_count` ≥1 且小樣本 → 不得 pass，只能 degraded/fail**（認錯人 / 把陌生人叫成註冊者皆計 false_accept；20 次錯 1 次=5% 仍危險）|
+| 9 | fallback | **分層**：degraded → 不叫名但可語音互動；fail → 只泛稱「有人來了」絕不叫名；都不觸發 motion |
+| 10 | 換模型 | 只有 `unknown_false_accept_rate` fail（>10%）才考慮換 YuNet/SFace；**且先試 `sim_threshold` 調高（現 0.40）+ face_db 重 enroll** 這些零成本手段；recall fail 單獨不換（多為距離/光線/enroll 品質）|
+
+**主張範圍理由**：North Star §5 禁「守護 / 陌生人警報」；`stranger_alert` skill 已被 5/27 改 silent（`text=""`）；`sim_threshold_upper` 5/8 從 0.30 收緊到 0.40 是為壓 60%+ 陌生人誤報——所以陌生人=泛稱不點名、不警報，baseline 重點是 unknown-false-accept。
+
+**Criterion 映射（接 aggregator F2 分離指標，給實作者）**：face 的 `criteria_by_capability["face.recognition"]` =
+```python
+[
+  Criterion("registered_recall",         pass_min=0.80, degraded_min=0.60, higher_is_better=True),
+  Criterion("unknown_false_accept_rate", pass_min=0.03, degraded_min=0.10, higher_is_better=False),
+  Criterion("wrong_person_count",        pass_min=0,    degraded_min=0,    higher_is_better=False),  # ≥1 → 該 metric 非 pass → 拉低總 grade（硬規則）
+]
+```
+aggregate 按 (capability_id, scenario_kind) 分組產出這些 key：`registered_recall`=positive round pass 率、`unknown_false_accept_rate`=idle round false_trigger 率、`wrong_person_count`=positive round 卻 false_trigger（認錯人）次數。**round_meta 須標 `scenario_kind`**（positive=known 出場 / idle=只陌生人或無人）。`time_to_stable_ms` 為觀測欄、非 gating criterion。
+
+**Studio evidence**：name（或 unknown）/ similarity / face box / D435 distance / 該能力 scoreboard grade chip（全是 `/state/perception/face` 現成欄位）。
+
+**code 接地**：`/state/perception/face` 每 tick 發全部 tracks（`face_identity_node.py:634-641`，含 track_id/stable_name/sim/distance_m/bbox/mode/face_count）；`/event/face_identity` 只在 stable transition 發（:561）、**從不發 unknown** → 故 observer 必走 state 流。閾值現況 `sim_threshold_upper:0.40 / lower:0.22 / stable_hits:2 / max_faces:5`（`face_perception/config/face_perception.yaml`）。
+
+---
+
+## 2. 語音功能 ✅（2026-06-01 拍定，voice recon workflow file:line 接地）
+
+> 拆兩 row：`voice.command`（固定指令）、`voice.stop`（說「停」）。observer = 現成 `speech_test_observer`（PASS/MARGINAL/FAIL，CSV 含 asr/intent/e2e latency + confidence）。
+
+### 2a. `voice.command`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——固定指令輸入 |
+| 2 | claim_level | mainline |
+| 3 | risk_role | convenience |
+| 4 | dependency_role | **trigger**（fail→不觸發該 skill）|
+| 5 | observer | ✅ `speech_test_observer` 現成（→ A2 轉 record）|
+| 6 | scenario | 6-8 個 demo 固定指令各 ≥3 輪（從 `speech_30round.yaml` 取 demo 主線用到的 intent）|
+| 7 | metrics | accuracy / e2e_latency / play_ok_rate（ASR/intent/TTS 為 **sub-metric**，任一 fail 則 row fail）+ **TTS TTFA 另計** |
+| 8 | pass/deg/fail | accuracy **≥80% / 70-80% / <70%**；e2e_median ≤3.5s；play_ok ≥80%；**TTFA p90 ≤2s/2-4s/>4s**（latency 起算見「設計結論」）|
+| 9 | fallback | **分層**：ASR/intent fail → 請重說 / RuleBrain 接手；TTS quality lane 慢 → edge_tts fast lane；TTS 全斷 → Studio 顯示文字不出聲。degraded 不觸發 motion 類 skill |
+| 10 | 換模型 | （ASR）SenseVoice local fallback 已備；（TTS）TTFA fail(>4s) **且** edge_tts fallback 也 fail 才談 ElevenLabs，且需評估雲端依賴風險（斷網則廢，與 Edge AI framing 矛盾）|
+
+**code 接地**：`speech_test_observer.py` 已有 PASS_CRITERIA（fixed_accuracy≥80%/e2e_median≤3500ms/e2e_max≤6000ms/play_ok≥80%）+ CSV 欄位（asr_latency_ms/intent_latency_ms/e2e_latency_ms/intent_confidence/match/status）；intent 分類 `intent_classifier.py:36-200`（7 SUPPORTED_INTENTS + confidence 權重）。
+
+### 2b. `voice.stop`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——說「停」會停（互動體驗，**非安全機制宣稱**）|
+| 2 | claim_level | mainline |
+| 3 | risk_role | convenience（operator_abort）|
+| 4 | dependency_role | **trigger** |
+| 5 | observer | 🟡 命中率現成；從 30 輪拆「停」專項 |
+| 6 | scenario | 「停」專項 N 輪（含噪音）|
+| 7 | metrics | FN（漏聽）|
+| 8 | pass/deg/fail | **FN 硬性=0**（任一漏聽=fail，不平均）|
+| 9 | fallback | **不影響安全評級**——motion 安全一律由 `reactive_stop` + 物理 e-stop 保證 |
+| 10 | 換模型 | n/a |
+
+**定性鎖定**：stop 是「額外便利」，真安全靠 reactive_stop + 物理 e-stop（對齊 North Star「安全靠物理不靠語音」）。**不在任何 skill 的安全依賴鏈**。
+**code**：`safety_gate.py:11` `SAFETY_KEYWORDS=("停","stop","暫停","煞車","緊急")` → bypass LLM → `stop_move`（:23）= 現成的 System 1 fast path 雛形。
+
+### 設計結論：manual mic boundary + latency 起算（v0.1 baseline 範圍）
+
+> voice recon workflow 證實，6/18 語音主線改用 **manual mic boundary**（VAD 已被 ADR-0003 凍結、不作斷句依據），baseline latency 從 `manual_mic_stop` 起算才反映真實 demo 操作。
+
+**v0.1 baseline scope（要做）**：
+- voice.command/stop 量測（走 demo entrypoint）
+- **mic_stop signal（demo-blocking 前置）**：Studio `use-audio-recorder.ts` stopRecording 發 WebSocket `mic_stop` event → stt_intent_node 訂閱 → 立即 finalize + 解 echo gate。topic = `/event/mic_boundary`。**沒有它，manual mic boundary 量不到，latency 還是 VAD 舊世界。**（~10-15 行）
+- **latency clock 改 mic_stop-based（雙記錄）**：observer 同時記 `mic_stop_ts` 與舊 `speech_start_ts`；新 `e2e_latency_ms` 用 mic_stop、舊欄位改名 `e2e_latency_ms_old` 保留對照。**報告明標「metric v2（mic_stop 起算）」避免被誤讀成「快了 2 秒」（量法變，非系統變快）**。
+- VAD `energy_vad.enabled` 6/18 demo 設 False（main 拔掉），safe default 留 True（fallback）；echo gate 在 manual mic_stop 時立即解（避免時序衝突丟錄音）。
+
+**not v0.1（另線：Voice Latency Improvement / System1-System2 Fast Path）**：
+- fast_router 節點（`graph.py` 在 safety_gate 後插分流：intent∈SUPPORTED 且 conf≥0.8 **且非 motion** → System1 canned shortcut skip LLM；否則 System2 走完整 LLM）
+- Piper fast TTS cache、canned first-feedback、LLM/VLM slow path orchestration
+- **go/no-go 條件 = baseline fail**：若 voice.command baseline 顯示 `mic_stop_to_first_feedback >1s` 或 `mic_stop_to_e2e >3.5s` 或 `TTS TTFA p90 >2s` 才啟動。對齊「沒有 baseline fail，不談架構重構」。
+- diffusion action model = 明確 future（無 dataset、Go2 靠 skill API、對 latency 無直接幫助）。
+
+**System1 fast-path 安全細節**：motion intent（如 `come_here`）即使 conf≥0.8 也**不能純 canned 直接動**，仍須過 nav gate（避免「靠近/靠精」ASR 誤聽觸發 Go2 前進）；只有 greet/status/canned-reply 等無 motion 才能純 System1。
+
+**completeness critic 抓到的洞**（記入另線 spec，非 v0.1）：Sev2 confidence 計算無 absolute threshold（誤觸風險）、Sev5 canned 帶 audio tag 但 piper 不支援（情感不一致，去 tag）、Sev6 no-speech/空 ASR 無 fallback（按 mic 沒講話→播「沒聽清楚」尷尬，加 `intent=no_speech`）。
+
+**現實接地**：60-70% 已就位（intent classifier / safety_gate 短路 / canned template 30+ 句 / TTS cache 框架 / echo gate）；30-40% 要補（mic_stop 訊號流 / fast_router / latency 改點）。
+
+---
+
+## 3. 姿勢辨識 ✅（2026-06-01 拍定）
+
+> 單幀 2D 幾何分類（`pose_classifier.classify_pose`：trunk_angle/hip_angle/vertical_ratio，COCO 17 keypoints）。standing/sitting/crouching/bending 穩；akimbo/knee_kneel 不穩（不主張）。fallen 幻覺確認存在（無人時鎖衣架判 fallen，README:71；投票 buffer 20 幀只降未消）。
+
+### 3a. `pose.basic`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **否**（不進 Brain 主線）——只 Studio 顯示「看得出在做什麼」|
+| 2 | claim_level | **studio_only** |
+| 3 | risk_role | evidence_only |
+| 4 | dependency_role | content |
+| 5 | observer | ❌ 新 `perception_baseline_observer`（event）薄測 |
+| 6 | scenario | standing/sitting（+crouching/bending）各 ≥3 次 recall，**只 observe 不觸發 motion** |
+| 7 | metrics | recall（各姿勢命中率）|
+| 8 | pass/deg/fail | 寬門檻（studio_only）：recall ≥70% 可顯 / <70% 連 studio 也不信。akimbo/knee_kneel 不穩→不主張 |
+| 9 | fallback | studio-only 顯示；任何情況不進 Brain 決策、不觸發 motion |
+| 10 | 換模型 | **6/18 前不換**；recall fail **只降級為 unknown / 不顯示姿勢**（不觸發換模型工作）。future 若要把 pose 升級成照護/主線能力，才評估 RTMPose/PINTO。（避免 P2 功能因 baseline fail 偷偷變成 P0 換模型工作）|
+
+### 3b. `pose.fall`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **否**（North Star §5 禁說跌倒可靠）|
+| 2 | claim_level | **future** |
+| 3 | risk_role | evidence_only |
+| 4 | dependency_role | evidence |
+| 5 | observer | ❌ 本輪不測 |
+| 6 | scenario | **不測**（幻覺未解）|
+| 7 | metrics | — |
+| 8 | pass/deg/fail | 標 **insufficient_data**（不評）|
+| 9 | fallback | Studio 可顯紅 alert 供 debug，但 **fallen TTS 永靜音**（現狀 `FALL_ALERT_TTS=""`，event_action_bridge 5/8 移除模板）、不停車、不進 Brain |
+| 10 | 換模型 | n/a（幻覺是判定邏輯問題非模型，先不主張）|
+
+**code 接地**：fallen 判定 `interaction_rules.py:83 should_fall_alert`（要 persist 夠久）；fallen TTS muted（`event_action_bridge.py:75-80` 移除模板 + Brain `fallen_alert` `FALL_ALERT_TTS=""`）；vertical_ratio gate（`pose_classifier.py:81` ankle_y/image_height>0.7）已濾部分 false fallen 但未根治衣架幽靈。
+
+## 4. 手勢辨識 `gesture.wave` ✅（2026-06-01 拍定）
+
+> wave 走 `WaveDetector`（dynamic_gesture_detector，per-hand，window 1.5s/reversals 2/amplitude 50px/cooldown 2.5s）。static（ok/thumbs/palm）走 `gesture_classifier`+`detect_ok_circle`，code 還在跑但 **6/18 不主張**。
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——只主張 wave（揮手打招呼）。static ok/thumbs/palm **全不主張**（不進 Brain 主線）|
+| 2 | claim_level | mainline |
+| 3 | risk_role | convenience（emote）|
+| 4 | dependency_role | **trigger**（fail→完全不觸發 wave_hello）|
+| 5 | observer | ❌ 新 `perception_baseline_observer`（event）。**必走 demo recognizer backend + 人工 ground-truth**——wave confidence `hardcode 1.0`（vision_perception_node.py:414）無鑑別力，recall/誤觸完全靠人工標註；**不可用壓測 mediapipe backend 的 idle 結果當最終 baseline**（backend≠demo）|
+| 6 | scenario | person-present idle（人在框內手自然放鬆）60s×10=**10min** + natural hand motion + real wave **1m/2m 各≥10 次**。每 round 標 `scenario_kind`（idle / positive）|
+| 7 | metrics | wave recall / **idle false_trigger_rate**（scenario_kind=idle）/ repeated_trigger_count / latency |
+| 8 | pass/deg/fail | recall ≥90%/80-90%/<80%；**idle 誤觸是硬 gate（權重 > recall）：≤1/10min=pass / 1-3=degraded / >3=fail（不管 recall）**。注意 person-present idle ≠ idle-EMPTY，真值要「人在框內不刻意比手勢」|
+| 9 | fallback | pass→觸發 `wave_hello`（emote api 1016）；degraded→Studio 顯示不觸發；fail→完全不用 gesture trigger |
+| 10 | 換模型 | **修法順序**：(1) 先調 WaveDetector 超參（reversals/amplitude/cooldown/window，零成本）；(2) **不**先修 static recognizer score floor（static 非主張）；(3) 超參調不下 **且** recall 真 fail 才看 PINTO 481_WHC 揮手模型（go/no-go 2026-06-06）。idle 誤觸 fail 優先調 cooldown/reversals |
+
+**code 接地**：`WaveDetector`（vision_perception_node.py:153-155，per-hand + 2.5s publish cooldown）；wave confidence hardcode 1.0（:414，繞過 vote buffer）；static 路徑 `gesture_classifier.py` + `detect_ok_circle`（:377-386）；recon 證 MediaPipe Recognizer 無 `score_threshold`（預設 -1=停用）→ static 無 confidence floor。
+
+## 5. 物體辨識 `object.cup` ✅（2026-06-01 拍定）
+
+> YOLO26n ONNX + TensorRT FP16。`whitelist=[41,999]`=cup-only（41=COCO cup，999=dummy 強制 INTEGER_ARRAY 避 BYTE_ARRAY 坑）。**cup-only 是刻意對齊 6/18 主張、非壞掉**（commit b81cfdd 5/27 demo video mode）。
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——只主張 object.cup。bottle/wallet/key/denture/`object.general`/VLM 場景描述 **全 future** |
+| 2 | claim_level | mainline |
+| 3 | risk_role | evidence_only |
+| 4 | dependency_role | content |
+| 5 | observer | ❌ 新 `perception_baseline_observer`（event）。**baseline 必須真起 `object_perception`**（現無 consumer 訂 `/event/object_detected`）|
+| 6 | scenario | positive：cup 放桌上 1m/2m 各 ≥5 次（含背景干擾）；idle：空場景/無 cup 連續 60s 量 false-positive。每 round 標 `scenario_kind`。**不測地上/人手拿**（複雜度高、非 demo 主線）|
+| 7 | metrics | `cup_recall` / `idle_false_positive`（事件數）/ `wrong_class_count` / latency。**計算規則（對齊 aggregator scenario_kind 分組）**：<br>• **positive cup round**：cup detected=pass；no detection=miss；**wrong class（cup 在場卻認成 bottle 等）=wrong_class／miss → 傷 `cup_recall`，不算 false-positive**<br>• **idle no-cup round**：任何 cup 事件=false_positive |
+| 8 | pass/deg/fail | **不對稱門檻**：cup recall ≥80%/60-80%/<60%（content，漏認只是不提、不傷）。**idle false-positive**：1 個 idle round = **1 個 60s 窗**（生一筆 record，`false_trigger`=該窗內有無誤報 cup）；單窗 0 次=pass / 1 次=degraded / >1 次=fail。**aggregator 對齊**：`unknown_false_accept_rate` = 誤觸窗數/總窗數（單窗 0→rate 0；跨 N 窗 k/N），`object.cup` Criterion 用此率、門檻對應上述事件數語意（憑空說「有杯子」很傷 demo）|
+| 9 | fallback | **分層**：pass→口頭 remark「桌上有杯子」；degraded→Studio 顯示 bbox/label 不口頭；fail→不進 demo 主線 |
+| 10 | 顏色 / 換模型 | **顏色不進 claim**（無 color detection code，`coco_classes.py:152 class_color` 只是 debug 上色）。**修法順序**：(1) cup-only whitelist 現狀正確、不動；(2) baseline fail 先調 conf threshold/lighting/ROI/TRT（零換模型）；(3) recall fail 且調不下才測 YOLO26s（mAP+7.7pp，但 Nano FPS **HIGH risk**）；(4) PINTO/VLM 更後。wallet/key/denture 全 future 不拖累 6/18 |
+
+**code 接地**：`object_perception.yaml:20 class_whitelist=[41,999]`；event schema `class_name`/`confidence`/`bbox`/`event_type=object_detected`（object_perception_node.py:365,416）；無 color detection（只有 `class_color` debug 上色 + `red→紅色` label 翻譯表）。
+
+## 6. 導航避障 ✅（2026-06-01 拍定，nav recon + D435 fusion recon file:line 接地）
+
+> 4 能力拆開。**核心紀律**：safe_stop/no_auto_resume 是 safety_critical，short_move 是 actuation——全是 mainline **target**，但 baseline pass 前一律 insufficient_data，**不可寫成 pass**。RPLIDAR(Sensitivity mode，**已設非待改**) 主力 2D nav，D435 depth witness 補強，Go2 內建 LiDAR/range_obstacle/onboard 全 spike/future。
+
+### 6a. `nav.safe_stop`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | P0 target（why-dog 安全核心）|
+| 2 | claim_level | mainline |
+| 3 | risk_role | **safety_critical** |
+| 4 | dependency_role | **safety_guard** |
+| 5 | observer | ❌ recorder `_cb_reactive_status` no-op（BD-7 未接）→ **insufficient_data** |
+| 6 | scenario | 真障礙停車 N 輪 |
+| 7 | metrics | `collision_count` / `stop_margin_m` / `stop_latency_ms`（先記錄）/ `false_stop_rate`（先記錄，避免亂停）|
+| 8 | pass/deg/fail | **結構現在鎖、數字 calibrate-from-run-1**：`collision_count` 任一次=fail（硬門檻）；`stop_margin_m` pass 需 ≥0.10m；stop_latency/false_stop_rate 先記錄不硬設 |
+| 9 | fallback | **FAIL→禁所有 motion/nav**（safety_guard）|
+| 10 | 補強 | D435 當 depth witness 交叉驗證 LiDAR stop 是否合理；**baseline 前不當主判斷來源** |
+
+**不可寫**：`safe_stop 已完成`。runtime 有 reactive_stop 4-mode，但 recorder 沒接好前一律 insufficient_data。
+
+### 6b. `nav.no_auto_resume`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | P0 target |
+| 2 | claim_level | mainline |
+| 3 | risk_role | **safety_critical** |
+| 4 | dependency_role | **safety_guard** |
+| 5 | observer | ❌ **比量測缺口更嚴重——行為定義衝突** |
+| 6 | scenario | 障礙移開後不暴衝 N 輪 |
+| 7 | metrics | 暴衝次數（任一暴衝=fail 硬性）|
+| 8 | pass/deg/fail | **正確行為定義（先鎖）**：stop 後**不自動 resume 原 goal**，必須 operator/Brain 發新命令才動 |
+| 9 | fallback | **FAIL→禁所有 motion/nav** |
+| 10 | ⚠️ 行為待改 | **現行 `reactive_stop_node.py:307 _maybe_call_nav_pause` 是 auto-resume**（離開 danger→`/nav/resume`），且 hold_brake mode 又故意不 resume（:33-34）→ **行為不統一、與 no_auto_resume 語意相反**。標 insufficient_data + 「**行為待重定義（BD-8）**」。不只量不到，是設計要改 |
+
+### 6c. `nav.short_move`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | P0 target / **why-dog 具身證明**（為何要機器狗不是 APP）|
+| 2 | claim_level | mainline |
+| 3 | risk_role | **actuation** |
+| 4 | dependency_role | **actuation** |
+| 5 | observer | 🟡 手動發 `/nav/goto_relative`→`/event/nav/mission`(outcome_code/actual_distance) 量得到；但 demo 主線量不到（見下）|
+| 6 | scenario | goto_relative 0.3m×N / 0.5m×N |
+| 7 | metrics | goto 成功率 / actual_distance 分佈 |
+| 8 | pass/deg/fail | goto SUCCEEDED rate ≥85%/70-85%/<85%（calibrate-from-run-1）|
+| 9 | fallback | **需 #6a safe_stop + #6b no_auto_resume 先 pass 才能走 motion**；未達前不放行 |
+| 10 | ⚠️ 3 個 blocker | **現 insufficient_data，不可寫 pass**：(a) Brain skill `nav_demo_point→goto_relative` 斷在 `interaction_executive_node.py:278`（只接 goto_named，goto_relative 走 `nav_unimplemented_phase_a`，BD-10+ 才接）；(b) F7 未定位（reactive_stop narrow-field threshold 經 mux pri200 遮蔽 nav pri10）；(c) 0.85 profile 無可信實機 motion 證據。baseline pass 才從 target 變可講 |
+
+### 6d. `nav.dynamic_avoidance`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **否**（future/bonus，明確不講）|
+| 2 | claim_level | **future** |
+| 3 | risk_role | actuation |
+| 4 | dependency_role | actuation |
+| 5-9 | — | 架構 stop-only 不繞障；標 insufficient_data；不主張（非 fail）|
+| 10 | 後話 | ComposableNode + velocity_smoother，Phase 11+ |
+
+### 6e. nav spike / future queue（全不進 6/18 主宣稱）
+
+**quick sanity spike（上機十幾分鐘可測、不主張）**：
+- `range_obstacle[4]`：Go2 內建 4 向粗略障礙距離，零 consumer、韌體語意未記錄。10 分鐘 sanity test 看值域/方向/更新率。
+- onboard avoidance（api 1004）：Go2 機身內建避障，從未測（ADR-0006 禁用）。5 分鐘低風險環境測。
+- **D435 Fusion Shadow Test**：不讓 Go2 動，只錄資料——啟 D435 pointcloud→`/scan_d435_shadow`（`pointcloud_to_laserscan`，**必須 `target_frame:=base_link` 且先驗 TF**——不設 target_frame 會讓 height filter 在 optical frame 語意錯掉，high/low 切片全亂；參考 `docs/navigation/research/2026-05-25-realsense-d435-full-stack-deepdive.md:90`）、height filter **0.05-0.50**（非舊 0.20-0.80）+ 同錄 `/scan_rplidar`，放矮箱/桌面邊緣/椅腳三種障礙，量「RPLIDAR 漏掉而 D435 補到的比例」。**不可沿用舊 detour script**（hack TF / `depthimage_to_laserscan` 無 height filter / danger=0.40 / safety_only 舊坑）。延遲/TF/false-positive 可接受才考慮接 safe_stop 或 Nav2 obstacle layer。**過了才升級，不可先宣稱 fusion 已可靠**。
+
+**future sidecar（6/18 不碰）**：
+- Go2 內建 3D LiDAR：**拿得到**（decode path 活、~7Hz；推翻舊「拿不到/頻率低」說法）**但 Pro 韌體每幀~22 點≈18% 覆蓋太稀疏**，不能當主導航；密集版只在 EDU 版+CycloneDDS。
+- nvblox/Isaac ROS、ORB_SLAM2/RTAB-Map RGB-D SLAM、D435 full costmap fusion：post-baseline，Jetson 8GB 算力評估後再說。
+
+**D435 定位校正（重要，修 doc drift）**：D435 **不是避障死路**。當前水平掛法（離地 0.52m、FOV ±29°）地面最近可見約 0.94m，0-0.94m 是盲區——但這是**掛法 trade-off（可調俯角/改參數改善），非物理死路**。（latency：本地證據只支持 `depth_safety_node` status tick ~5Hz≈200ms，**不代表端到端 stop latency**——從感測到 Go2 停住的 e2e latency 仍需 baseline 實測；4/3 的 1.5s 是當時 e2e 估計）4/3 失敗是倉促偽診斷（掛角/參數/延遲三層混為一談）。正確定位：**RPLIDAR 高度補強 witness + depth safety gate + 人臉/物體相機**。深度+光達融合是業界標配（Nav2 obstacle_layer 多 observation_sources，`nav2_params_detour.yaml:220` 已有 `scan d435_scan` 配法，但 detour script 有危險舊坑不可直接復活）。
+
+> nav 內部 blocker（F7 診斷、0.85 profile 標記、recorder BD-7/8、D435 shadow test）屬 nav workstream，不是 capability spec 的 grill 範圍——見 docs/navigation/。
+
+## 7. PawAI Brain ✅（2026-06-01 拍定，skill_gate + trace 鏈 file:line 接地）
+
+> **核心紀律（避免偷換概念）**：brain 兩個能力跟感知能力**量法不同**——不是上機採樣統計分佈，是**邏輯真值表 / scenario replay**。而且 `brain.skill_gate` 必須拆成兩層看，**現有 gate 能擋 world flags ≠ scoreboard grade 已 fail-closed 接進 gate**：
+>
+> | 層 | 是什麼 | 現況 | 怎麼驗 |
+> |---|---|---|---|
+> | **Skill Policy Gate（現有）** | 吃 `demo_status_baseline` + `static_enabled` + `cooldown` + WorldFlags(`tts_playing`/`obstacle`/`nav_safe`)，回 `effective_status` → `proposed`/`needs_confirm`/`blocked` | ✅ 已實作（`compute_effective_status` + `normalize_proposal_v2`），340 offline tests 覆蓋這層 | pytest 真值表（現成可測）|
+> | **Capability Health Gate（scoreboard-first 真正要的）** | 吃 baseline `grade` / `claim_level` / `brain_allowed`，fail-closed 擋掉 grade≠pass 或 claim_level∈{future,not_claimed} 的 skill | ❌ **`compute_effective_status()` 目前完全沒吃 grade**（effective_status.py:38-70 無 grade 分支）| 待 v0.2 接 + 真值表（**接了才算數**）|
+>
+> **SayCan 類比**：LLM 提候選 skill（"say"）→ gate 用 baseline grade 當 affordance（"can"）決定能不能做。我們的 `brain_allowed = (grade==pass AND claim_level==mainline)` 就是 SayCan 的 affordance-gating，只是 affordance 來源是 baseline scoreboard。
+>
+> **裁決：`brain.skill_gate` 不能因為 340 offline tests 就寫 pass**——那些 test 驗的是 Skill Policy Gate 層，不是 grade-consuming 層。grade 沒接進 gate 之前一律 `insufficient_data`。
+
+### 7a. `brain.skill_gate`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | P0 target（scoreboard-first 能不能落地的核心）。**但 grade 未接進 gate 前 = insufficient_data，不可寫 pass** |
+| 2 | claim_level | mainline |
+| 3 | risk_role | **safety_critical**（gate fail-open＝unsafe skill 漏放行，直接安全風險）|
+| 4 | dependency_role | **safety_guard** |
+| 5 | observer | **pytest 真值表，非上機採樣**。🟡 Skill Policy Gate 層現成可測（340 tests）；❌ Capability Health Gate 真值表＝新 deliverable（依賴 grade 接進 `compute_effective_status`，尚未做）。**理由**：gate 失敗模式是「該擋沒擋」（fail-open），要窮舉真值表證明；採樣永遠測不到「grade=insufficient_data 時有沒有 fail-closed」這種角落（正常 demo 不會自然產生那狀態）|
+| 6 | scenario | 真值表窮舉：每個 (claim_level × grade × risk_role) 組合 → 預期 gate 行為。**重點 case**：grade∈{fail,insufficient_data} 的 skill 必被擋；claim_level∈{future,not_claimed} 永不進 mainline；motion/nav 在 insufficient_data 必 fail-closed |
+| 7 | metrics | `unsafe_allowed_count`（該擋卻放行數）/ fail-closed 真值表覆蓋數 ÷ 應覆蓋數 |
+| 8 | pass/deg/fail | **只有 pass / fail / insufficient_data，無 degraded**（gate 不允許半對）。**pass 條件全部成立**：(a) `unsafe_allowed_count = 0`；(b) grade≠pass 的依賴 skill 全被擋；(c) future/not_claimed 的 capability 永不進 mainline；(d) insufficient_data 對 motion/nav 必 fail-closed。任一條 fail-open＝fail |
+| 9 | fallback | **gate fail → 不允許 demo 主線 motion/nav**，只能 Studio 顯示或 explain-only。fail-closed 是預設（缺 grade／snapshot 不可信 → 全當 insufficient_data → 擋）|
+| 10 | v0.2 必做 | **grade 接進 gate 是 v0.2 必做、非 optional**。**插入點（對齊 Master Plan §D line 184）**：grade 分支接在 `disabled / studio_only / explain_only / demo_guide / static_enabled / enabled_when / cooldown` 判定**之後**、`tts_playing / obstacle / nav_safe` physical-block 判定**之前**——grade∈{fail,insufficient_data} 或 claim_level∈{future,not_claimed} → `disabled`/`blocked`，reason 帶 baseline provenance。**不可覆蓋 skill-level hard disable**：`disabled/studio_only/explain_only` 是 skill 層硬約束，capability grade 不得翻案（否則會出現「能力 pass 但 skill 本該 disabled」被錯放行）。接了 + 真值表全綠才從 insufficient_data 升 pass |
+
+**不可寫**：`skill_gate 已完成` / `340 tests 過＝scoreboard gate 已落地`。現有 tests 只覆蓋 Skill Policy Gate（world flags），不覆蓋 grade-consuming 層。
+
+### 7b. `brain.trace`
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——「決策可解釋」是 demo 給老師看的證據鏈（為何做/為何擋）|
+| 2 | claim_level | mainline |
+| 3 | risk_role | **evidence_only** |
+| 4 | dependency_role | **evidence** |
+| 5 | observer | **固定 scenario replay**，檢查 trace stage 是否完整（非上機採樣、非真值表）。🟡 trace 已在發（`/brain/conversation_trace`），observer = 跑固定對話腳本 → 比對 trace stage 序列完整性 |
+| 6 | scenario | replay 數個固定對話：(a) 正常 skill 放行、(b) skill 被 gate 擋、(c) needs_confirm、(d) rejected_not_allowed、(e) safety「停」短路。每個都檢查 trace |
+| 7 | metrics | trace 完整率（每次 proposal 有無 skill_gate stage）/ blocked-with-reason 率 |
+| 8 | pass/deg/fail | **pass 條件（code path，scenario replay 可驗）**：(a) 每次 skill proposal 都有 `skill_gate` trace；(b) 被擋時 detail 帶 reason；(c) proposed / blocked / needs_confirm / rejected_not_allowed 四態都能從 trace 看出。**(d) Studio 顯示真實 trace（非 mock）= §8 `studio.evidence` 的判定範圍，§7b 不自評該項**（避免把 Brain trace code path 與 Studio evidence 混成一個能力）。degraded＝trace 發得出但有 conditional-emit 破洞（如 chat turn 無 `skill_gate` row）|
+| 9 | fallback | trace 是唯讀證據層，不 gate 任何行為；fail（trace code path 缺漏）→ 只影響「可解釋性」展示，不影響 motion/nav 安全 |
+| 10 | 換模型 | n/a（觀測層）|
+
+> **§7b / §8 邊界（2026-06-01 Roy review 鎖定）**：`brain.trace` 的 **code path 完整性**可由 scenario replay 獨立驗證（trace 有沒有發、四態可不可辨、reason 在不在）；**Studio 顯示的是不是真實 trace（非 mock）留給 §8 `studio.evidence` 定義**。兩者是不同能力，不可混評。
+
+**code 接地**：
+- **skill_gate 鏈**：`CapabilityRegistry.build_entries`（registry.py:54）組 entry → `compute_effective_status`（effective_status.py:26，純函式、**無 grade 分支**）→ `normalize_proposal_v2`（skill_policy_gate.py:88）按 effective_status 分流：`available`→proposed、`needs_confirm`→needs_confirm、其他→`blocked` detail=`{name}:{eff}`；entry=None 但在 allowlist→`blocked: not_in_capability_context`（**已是 fail-closed，drop 不轉 brain_node**，:79-82）。`brain_allowed` 概念目前**只在 doc，code 尚未實作**。
+- **trace 鏈**：每 stage append `state["trace"]`，已實作 stage = `input`/`mode_classifier`/`safety_gate`/`llm_decision`/`json_validate`/`skill_gate`/`repair`/`verifier`；`_publish_traces`（conversation_graph_node.py:944）發 `TracePayload`(session_id/stage/status/detail/engine，schemas.py:43) → `/brain/conversation_trace`；`brain_node._emit_trace`（:887）另一條含 `ts`。Studio gateway 消費見 `pawai-studio/gateway/studio_gateway.py`（real-vs-mock 待 §8 一起驗）。
+
+> **fast/slow 系統是另線（獨立 plan，不塞進本 spec 主體）**：6/18 正確版本＝三層階序 **Safety Kernel（`reactive_stop` / e-stop / `no_auto_resume` / nav safety，永遠最高、brain-independent）> System1（低風險、可驗證、低延遲互動捷徑：fixed intent / canned / cached TTS / non-motion skill）> System2（LLM/VLM 慢思考）**。對齊 SayCan / Nav2 BT，**非** diffusion action model / VLA low-level policy。
+> **硬邊界（防 fast_router 為了快跳過 gate）**：fast path **不得繞過** `skill_policy_gate` / `capability_health gate` / nav safety；只允許 **non-motion / canned / explain-only** 類互動先行。motion/nav 一律仍走完整 gate + Safety Kernel。
+> go/no-go = voice baseline fail。詳見 §2 設計結論 + 新 plan `docs/pawai-brain/plans/2026-06-02-fast-slow-interaction-lane-plan.md`（brain 架構審查產出）。
+
+## 8. `studio.evidence` ✅（2026-06-01 拍定，gateway + frontend recon file:line 接地）
+
+> **核心 framing（recon 翻案）**：Studio **不缺 dashboard，缺「誠實層」**。感知面板/影像/chat/trace 都已存在且相當完整 ── 真正的洞是 **mock 與 live 用同一套 event 格式、前端無 provenance、且預設 `start.sh` 跑的是 mock server**（`start.sh:44-46` port 8080）。老師看畫面時無法分辨真感知 vs 腳本 mock。所以 6/18 的「最小可信」工作 = **在既有 dashboard 上加誠實層**（provenance 標籤 + frozen scoreboard chip + reason），**不是再做面板**。**缺的是可信度,不是覆蓋度。**
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——`existing live dashboard + provenance label + frozen scoreboard chip`。**明確不是**「完整 observability dashboard / runtime health monitor」 |
+| 2 | claim_level | mainline |
+| 3 | risk_role | **evidence_only** |
+| 4 | dependency_role | **evidence** |
+| 5 | observer | gateway live smoke + **frontend source-label smoke**（跑 live 看 `live` / 跑 mock 看 `mock`）+ screenshot / `/api/*` check |
+| 6 | scenario | (a) 起 live gateway → 驗 UI 標 `live`；(b) 起 mock server → 驗 UI 明顯標 `mock`（不得偽裝）；(c) replay 一段對話 → 驗 trace drawer 顯 stage/status/reason；(d) 載入一份 `baseline_snapshot.json` → 驗 chip 顯 capability/grade/reason/timestamp；(e) 斷某來源 → 驗顯 `missing` 非空白 |
+| 7 | metrics | provenance 正確率（mock↔mock / live↔live）/ trace 顯示完整度 / scoreboard chip 欄位齊全 / blocked+insufficient_data 有 reason |
+| 8 | pass/deg/fail | **pass（5 條全成立）**：(1) 前端明確標來源 `live/mock/frozen/missing`；(2) **跑 mock server 時 UI 必須明顯顯 `mock`，不得偽裝 live**；(3) `/brain/conversation_trace` 能顯 stage/status/detail(reason)；(4) frozen scoreboard chip 顯 `capability_id/grade/reason(failure_reason)/last_tested_at`；(5) **blocked/insufficient_data 必帶 reason**（不准只顯 `fail`）。<br>**degraded**：live trace 有但無 scoreboard chip／有 chip 但無 provenance／trace 不完整但非 mock。<br>**fail**：UI 仍 mock 且無標籤／trace 完全顯不出／**scoreboard 偽裝成 live health**／blocked 無 reason |
+| 9 | fallback | Studio 掛 → scoreboard grade 仍可由 **CLI / snapshot 檔**讀（§9），不影響 baseline 判讀；Studio 是 evidence 不是 authority |
+| 10 | 換模型 | n/a（evidence 層）|
+
+**⚠️ 必寫進 spec 的 overclaim 防線（Roy 鎖定）**：
+> **Studio 顯示的是 evidence,不是 authority。** Studio 可展示 Brain trace / frozen scoreboard / live sensor events,**但不能宣稱「IE 第二道 gate 已吃 scoreboard / runtime 全層已 enforce」,因為 P1-1（`brain_node.py:505-533` executor 不查 grade/effective_status）尚未修**。Studio 顯示「gate blocked X」只反映 PawAI Brain（pawai_brain）那層的 gate 決策;IE scoreboard-aware enforcement 是 v0.2 待補。
+
+**scope 例外聲明（修 Master Plan line 229 drift）**：frozen scoreboard chip 是 6/18 **新增的極小唯讀 Studio 任務**（`GET /api/scoreboard` 讀 `baseline_snapshot.json` → 前端一個 chip），**是 Master/Implementation Plan line 229「Studio UI 砍項」的有限例外** ── 例外範圍嚴格限：**唯讀、不 live recompute、不接 runtime Brain gate、只讀 frozen snapshot**。超出此範圍的 Studio health panel / runtime monitor 仍砍。
+
+**code 接地**：
+- **live 已存在**：`studio_gateway.py:73-82` 訂真 ROS topic（face/gesture/pose/speech/object + `/state/pawai_brain` + `/brain/proposal` + `/brain/skill_result` + **`/brain/conversation_trace`(:81)** + shadow）→ PawAIEvent envelope → `/ws/events`；video 走 Image→JPEG→WS binary。前端面板齊（`frontend/components/` face/gesture/pose/object/speech/chat/navigation/live）。**§7b 依賴的「Studio 顯真實 trace」架構上通**（trace 已 forward），差前端 trace drawer 渲染確認。
+- **provenance greenfield**：現有 `source` 欄位（`contracts/types.ts:25,59,95,118,155`）是**感知模態**（face/speech/...）**非資料真偽**；mock(`backend/mock_server.py`) 發的 envelope 與 live **一字不差**；前端 `use-websocket.ts` 連同一 `/ws/events`、分不出後端是 gateway 還是 mock。→ **provenance 標籤是 #1 deliverable**。
+- **scoreboard chip greenfield**：`/api/capability`（`studio_gateway.py:268,538-541`）只回 **Nav/Depth 的 Bool tri-state**（Phase B Trace Drawer），**不是 baseline scoreboard grade** → `/api/scoreboard` 為新 endpoint。
+- **預設即 mock**：`start.sh:44-46` 預設起 mock server（port 8080）；live 要 `start-live.sh --live` 連 Jetson。→ 誠實層沒做之前,預設 demo 畫面就是假資料。
+
+## 9. `cli.readiness` ✅（2026-06-01 拍定，pawai CLI recon file:line 接地）
+
+> **authority 核心句**：`pawai readiness` 是 **demo readiness authority** ── 它以 **frozen baseline snapshot + deploy manifest + preflight metadata** 做 **fail-closed 判定**。Studio 只讀它的結果做 evidence 展示（§8），**Brain v0.1 不即時消費它**（v0.2 才接 runtime gate）。分工：`doctor`=系統現在能不能跑（環境/網路/lock/driver）；`readiness`=demo 用的 baseline snapshot 可不可信。**兩者不混。**
+
+| # | 項目 | 決定 |
+|---|---|---|
+| 1 | 6/18 主張 | **是**——`pawai readiness` 作 demo readiness authority |
+| 2 | claim_level | mainline |
+| 3 | risk_role | **safety_support**（誤判 ready 會讓不可信數據上 demo / 餵 Studio，間接安全相關）|
+| 4 | dependency_role | **evidence** |
+| 5 | observer | **pytest 真值表 + 一次 Jetson smoke**（非採樣）。失敗模式是「該說不可信卻說 ready」(fail-open)，要窮舉真值表 |
+| 6 | scenario | 真值表窮舉 (snapshot 缺檔 / schema 錯 / run_trusted=False / preflight fail / sha mismatch / capability list 不全 / age 過舊 / 全通過) → 預期 verdict；+ 1 次 Jetson smoke（真 snapshot → `pawai readiness` 跑得出 + `--json` 格式正確）|
+| 7 | metrics | fail-closed 真值表覆蓋數 ÷ 應覆蓋數；`fail_open_count`（該 not_ready 卻 ready）|
+| 8 | pass/deg/fail | **只有 pass / fail / insufficient_data，無 degraded**。**注意兩層別混**：(a)『**capability grade**』= readiness **機制本身**正不正確（真值表全綠 + Jetson smoke 過 → pass；任一 fail-open → fail；尚未建 → insufficient_data）；(b)『**runtime verdict**』= 命令對某份 snapshot 的輸出 `ready / not_ready`。scoreboard 評的是 (a) |
+| 9 | fallback | readiness 機制本身壞 → 對自己也 fail-closed（當 not_ready）；Studio/CLI 顯 not_ready。任何不確定 = not_ready |
+| 10 | 換模型 | n/a（CLI 工具層）|
+
+**命令設計**：新 `pawai readiness` / `pawai readiness --json` 子命令（**與 `doctor` 分開、不塞進 doctor 主邏輯**；但 `doctor` 可呼叫它顯摘要）。
+
+**檢查表（最小，全項皆 fail-closed 預設）**：
+```text
+baseline_snapshot.json 存在嗎？
+snapshot schema version 對嗎？
+run_trusted == true 嗎？
+layer0_preflight 是 pass / pass_with_warnings 嗎？
+snapshot git_sha 跟 deployed manifest（.pawai-last-deploy）sha 對得上嗎？
+snapshot age（advisory，不擋 verdict）
+15 個 capability 是否都列出？
+mainline 能力是否都有 grade / reason？
+```
+
+**fail-closed 規則（任何不確定 = not_ready）**：
+```text
+snapshot 缺檔              → not_ready
+schema invalid             → not_ready
+run_trusted == false       → not_ready
+layer0_preflight fail      → not_ready
+snapshot sha != deploy sha → not_ready   ← 跑的不是這份 code，硬擋
+capability list 不全       → not_ready
+mainline 能力缺 grade/reason → not_ready
+全部通過                   → ready
+```
+
+**有效期限（不設武斷時間 TTL）**：**硬 stale 訊號 = sha mismatch**（snapshot.git_sha != 當前 deploy sha → not_ready）。**age 只警告不擋 verdict**：`>3 days → warning`、`>7 days → strong warning`。理由：時間不重要,重要的是「這份 snapshot 是不是當前跑的 code 量的」── 3 天前但 sha 對=可信;1 小時前但 sha 不對=不可信。
+> **概念別混（防 drift）**：deploy manifest 的 `stale_after_h=6h`（IMPL `current_run_meta`，檢查**部署記錄**新舊）與這裡 snapshot age 3d/7d advisory（檢查**baseline snapshot**新舊）是**不同概念**，兩者各自為政、不可互相套用。
+
+**demo 當天 override（有界 + 留痕，不萬能）**：`pawai readiness --accept-warnings`（或 `--force-ready`）
+- **可 override（軟條件）**：age warning / missing optional notes / preflight `pass_with_warnings`
+- **不可 override（硬條件）**：snapshot missing / schema invalid / run_trusted=False / layer0_preflight fail / **sha mismatch** / capability list 不全
+- override 必留痕（蓋進 readiness 輸出）：`{"override": true, "operator": "...", "reason": "...", "timestamp": "..."}` → demo 後追問題不失憶；evidence 看得出「人工放行,非真綠」。對齊 nav runbook「明確人工安全 override」。
+
+**snapshot 路徑（沿用 nav env-override 慣例,不寫死）**：
+
+| 用途 | 路徑 | git |
+|---|---|---|
+| working snapshot | `artifacts/baseline/baseline_snapshot.json`（Jetson `~/elder_and_dog/...`）| ❌ `.gitignore` 加 `artifacts/` |
+| frozen demo snapshot | `artifacts/baseline/frozen/2026-06-18/baseline_snapshot.json` | ❌（量測產物）|
+| example fixture（test + Studio mock + schema example）| `pawai_brain/test/fixtures/baseline_snapshot.example.json` | ✅ git-track（需穩定樣本）|
+
+- `pawai readiness` + gateway `/api/scoreboard`（§8）皆用 env 可覆寫 `PAWAI_SCOREBOARD_PATH`（預設 working 路徑）。WSL 跑 readiness 經 SSH 讀 Jetson 路徑（沿用 `status.py:88 cat {jetson_repo}/.pawai-last-deploy`）。
+
+**§8 ↔ §9 接點**：§9 產 + freeze 的 `baseline_snapshot.json` 就是 §8 `/api/scoreboard` 唯讀的那份;demo 當天用 frozen snapshot,不即時重算（避免 grade 抖動讓 Brain/UI 跳變）。**`/api/scoreboard` owner = Studio gateway/frontend team**（非 Brain），source path 由 `PAWAI_SCOREBOARD_PATH` 控制（預設 working 路徑）。
+
+**code 接地**：
+- **已存在**：`.pawai-last-deploy` provenance manifest（`main.py:95` 構造含 git sha + deploy ts、`main.py:643` 寫 Jetson、`status.py:12,88` 讀）;`pawai doctor`/`status` click 命令齊。
+- **greenfield（全新）**：`pawai readiness` 子命令、`build_scoreboard.py`（Impl Plan Task 3b，`--out` 現為裸 `baseline_snapshot.json` 待定目錄）、`baseline_snapshot.json`、freeze 機制、`PAWAI_SCOREBOARD_PATH` env、§8 `/api/scoreboard`。
+
+---
+
+> 每節拍定後立即 fold + 該能力 dry-run（若涉及 observer 邏輯）。所有門檻 provisional until baseline。

--- a/docs/runbook/2026-06-18-baseline-runbook.md
+++ b/docs/runbook/2026-06-18-baseline-runbook.md
@@ -1,0 +1,39 @@
+# Baseline Runbook（上機跑 capability baseline，Roy 親自跑）
+
+> **性質**：在 Jetson 上跑 capability baseline 的操作手冊。這份是「**怎麼上機量、JSONL 存哪、snapshot 怎麼 freeze、demo 當天怎麼用**」的唯一真相源。
+> **不放**：架構決策（Master Plan）、門檻數字（Capability Baseline Spec）、code 結構（Implementation Plan）。
+> **關係**：Master Plan `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md`｜Spec `docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md`｜Implementation `docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md`
+> **既有相關 runbook**：`docs/runbook/demo_script.md`、`demo-30-case-checklist.md`、`demo-frozen-backlog.md`（demo 展示用，與本 baseline 量測 runbook 互補）。
+
+> **鐵律：as-is baseline 必走 demo entrypoint**（`start_full_demo_tmux.sh` / 各 lane 腳本），**不裸 `ros2 run`**——裸跑會拿到錯的 mic_gain(1.0≠8.0) / gesture backend(rtmpose≠recognizer) / whisper device(cpu-int8≠cuda-fp16)。
+
+---
+
+## 上機流程
+
+0. **Layer-0 Preflight**：跑填好的 `pawai`/`jetson-verify demo.yaml`；`fail → 全 insufficient_data，停`。記 `version_snapshot`（讀 `.pawai-last-deploy` + WSL commit，mismatch 警告）。
+1. **環境鎖定**：`sudo bash benchmarks/scripts/prepare_env.sh`（nvpmodel -m 0 + jetson_clocks；必要時 `--drop-cache`）。
+2. **資源採樣**：背景跑 `benchmarks/core/monitor.py JetsonMonitor`（reuse），aggregate 值填回 scenario 的 `cpu_pct/gpu_pct/ram_mb`。
+   - 實機參考（2026-05-31 motion-safe 感知 lane face+vision+D435）：RAM ~1.17GB used / avail 6.2GB、CPU ~41%、temp ~53–54°C、`/state/perception/face` 19.97Hz、vision debug_image ~3.9–4.8Hz。
+3. **逐能力跑**（深測優先 voice → face/gesture/object；nav 受跑序鐵律約束，見下）：
+   - voice：走 `run_speech_test.sh` → `speech_test_observer` → 轉 JSONL（A2 轉 record：補 `capability_id=voice.command/voice.stop`）。**前置（demo-blocking，見 spec §2 設計結論）**：先確認 `mic_stop` 訊號流已接（Studio stopRecording 發 `/event/mic_boundary` → stt_intent 訂閱），baseline 走 **manual mic boundary**（`energy_vad.enabled=False`）；latency **雙記錄**（新 `e2e` 從 `mic_stop_ts` 起算、保留舊 `speech_start_ts` 欄位對照，報告標「metric v2」）。voice.stop 從 30 輪拆「停」專項 N 輪（含噪音），FN 硬性=0。
+   - **gesture/object**（required baseline step——mainline 主張，必跑）：起感知 lane（demo entrypoint），跑 `perception_baseline_observer`（Task 4，event-only），operator 宣告 round_meta（每 round 標 `scenario_kind` = positive / idle）+ 人工確認 → JSONL。**object 必須先起 `object_perception`（拿 demo 杯子測 `object.cup`）；gesture 必須切 `recognizer` backend**（demo 真實 backend，非壓測 mediapipe），含 person-present idle 誤觸段。
+   - **face**（required）：跑 `face_baseline_observer`（Task 4b，吃 `/state/perception/face` 連續流），operator 宣告 FaceRoundMeta（expected 註冊者名 / "unknown"(idle) / distance / window，每 round 標 `scenario_kind`）→ JSONL。**勿用 `perception_baseline_observer` 跑 face**（event-only 量不出 unknown-false-accept）。
+   - **nav 跑序鐵律（§6 鎖定）**：`safe_stop` + `no_auto_resume` **pass（或明確人工安全 override）前，不允許跑 motion**。順序不可顛倒（不可先跑 motion 再補 safety）。
+     - `nav.safe_stop` / `nav.no_auto_resume`：**等 recorder BD-7/BD-8**（no_auto_resume 還需 **BD-8 行為重設計**，非只接 recorder），本輪標 insufficient_data。
+     - `nav.short_move`：safety 兩項未 pass 前**只做 dry-run / action-path check**（手動發 goto_relative 驗 action server 鏈路通、量 /event/nav/mission，**不讓 Go2 實際走**）；safety pass 或人工 override 後才跑真實 0.3/0.5m motion。fresh stack 先定位 F7、走 BD-7D wrapper。
+
+> **附註（執行日誌，非主流程）**：2026-05-31 的 motion-safe 探測輪**未**測 object/gesture-recognizer（當天只驗感知 lane 可起）。正式 baseline run 必須補齊上述 object_perception + recognizer backend——它們是 mainline required step，不可停在 `insufficient_data`。
+4. **產 snapshot**：`build_scoreboard.py`（Task 3b，≤30 行 CLI，讀 `baseline_result.jsonl` + `--manifest` + `--preflight artifacts/baseline/preflight_result.json` → `aggregate` → 寫 `artifacts/baseline/baseline_snapshot.json`）。**必須帶 `--preflight`**——缺 preflight → `run_trusted=False` → 全 grade 覆寫 insufficient_data（fail-closed）。
+5. **判讀**：看每能力 grade + brain_allowed，決定進主線(pass+mainline) / 只顯示(degraded/studio_only) / 不宣稱(fail) / 不放行高風險(insufficient_data)。**這就是 v0.1 的成功定義達成點。**
+
+---
+
+## JSONL / snapshot 存放與 freeze（Demo Readiness，§9 待 grill 補細節）
+
+- baseline 逐 round → append 同一個 `baseline_result.jsonl`（face/gesture/object/voice/nav 共用）。
+- `build_scoreboard.py` 讀 jsonl + `--manifest`（Jetson `.pawai-last-deploy`）+ `--preflight artifacts/baseline/preflight_result.json` → 產 `artifacts/baseline/baseline_snapshot.json`。
+- **demo 當天用 frozen snapshot**（不在 demo 中即時重算，避免 grade 抖動讓 Brain 行為跳變）。snapshot 帶 `run_id / git sha / deploy timestamp / run_trusted`。
+- preflight fail → `run_trusted=False` → 全 grade 覆寫 insufficient_data（fail-closed），snapshot 不可當 demo 依據。
+
+> §9 Demo Readiness / Frozen Snapshot 的完整規則（有效期限 / 現場 override / live vs frozen）待逐功能討論到 §9 後補。

--- a/docs/runbook/2026-06-18-baseline-runbook.md
+++ b/docs/runbook/2026-06-18-baseline-runbook.md
@@ -11,7 +11,7 @@
 
 ## 上機流程
 
-0. **Layer-0 Preflight**：跑填好的 `pawai`/`jetson-verify demo.yaml`；`fail → 全 insufficient_data，停`。記 `version_snapshot`（讀 `.pawai-last-deploy` + WSL commit，mismatch 警告）。
+0. **Layer-0 Preflight**：跑填好的 `pawai`/`jetson-verify demo.yaml`；`fail → 全 insufficient_data，停`。記 `version_snapshot`（讀 `.pawai-last-deploy` + WSL commit）。**`snapshot sha != deploy sha` = 硬擋**（§9：`→ not_ready`、不可 override——跑的不是這份 code，snapshot 不可當 demo 依據）；**age 才是 advisory warning**（>3d warning / >7d strong warning，不擋 verdict）。
 1. **環境鎖定**：`sudo bash benchmarks/scripts/prepare_env.sh`（nvpmodel -m 0 + jetson_clocks；必要時 `--drop-cache`）。
 2. **資源採樣**：背景跑 `benchmarks/core/monitor.py JetsonMonitor`（reuse），aggregate 值填回 scenario 的 `cpu_pct/gpu_pct/ram_mb`。
    - 實機參考（2026-05-31 motion-safe 感知 lane face+vision+D435）：RAM ~1.17GB used / avail 6.2GB、CPU ~41%、temp ~53–54°C、`/state/perception/face` 19.97Hz、vision debug_image ~3.9–4.8Hz。


### PR DESCRIPTION
## 內容（純 docs，零 nav code）

從 `feat/nav-metrics-ladder` 抽出 baseline 專屬的 2 個 docs commit（cherry-pick）進 main：

- `docs/mission/2026-06-18-demo-north-star.md` — North Star v2（戰略邊界）
- `docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md` — §1-§9 門檻唯一真相源
- `docs/pawai-brain/plans/2026-05-31-capability-baseline-scoreboard-plan.md` — Master Plan
- `docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md` — 6 deliverable TDD
- `docs/runbook/2026-06-18-baseline-runbook.md` — 上機流程
- `docs/pawai-brain/plans/2026-06-02-baseline-issues-draft.md` — issue source-of-record
- `.gitignore` — 加 `/artifacts/`（baseline 量測產物不入 repo）

## 為什麼提前進 main

GitHub issues #71-#89 已引用這些 spec/plan。docs 不在 main，其他 agent 看 main 找不到真相源。

## Scope 鎖

純 docs，不含任何 nav burndown 程式或 working-tree WIP。Refs #88 #89。

🤖 Generated with [Claude Code](https://claude.com/claude-code)