### PR TITLE
feat(scoreboard): #79 aggregator + build_scoreboard CLI

### DIFF
--- a/benchmarks/core/build_scoreboard.py
+++ b/benchmarks/core/build_scoreboard.py
@@ -1,0 +1,89 @@
+"""CLI wrapper for building a baseline scoreboard snapshot from JSONL results."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Optional
+
+from .grader import Criterion
+from .scoreboard import aggregate, load_results, write_snapshot
+from .scoreboard_schema import current_run_meta
+
+DEFAULT_OUT_PATH = "artifacts/baseline/baseline_snapshot.json"
+
+DEFAULT_CRITERIA: dict[str, list[Criterion]] = {
+    "face.recognition": [
+        Criterion("registered_recall", 0.80, 0.60, higher_is_better=True),
+        Criterion("unknown_false_accept_rate", 0.03, 0.10, higher_is_better=False),
+        Criterion("wrong_person_count", 0, 0, higher_is_better=False),
+    ],
+    "voice.command": [
+        Criterion("success_rate", 0.80, 0.70, higher_is_better=True),
+    ],
+    "gesture.wave": [
+        Criterion("success_rate", 0.90, 0.80, higher_is_better=True),
+        Criterion("false_trigger_rate", 0.10, 0.30, higher_is_better=False),
+    ],
+    "object.cup": [
+        Criterion("success_rate", 0.80, 0.60, higher_is_better=True),
+        Criterion("false_trigger_rate", 0.01, 0.10, higher_is_better=False),
+    ],
+}
+
+
+def _load_json(path: Optional[str]) -> Optional[dict]:
+    if not path:
+        return None
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_criteria(path: Optional[str]) -> Optional[dict[str, list[Criterion]]]:
+    raw = _load_json(path)
+    if raw is None:
+        return None
+    return {capability: [Criterion(**item) for item in items] for capability, items in raw.items()}
+
+
+def build_scoreboard(
+    jsonl_path: str,
+    manifest_path: Optional[str] = None,
+    preflight_path: Optional[str] = None,
+    criteria: Optional[dict[str, list[Criterion]]] = None,
+    out_path: str = DEFAULT_OUT_PATH,
+) -> str:
+    records = load_results(jsonl_path)
+    run_meta = current_run_meta(
+        jetson_manifest=_load_json(manifest_path),
+        layer0_preflight=_load_json(preflight_path),
+    )
+    scores = aggregate(records, criteria or DEFAULT_CRITERIA)
+    out = Path(out_path)
+    if out.parent != Path("."):
+        out.parent.mkdir(parents=True, exist_ok=True)
+    write_snapshot(scores, run_meta, str(out))
+    return str(out)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("jsonl")
+    parser.add_argument("--manifest")
+    parser.add_argument("--preflight")
+    parser.add_argument("--criteria")
+    parser.add_argument("--out", default=DEFAULT_OUT_PATH)
+    args = parser.parse_args()
+
+    path = build_scoreboard(
+        args.jsonl,
+        manifest_path=args.manifest,
+        preflight_path=args.preflight,
+        criteria=_load_criteria(args.criteria),
+        out_path=args.out,
+    )
+    print(f"snapshot -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/core/scoreboard.py
+++ b/benchmarks/core/scoreboard.py
@@ -1,0 +1,198 @@
+"""Aggregate baseline JSONL records into a capability scoreboard snapshot.
+
+The snapshot carries static capability metadata plus the derived Brain allow
+decision. This module is intentionally pure Python and does not connect to
+Brain runtime or ROS.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+from .grader import Criterion, GRADE_INSUFFICIENT, brain_allowed, grade_capability
+from .scoreboard_schema import CAPABILITY_META
+
+
+@dataclass
+class CapabilityScore:
+    capability_id: str
+    grade: str
+    sample_count: int
+    success_rate: float
+    false_trigger_rate: float
+    latency_p50: Optional[float]
+    latency_p90: Optional[float]
+    confirmed: bool
+    positive_count: int = 0
+    idle_count: int = 0
+    registered_recall: Optional[float] = None
+    unknown_false_accept_rate: Optional[float] = None
+    wrong_person_count: int = 0
+
+
+def _pctl(values: list[Optional[float]], p: float) -> Optional[float]:
+    xs = sorted(v for v in values if v is not None)
+    if not xs:
+        return None
+    k = int(round((p / 100.0) * (len(xs) - 1)))
+    k = max(0, min(len(xs) - 1, k))
+    return xs[k]
+
+
+def load_results(path: str) -> list[dict]:
+    records: list[dict] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def _scenario_kind(record: dict) -> str:
+    return record.get("scenario_kind", "positive")
+
+
+def _passed(record: dict) -> bool:
+    return record.get("pass_fail") == "pass"
+
+
+def _false_triggered(record: dict) -> bool:
+    return record.get("false_trigger") is True
+
+
+def _rate(count: int, total: int) -> Optional[float]:
+    if total <= 0:
+        return None
+    return count / total
+
+
+def _round_optional(value: Optional[float]) -> Optional[float]:
+    if value is None:
+        return None
+    return round(value, 3)
+
+
+def aggregate(
+    records: list[dict],
+    criteria_by_capability: dict[str, list[Criterion]],
+    confirm_min: int = 3,
+) -> dict[str, CapabilityScore]:
+    """Aggregate records by capability without mixing positive and idle scenarios."""
+    by_capability: dict[str, list[dict]] = {}
+    for record in records:
+        by_capability.setdefault(record["capability_id"], []).append(record)
+
+    scores: dict[str, CapabilityScore] = {}
+    for capability_id, cap_records in by_capability.items():
+        sample_count = len(cap_records)
+        positives = [r for r in cap_records if _scenario_kind(r) == "positive"]
+        idles = [r for r in cap_records if _scenario_kind(r) == "idle"]
+
+        success_rate = _rate(sum(1 for r in cap_records if _passed(r)), sample_count)
+        false_trigger_rate = _rate(
+            sum(1 for r in cap_records if _false_triggered(r)),
+            sample_count,
+        )
+        registered_recall = _rate(sum(1 for r in positives if _passed(r)), len(positives))
+        unknown_false_accept_rate = _rate(
+            sum(1 for r in idles if _false_triggered(r)),
+            len(idles),
+        )
+        wrong_person_count = sum(1 for r in positives if _false_triggered(r))
+        latencies = [r.get("latency_ms") for r in cap_records]
+
+        metrics = {
+            "success_rate": success_rate,
+            "false_trigger_rate": false_trigger_rate,
+            "latency_p50": _pctl(latencies, 50),
+            "latency_p90": _pctl(latencies, 90),
+            "registered_recall": registered_recall,
+            "unknown_false_accept_rate": unknown_false_accept_rate,
+            "wrong_person_count": wrong_person_count,
+        }
+        grade = grade_capability(
+            metrics,
+            criteria_by_capability.get(capability_id, []),
+            sample_count,
+            confirm_min,
+        )
+        scores[capability_id] = CapabilityScore(
+            capability_id=capability_id,
+            grade=grade,
+            sample_count=sample_count,
+            success_rate=round(success_rate, 3) if success_rate is not None else 0.0,
+            false_trigger_rate=round(false_trigger_rate, 3)
+            if false_trigger_rate is not None
+            else 0.0,
+            latency_p50=metrics["latency_p50"],
+            latency_p90=metrics["latency_p90"],
+            confirmed=sample_count >= confirm_min,
+            positive_count=len(positives),
+            idle_count=len(idles),
+            registered_recall=_round_optional(registered_recall),
+            unknown_false_accept_rate=_round_optional(unknown_false_accept_rate),
+            wrong_person_count=wrong_person_count,
+        )
+    return scores
+
+
+def _empty_score_dict(capability_id: str) -> dict:
+    return {
+        "capability_id": capability_id,
+        "grade": GRADE_INSUFFICIENT,
+        "sample_count": 0,
+        "success_rate": None,
+        "false_trigger_rate": None,
+        "latency_p50": None,
+        "latency_p90": None,
+        "confirmed": False,
+        "positive_count": 0,
+        "idle_count": 0,
+        "registered_recall": None,
+        "unknown_false_accept_rate": None,
+        "wrong_person_count": 0,
+    }
+
+
+def to_snapshot(scores: dict[str, CapabilityScore], run_meta: dict) -> dict:
+    run_trusted = bool(run_meta.get("run_trusted", False))
+    capabilities = {}
+
+    for capability_id, meta in CAPABILITY_META.items():
+        if capability_id in scores:
+            capability = asdict(scores[capability_id])
+        else:
+            capability = _empty_score_dict(capability_id)
+
+        if not run_trusted:
+            capability["grade"] = GRADE_INSUFFICIENT
+            capability["failure_reason"] = (
+                f"layer0_preflight={run_meta.get('layer0_preflight_status', 'unknown')}"
+            )
+
+        capability["claim_level"] = meta["claim_level"]
+        capability["risk_role"] = meta["risk_role"]
+        capability["depth"] = meta["depth"]
+        capability["dependency_role"] = meta["dependency_role"]
+        capability["brain_allowed"] = brain_allowed(
+            capability["grade"],
+            meta["claim_level"],
+        )
+        capabilities[capability_id] = capability
+
+    return {
+        "schema_version": "scoreboard-0.1",
+        **run_meta,
+        "capabilities": capabilities,
+    }
+
+
+def write_snapshot(
+    scores: dict[str, CapabilityScore],
+    run_meta: dict,
+    out_path: str,
+) -> None:
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(to_snapshot(scores, run_meta), f, ensure_ascii=False, indent=2)

