### PR TITLE
feat(scoreboard): #72 four-tier grader + brain_allowed derive

### DIFF
--- a/benchmarks/core/grader.py
+++ b/benchmarks/core/grader.py
@@ -1,0 +1,68 @@
+"""Four-tier capability grader (v0.1).
+
+Pure functions with no ROS dependencies. The grader combines threshold bands
+with sample sufficiency, then derives a conservative Brain allow decision from
+grade and claim level.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+GRADE_PASS = "pass"
+GRADE_DEGRADED = "degraded"
+GRADE_FAIL = "fail"
+GRADE_INSUFFICIENT = "insufficient_data"
+
+
+@dataclass
+class Criterion:
+    metric: str
+    pass_min: float
+    degraded_min: float
+    higher_is_better: bool = True
+
+
+def grade_one(value: Optional[float], crit: Criterion) -> str:
+    """Grade a single metric. Missing values fail closed."""
+    if value is None:
+        return GRADE_FAIL
+    if crit.higher_is_better:
+        if value >= crit.pass_min:
+            return GRADE_PASS
+        if value >= crit.degraded_min:
+            return GRADE_DEGRADED
+        return GRADE_FAIL
+
+    if value <= crit.pass_min:
+        return GRADE_PASS
+    if value <= crit.degraded_min:
+        return GRADE_DEGRADED
+    return GRADE_FAIL
+
+
+def grade_capability(
+    metrics: dict,
+    criteria: list[Criterion],
+    sample_count: int,
+    confirm_min: int = 3,
+) -> str:
+    """Combine threshold bands and sample sufficiency into a four-tier grade."""
+    if sample_count <= 0:
+        return GRADE_INSUFFICIENT
+    if not criteria:
+        return GRADE_INSUFFICIENT
+
+    grades = [grade_one(metrics.get(crit.metric), crit) for crit in criteria]
+    if GRADE_FAIL in grades:
+        return GRADE_FAIL
+    if GRADE_DEGRADED in grades:
+        return GRADE_DEGRADED
+    if sample_count < confirm_min:
+        return GRADE_DEGRADED
+    return GRADE_PASS
+
+
+def brain_allowed(grade: str, claim_level: str) -> bool:
+    """Allow Brain mainline only when grade passes and claim level is mainline."""
+    return grade == GRADE_PASS and claim_level == "mainline"

--- a/benchmarks/test/test_grader.py
+++ b/benchmarks/test/test_grader.py
@@ -1,0 +1,72 @@
+from benchmarks.core.grader import (
+    Criterion,
+    grade_capability,
+    brain_allowed,
+    GRADE_PASS,
+    GRADE_DEGRADED,
+    GRADE_FAIL,
+    GRADE_INSUFFICIENT,
+)
+
+HIGHER = Criterion(
+    metric="success_rate",
+    pass_min=0.90,
+    degraded_min=0.80,
+    higher_is_better=True,
+)
+LOWER = Criterion(
+    metric="false_trigger_rate",
+    pass_min=0.10,
+    degraded_min=0.30,
+    higher_is_better=False,
+)
+
+
+def test_zero_samples_is_insufficient():
+    assert (
+        grade_capability({"success_rate": 0.99}, [HIGHER], sample_count=0)
+        == GRADE_INSUFFICIENT
+    )
+
+
+def test_empty_criteria_is_not_pass():
+    # 缺 criteria 無從判斷 -> fail-closed，絕不可 pass
+    assert (
+        grade_capability({"success_rate": 0.99}, [], sample_count=5)
+        == GRADE_INSUFFICIENT
+    )
+
+
+def test_all_pass_but_unconfirmed_is_degraded():
+    assert grade_capability({"success_rate": 0.95}, [HIGHER], sample_count=1) == GRADE_DEGRADED
+
+
+def test_all_pass_and_confirmed_is_pass():
+    assert grade_capability({"success_rate": 0.95}, [HIGHER], sample_count=3) == GRADE_PASS
+
+
+def test_any_metric_fail_is_fail():
+    metrics = {"success_rate": 0.95, "false_trigger_rate": 0.40}
+    assert grade_capability(metrics, [HIGHER, LOWER], sample_count=5) == GRADE_FAIL
+
+
+def test_lower_is_better_band():
+    assert grade_capability({"false_trigger_rate": 0.05}, [LOWER], sample_count=5) == GRADE_PASS
+    assert (
+        grade_capability({"false_trigger_rate": 0.20}, [LOWER], sample_count=5)
+        == GRADE_DEGRADED
+    )
+
+
+def test_degraded_band_dominates_over_unconfirmed():
+    assert grade_capability({"success_rate": 0.85}, [HIGHER], sample_count=5) == GRADE_DEGRADED
+
+
+def test_brain_allowed_only_pass_and_mainline():
+    # claim_level 只能更嚴：pass 但 future -> 不放行
+    assert brain_allowed(GRADE_PASS, "mainline") is True
+    assert brain_allowed(GRADE_PASS, "future") is False
+    assert brain_allowed(GRADE_PASS, "studio_only") is False
+    assert brain_allowed(GRADE_DEGRADED, "mainline") is False
+    assert brain_allowed(GRADE_FAIL, "mainline") is False
+    assert brain_allowed(GRADE_INSUFFICIENT, "mainline") is False


### PR DESCRIPTION
## Linked issue

- [x] Closes #72
- [x] Refs #88

## Test command + output

```text
$ python3 -m pytest benchmarks/test/test_grader.py -v
8 passed
# 直接驗鎖：grade_one(None)->fail；missing metric->fail；brain_allowed 16 組合只 pass+mainline 為 True
```

## Hardware needed

- [x] none
- [ ] Jetson
- [ ] Go2

## Evidence

- [x] log: 8/8 pytest green（獨立複跑）；#71+#72 一起 16 passed。
- [x] fail-closed 鎖驗證：zero-sample/empty-criteria→insufficient_data、None/missing metric→fail、any-fail→fail、unconfirmed→degraded、brain_allowed 僅 pass+mainline。

## Out of scope

- [x] 不定義門檻數字（caller 給；DEFAULT_CRITERIA 屬 #79）
- [x] 不讀 JSONL / 不分組 / 不算 success_rate（屬 #79）
- [x] 不接 Brain runtime gate（brain_allowed v0.1 僅 derive 函式，#85 才接）

🤖 Generated with [Claude Code](https://claude.com/claude-code)