### PR TITLE
feat(scoreboard): #71 v0.1 schema + CAPABILITY_META + dual-sha run_meta

### DIFF
--- a/benchmarks/core/scoreboard_schema.py
+++ b/benchmarks/core/scoreboard_schema.py
@@ -1,0 +1,212 @@
+"""Capability baseline result schema + 靜態 capability metadata (v0.1)。
+
+一筆 JSONL record = 一次 scenario-run。claim_level / risk_role 是 capability 的「靜態屬性」，
+存 CAPABILITY_META，不進每筆 record（避免重複）。run-level meta 帶 version_snapshot 雙 sha
+（Jetson 無 .git，dev commit != Jetson install）。
+"""
+from __future__ import annotations
+
+import subprocess
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Optional
+
+SCHEMA_VERSION = "scoreboard-0.1"
+
+# capability_id -> 靜態屬性（claim_level/risk_role/dependency_role 是作者標的，不是量出來的）
+# dependency_role（2026-06-01 加）：fail 時依賴它的 demo skill 怎麼降級：
+#   trigger -> 不觸發該 skill；content -> skill 觸發但內容降級；safety_guard -> 禁 motion；
+#   actuation -> 禁該動作；evidence -> 只影響 Studio 顯示。與 risk_role 正交。
+#   v0.1 不被 grader 消費（design-only）。
+CAPABILITY_META: dict[str, dict[str, str]] = {
+    "face.recognition": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "evidence_only",
+        "dependency_role": "content",
+    },
+    "voice.command": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "convenience",
+        "dependency_role": "trigger",
+    },
+    "voice.stop": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "convenience",
+        "dependency_role": "trigger",
+    },
+    "gesture.wave": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "convenience",
+        "dependency_role": "trigger",
+    },
+    "object.cup": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "evidence_only",
+        "dependency_role": "content",
+    },
+    "nav.safe_stop": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "safety_critical",
+        "dependency_role": "safety_guard",
+    },
+    "nav.no_auto_resume": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "safety_critical",
+        "dependency_role": "safety_guard",
+    },
+    "nav.short_move": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "actuation",
+        "dependency_role": "actuation",
+    },
+    "nav.dynamic_avoidance": {
+        "depth": "future",
+        "claim_level": "future",
+        "risk_role": "actuation",
+        "dependency_role": "actuation",
+    },
+    "pose.basic": {
+        "depth": "thin",
+        "claim_level": "studio_only",
+        "risk_role": "evidence_only",
+        "dependency_role": "content",
+    },
+    "pose.fall": {
+        "depth": "future",
+        "claim_level": "future",
+        "risk_role": "evidence_only",
+        "dependency_role": "evidence",
+    },
+    "brain.skill_gate": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "safety_critical",
+        "dependency_role": "safety_guard",
+    },
+    "brain.trace": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "evidence_only",
+        "dependency_role": "evidence",
+    },
+    "studio.evidence": {
+        "depth": "deep",
+        "claim_level": "mainline",
+        "risk_role": "evidence_only",
+        "dependency_role": "evidence",
+    },
+    "cli.readiness": {
+        "depth": "thin",
+        "claim_level": "not_claimed",
+        "risk_role": "safety_support",
+        "dependency_role": "evidence",
+    },
+}
+
+
+@dataclass
+class CapabilityResult:
+    # --- 識別 ---
+    capability_id: str
+    scenario_id: str
+    run_id: str
+    timestamp: str
+    git_commit: str
+    # --- 判定 ---
+    expected_label: str
+    predicted_label: str
+    pass_fail: str
+    confidence: Optional[float] = None
+    distance_m: Optional[float] = None
+    distance_source: str = "manual_declared"
+    latency_ms: Optional[float] = None
+    frame_age_ms: Optional[float] = None
+    fps: Optional[float] = None
+    false_trigger: bool = False
+    stable_time_ms: Optional[float] = None
+    # --- 資源（reuse JetsonMonitor 後填；v0.1 可留 None）---
+    cpu_pct: Optional[float] = None
+    gpu_pct: Optional[float] = None
+    ram_mb: Optional[float] = None
+    failure_reason: str = ""
+
+    def to_record(self) -> dict:
+        rec = asdict(self)
+        rec["schema_version"] = SCHEMA_VERSION
+        return rec
+
+
+def _git(args: list[str]) -> str:
+    try:
+        return subprocess.check_output(["git", *args], text=True).strip()
+    except Exception:
+        return "unknown"
+
+
+def _git_short() -> str:
+    return _git(["rev-parse", "--short", "HEAD"])
+
+
+def _is_stale(when_iso: Optional[str], now_iso: Optional[str], stale_after_h: float) -> bool:
+    """Return True when deploy manifest time is missing, invalid, or too old."""
+    if not when_iso:
+        return True
+    try:
+        now_source = now_iso or datetime.now(timezone.utc).isoformat()
+        now = datetime.fromisoformat(now_source.replace("Z", "+00:00"))
+        when = datetime.fromisoformat(when_iso.replace("Z", "+00:00"))
+        return (now - when).total_seconds() > stale_after_h * 3600
+    except Exception:
+        return True
+
+
+def current_run_meta(
+    jetson_manifest: Optional[dict] = None,
+    demo_profile_env: Optional[dict] = None,
+    layer0_preflight: Optional[dict] = None,
+    now_iso: Optional[str] = None,
+    stale_after_h: float = 6.0,
+) -> dict:
+    """Return run-level metadata with WSL commit and Jetson install snapshot.
+
+    無 manifest 或與 dev commit 不符 -> version_mismatch=True（fail-closed）。
+    F2：Layer 0 preflight 非 pass/pass_with_warnings -> run_trusted=False。
+    """
+    manifest = jetson_manifest or {}
+    wsl_commit = _git_short()
+    wsl_dirty = bool(_git(["status", "--porcelain"]))
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"])
+    jetson_sha = manifest.get("git_sha_full")
+    manifest_exists = jetson_manifest is not None
+    mismatch = (jetson_sha is None) or (
+        not jetson_sha.startswith(wsl_commit) if wsl_commit != "unknown" else True
+    )
+    preflight_status = (layer0_preflight or {}).get("status", "unknown")
+    run_trusted = preflight_status in ("pass", "pass_with_warnings")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "run_id": str(uuid.uuid4()),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "wsl_commit": wsl_commit,
+        "wsl_dirty": wsl_dirty,
+        "branch": branch,
+        "jetson_install_sha": jetson_sha,
+        "jetson_deploy_ts": manifest.get("when"),
+        "jetson_sync_method": manifest.get("sync_method"),
+        "jetson_dirty": bool(manifest.get("dirty")),
+        "manifest_exists": manifest_exists,
+        "version_mismatch": bool(mismatch),
+        "version_stale": _is_stale(manifest.get("when"), now_iso, stale_after_h),
+        "layer0_preflight_status": preflight_status,
+        "run_trusted": run_trusted,
+        "demo_profile_env": demo_profile_env or {},
+    }