--- a/benchmarks/test/test_build_scoreboard.py
+++ b/benchmarks/test/test_build_scoreboard.py
@@ -1,0 +1,56 @@
+import json
+
+from benchmarks.core.build_scoreboard import DEFAULT_CRITERIA, build_scoreboard
+
+
+def _write_jsonl(path, rows):
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_build_scoreboard_preflight_pass_produces_snapshot(tmp_path):
+    jsonl = tmp_path / "baseline_result.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            {
+                "capability_id": "gesture.wave",
+                "pass_fail": "pass",
+                "false_trigger": False,
+                "latency_ms": 100,
+                "scenario_kind": "positive",
+            }
+            for _ in range(3)
+        ],
+    )
+    preflight = tmp_path / "preflight.json"
+    preflight.write_text(json.dumps({"status": "pass"}), encoding="utf-8")
+    out = tmp_path / "snap.json"
+    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+    snap = json.loads(out.read_text(encoding="utf-8"))
+    assert snap["run_trusted"] is True
+    assert len(snap["capabilities"]) == 15
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "pass"
+
+
+def test_build_scoreboard_missing_preflight_is_failclosed(tmp_path):
+    jsonl = tmp_path / "baseline_result.jsonl"
+    _write_jsonl(
+        jsonl,
+        [
+            {
+                "capability_id": "gesture.wave",
+                "pass_fail": "pass",
+                "false_trigger": False,
+                "latency_ms": 100,
+                "scenario_kind": "positive",
+            }
+            for _ in range(3)
+        ],
+    )
+    out = tmp_path / "snap.json"
+    build_scoreboard(str(jsonl), preflight_path=None, out_path=str(out))
+    snap = json.loads(out.read_text(encoding="utf-8"))
+    assert snap["run_trusted"] is False
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "insufficient_data"

--- a/benchmarks/test/test_scoreboard.py
+++ b/benchmarks/test/test_scoreboard.py
@@ -1,0 +1,133 @@
+from benchmarks.core.scoreboard import aggregate, to_snapshot
+from benchmarks.core.grader import Criterion, GRADE_PASS, GRADE_FAIL
+
+CRIT = {
+    "gesture.wave": [
+        Criterion("success_rate", 0.90, 0.80, higher_is_better=True),
+        Criterion("false_trigger_rate", 0.10, 0.30, higher_is_better=False),
+    ],
+}
+
+
+def _rec(cap, ok, ft=False, lat=100.0, kind="positive"):
+    return {
+        "capability_id": cap,
+        "pass_fail": "pass" if ok else "fail",
+        "false_trigger": ft,
+        "latency_ms": lat,
+        "scenario_kind": kind,
+    }
+
+
+def test_aggregate_success_rate_and_grade():
+    recs = [_rec("gesture.wave", True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    s = scores["gesture.wave"]
+    assert s.sample_count == 4
+    assert s.success_rate == 1.0
+    assert s.false_trigger_rate == 0.0
+    assert s.confirmed is True
+    assert s.grade == GRADE_PASS
+
+
+def test_aggregate_false_trigger_forces_fail():
+    recs = [_rec("gesture.wave", True, ft=True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    assert scores["gesture.wave"].grade == GRADE_FAIL
+
+
+def test_aggregate_separates_recall_from_false_accept():
+    # F2: known/unknown are not mixed. 3 positive hits + 2 idle with 1 false accept.
+    recs = [
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", False, ft=True, kind="idle"),
+        _rec("face.recognition", True, kind="idle"),
+    ]
+    s = aggregate(recs, {}, confirm_min=3)["face.recognition"]
+    assert s.positive_count == 3 and s.idle_count == 2
+    assert s.registered_recall == 1.0
+    assert s.unknown_false_accept_rate == 0.5
+    assert s.wrong_person_count == 0
+
+
+def test_aggregate_wrong_person_counted_on_positive_round():
+    recs = [
+        _rec("face.recognition", True, kind="positive"),
+        _rec("face.recognition", False, ft=True, kind="positive"),
+    ]
+    s = aggregate(recs, {}, confirm_min=3)["face.recognition"]
+    assert s.wrong_person_count == 1
+    assert s.registered_recall == 0.5
+
+
+def test_snapshot_carries_claim_level_and_brain_allowed():
+    recs = [_rec("gesture.wave", True, lat=v) for v in (50, 100, 150, 200)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(
+        scores,
+        {
+            "git_commit": "abc",
+            "timestamp": "2026-05-31T00:00:00Z",
+            "run_trusted": True,
+        },
+    )
+    assert snap["git_commit"] == "abc"
+    cap = snap["capabilities"]["gesture.wave"]
+    assert cap["latency_p50"] is not None and cap["latency_p90"] is not None
+    assert cap["claim_level"] == "mainline"
+    assert cap["risk_role"] == "convenience"
+    assert cap["dependency_role"] == "trigger"
+    assert cap["brain_allowed"] is True
+
+
+def test_future_capability_not_brain_allowed_even_if_pass():
+    recs = [_rec("nav.dynamic_avoidance", True) for _ in range(4)]
+    crit = {"nav.dynamic_avoidance": [Criterion("success_rate", 0.9, 0.8)]}
+    scores = aggregate(recs, crit, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": True})
+    cap = snap["capabilities"]["nav.dynamic_avoidance"]
+    assert cap["brain_allowed"] is False
+
+
+def test_snapshot_always_lists_all_15_capabilities():
+    recs = [_rec("gesture.wave", True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": True})
+    assert len(snap["capabilities"]) == 15
+    untested = snap["capabilities"]["face.recognition"]
+    assert untested["grade"] == "insufficient_data"
+    assert untested["sample_count"] == 0
+    assert untested["success_rate"] is None
+    assert untested["brain_allowed"] is False
+    assert untested["dependency_role"] == "content"
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "pass"
+
+
+def test_missing_run_trusted_defaults_failclosed():
+    recs = [_rec("gesture.wave", True) for _ in range(5)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc"})
+    assert snap["capabilities"]["gesture.wave"]["grade"] == "insufficient_data"
+    assert all(c["grade"] == "insufficient_data" for c in snap["capabilities"].values())
+
+
+def test_layer0_preflight_fail_forces_all_insufficient():
+    recs = [_rec("gesture.wave", True) for _ in range(5)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    assert scores["gesture.wave"].grade == "pass"
+    snap = to_snapshot(
+        scores,
+        {
+            "git_commit": "abc",
+            "run_trusted": False,
+            "layer0_preflight_status": "fail",
+        },
+    )
+    cap = snap["capabilities"]["gesture.wave"]
+    assert cap["grade"] == "insufficient_data"
+    assert cap["brain_allowed"] is False
+    assert cap["failure_reason"] == "layer0_preflight=fail"
+    assert cap["success_rate"] is not None
+    assert all(c["grade"] == "insufficient_data" for c in snap["capabilities"].values())


### PR DESCRIPTION
## Linked issue

- [x] Closes #79
- [x] Refs #88

## Test command + output

```text
$ python3 -m pytest benchmarks/test/test_scoreboard.py benchmarks/test/test_build_scoreboard.py -q
11 passed
$ python3 -m pytest benchmarks/test/ -q
57 passed, 2 skipped   # 含 #71/#72
```

## Hardware needed

- [x] none
- [ ] Jetson
- [ ] Go2

## Evidence

- [x] log: 11/11 green（獨立複跑）。4 LOCK 直接驗證：default out=artifacts/baseline/baseline_snapshot.json、zero→15列(insufficient/None)、missing run_trusted→全 insufficient(fail-closed)、preflight fail→覆寫但保留 raw。
- [x] overclaim 防線：nav.safe_stop / brain.skill_gate 無記錄時自然吐 insufficient_data（無特例 code）。nav.dynamic_avoidance 量到 pass 仍 brain_allowed=False（future）。

## ⚠️ 2 處對 impl-plan skeleton 的偏離（reviewer 獨立抓出，皆有益）

1. **build_scoreboard 加 parent-dir mkdir guard**（plan 漏）→ 防 default `artifacts/baseline/` 不存在時 runbook step4 crash。
2. **DEFAULT_CRITERIA gesture/object 用 `false_trigger_rate`**（plan Task3b 寫 `unknown_false_accept_rate`）→ 必要：plan 的選擇會讓 plan 自己的 Task3b test（gesture 純 positive→預期 pass）fail（ufa=None→fail）。**provisional default，gesture/object false-accept 指標待 #82 baseline run（有 idle round）時與 spec §gesture/§object 對齊。**

## Out of scope

- [x] 不接 Brain runtime / effective_status（v0.2 #85）
- [x] 不寫 pawai readiness / freeze / /api/scoreboard（#87/#76）
- [x] 不產 ROS observer（#74/#75）

🤖 Generated with [Claude Code](https://claude.com/claude-code)