--- a/benchmarks/test/test_scoreboard_schema.py
+++ b/benchmarks/test/test_scoreboard_schema.py
@@ -1,0 +1,111 @@
+from benchmarks.core.scoreboard_schema import (
+    CapabilityResult, SCHEMA_VERSION, CAPABILITY_META, current_run_meta,
+)
+
+
+def test_to_record_has_schema_version_and_core_fields():
+    r = CapabilityResult(
+        capability_id="gesture.wave",
+        scenario_id="wave_1.5m_frontal",
+        run_id="run-abc",
+        timestamp="2026-05-31T12:00:00Z",
+        git_commit="deadbee",
+        expected_label="wave",
+        predicted_label="wave",
+        pass_fail="pass",
+        confidence=0.91,
+        distance_m=1.5,
+        latency_ms=120.0,
+    )
+    rec = r.to_record()
+    assert rec["schema_version"] == SCHEMA_VERSION
+    assert rec["capability_id"] == "gesture.wave"
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["distance_source"] == "manual_declared"
+    assert rec["failure_reason"] == ""
+
+
+def test_capability_meta_has_claim_and_risk_for_every_canonical_id():
+    # 每個 canonical capability 都要有靜態屬性（claim_level / risk_role / depth / dependency_role）
+    for cap, meta in CAPABILITY_META.items():
+        assert meta["claim_level"] in {"mainline", "studio_only", "future", "not_claimed"}
+        assert meta["risk_role"] in {
+            "safety_critical", "safety_support", "actuation", "convenience", "evidence_only",
+        }
+        assert meta["depth"] in {"deep", "thin", "future"}
+        # dependency_role（2026-06-01 新增）：每能力必標，供設計段 C / v0.2 chain-gating
+        assert meta["dependency_role"] in {
+            "trigger", "content", "safety_guard", "actuation", "evidence",
+        }
+    # nav 已拆成單一能力，不可有複合 id
+    assert "nav.safe_stop" in CAPABILITY_META
+    assert "nav.short_move" in CAPABILITY_META
+    assert "nav.short_move + nav.safe_stop" not in CAPABILITY_META
+    # dependency_role 與 risk_role 正交：safety_critical 能力的 dependency_role 是 safety_guard，非 evidence
+    assert CAPABILITY_META["nav.safe_stop"]["dependency_role"] == "safety_guard"
+    assert CAPABILITY_META["gesture.wave"]["dependency_role"] == "trigger"
+    assert CAPABILITY_META["face.recognition"]["dependency_role"] == "content"
+
+
+def test_run_meta_records_dual_sha_and_run_id():
+    meta = current_run_meta(
+        jetson_manifest={"git_sha_full": "abc123def", "when": "2026-05-31T10:00:00Z",
+                         "sync_method": "rsync", "dirty": False},
+        demo_profile_env={"REACTIVE_DANGER_M": "0.85", "MAP": "v9"},
+    )
+    assert meta["schema_version"] == SCHEMA_VERSION
+    assert "run_id" in meta and meta["run_id"]
+    assert meta["jetson_install_sha"] == "abc123def"
+    assert meta["jetson_deploy_ts"] == "2026-05-31T10:00:00Z"
+    assert meta["demo_profile_env"]["MAP"] == "v9"
+    # wsl_commit vs jetson_install_sha 不一致時要有 fail-closed 旗標
+    assert "version_mismatch" in meta
+
+
+def test_run_meta_without_manifest_flags_unknown_install():
+    meta = current_run_meta(jetson_manifest=None)
+    assert meta["jetson_install_sha"] is None
+    assert meta["version_mismatch"] is True  # 無 manifest = 無法確認 Jetson 跑的是哪版 → fail-closed
+    assert meta["manifest_exists"] is False
+
+
+def test_run_meta_flags_stale_manifest_by_age():
+    # 洞④：manifest 太舊（deploy 後沒重 deploy 就跑 baseline）→ version_stale=True（標註，非硬 block）
+    old = current_run_meta(
+        jetson_manifest={"git_sha_full": "abc123def", "when": "2020-01-01T00:00:00Z",
+                         "sync_method": "rsync", "dirty": False},
+        now_iso="2026-05-31T10:00:00Z", stale_after_h=6,
+    )
+    assert old["version_stale"] is True
+    fresh = current_run_meta(
+        jetson_manifest={"git_sha_full": "abc123def", "when": "2026-05-31T08:00:00Z",
+                         "sync_method": "rsync", "dirty": False},
+        now_iso="2026-05-31T10:00:00Z", stale_after_h=6,
+    )
+    assert fresh["version_stale"] is False
+
+
+def test_run_meta_records_dirty_and_branch():
+    meta = current_run_meta(jetson_manifest={"git_sha_full": "abc123def", "dirty": True})
+    assert "wsl_dirty" in meta and "branch" in meta and "manifest_exists" in meta
+    assert meta["jetson_dirty"] is True  # manifest 的 dirty 旗標要轉出來
+
+
+def test_run_meta_layer0_preflight_pass_marks_run_trusted():
+    # F2：preflight pass / pass_with_warnings → run_trusted=True
+    meta = current_run_meta(layer0_preflight={"status": "pass"})
+    assert meta["layer0_preflight_status"] == "pass"
+    assert meta["run_trusted"] is True
+    meta_w = current_run_meta(layer0_preflight={"status": "pass_with_warnings"})
+    assert meta_w["run_trusted"] is True
+
+
+def test_run_meta_layer0_preflight_fail_marks_untrusted():
+    # F2：preflight fail / 缺結果 → run_trusted=False（fail-closed，to_snapshot 會覆寫全 grade）
+    meta = current_run_meta(layer0_preflight={"status": "fail"})
+    assert meta["layer0_preflight_status"] == "fail"
+    assert meta["run_trusted"] is False
+    meta_none = current_run_meta()  # 沒跑 preflight = 不可信
+    assert meta_none["layer0_preflight_status"] == "unknown"
+    assert meta_none["run_trusted"] is False


### PR DESCRIPTION
## Linked issue

- [x] Closes #71
- [x] Refs #88

## Test command + output

```text
$ python3 -m pytest benchmarks/test/test_scoreboard_schema.py -v
8 passed in 0.11s
```

## Hardware needed

- [x] none
- [ ] Jetson
- [ ] Go2

## Evidence

- [x] log: 8/8 pytest green（獨立複跑）。CAPABILITY_META 恰 15 能力、逐列對齊 Master canonical 表（claim_level/risk_role/dependency_role）。
- [x] fail-closed 驗證：無 manifest→version_mismatch=True/run_trusted=False；缺 preflight→run_trusted=False。

## Out of scope

- [x] grader 判分（#72）
- [x] aggregator 聚合（#79）
- [x] 本 issue 只定「記錄格式 + 屬性表 + run 標記」三樣

🤖 Generated with [Claude Code](https://claude.com/claude-code)