### PR TITLE
docs(hitl): #86 HITL verification protocol + artifact schemas + motion sign-off

### DIFF
--- a/.claude/schemas/baseline_snapshot.schema.json
+++ b/.claude/schemas/baseline_snapshot.schema.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pawai.local/schemas/baseline_snapshot.schema.json",
+  "title": "PawAI Capability Baseline Snapshot",
+  "description": "Schema for benchmarks.core.scoreboard.to_snapshot output. run_meta fields are flattened at the top level.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "run_trusted",
+    "capabilities"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "scoreboard-0.1"
+    },
+    "run_id": {
+      "type": "string"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "wsl_commit": {
+      "type": "string"
+    },
+    "git_commit": {
+      "type": "string"
+    },
+    "wsl_dirty": {
+      "type": "boolean"
+    },
+    "branch": {
+      "type": "string"
+    },
+    "jetson_install_sha": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "jetson_deploy_ts": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "jetson_sync_method": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "jetson_dirty": {
+      "type": "boolean"
+    },
+    "manifest_exists": {
+      "type": "boolean"
+    },
+    "version_mismatch": {
+      "type": "boolean"
+    },
+    "version_stale": {
+      "type": "boolean"
+    },
+    "layer0_preflight_status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "pass_with_warnings",
+        "fail",
+        "unknown"
+      ]
+    },
+    "run_trusted": {
+      "type": "boolean"
+    },
+    "demo_profile_env": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "capabilities": {
+      "type": "object",
+      "required": [
+        "face.recognition",
+        "voice.command",
+        "voice.stop",
+        "gesture.wave",
+        "object.cup",
+        "nav.safe_stop",
+        "nav.no_auto_resume",
+        "nav.short_move",
+        "nav.dynamic_avoidance",
+        "pose.basic",
+        "pose.fall",
+        "brain.skill_gate",
+        "brain.trace",
+        "studio.evidence",
+        "cli.readiness"
+      ],
+      "properties": {
+        "face.recognition": {
+          "$ref": "#/$defs/capability"
+        },
+        "voice.command": {
+          "$ref": "#/$defs/capability"
+        },
+        "voice.stop": {
+          "$ref": "#/$defs/capability"
+        },
+        "gesture.wave": {
+          "$ref": "#/$defs/capability"
+        },
+        "object.cup": {
+          "$ref": "#/$defs/capability"
+        },
+        "nav.safe_stop": {
+          "$ref": "#/$defs/capability"
+        },
+        "nav.no_auto_resume": {
+          "$ref": "#/$defs/capability"
+        },
+        "nav.short_move": {
+          "$ref": "#/$defs/capability"
+        },
+        "nav.dynamic_avoidance": {
+          "$ref": "#/$defs/capability"
+        },
+        "pose.basic": {
+          "$ref": "#/$defs/capability"
+        },
+        "pose.fall": {
+          "$ref": "#/$defs/capability"
+        },
+        "brain.skill_gate": {
+          "$ref": "#/$defs/capability"
+        },
+        "brain.trace": {
+          "$ref": "#/$defs/capability"
+        },
+        "studio.evidence": {
+          "$ref": "#/$defs/capability"
+        },
+        "cli.readiness": {
+          "$ref": "#/$defs/capability"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "capability": {
+      "type": "object",
+      "required": [
+        "capability_id",
+        "grade",
+        "sample_count",
+        "success_rate",
+        "false_trigger_rate",
+        "latency_p50",
+        "latency_p90",
+        "confirmed",
+        "positive_count",
+        "idle_count",
+        "registered_recall",
+        "unknown_false_accept_rate",
+        "wrong_person_count",
+        "claim_level",
+        "risk_role",
+        "depth",
+        "dependency_role",
+        "brain_allowed"
+      ],
+      "properties": {
+        "capability_id": {
+          "type": "string"
+        },
+        "grade": {
+          "type": "string",
+          "enum": [
+            "pass",
+            "degraded",
+            "fail",
+            "insufficient_data"
+          ]
+        },
+        "sample_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "success_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "false_trigger_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "latency_p50": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "latency_p90": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "confirmed": {
+          "type": "boolean"
+        },
+        "positive_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "idle_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "registered_recall": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "unknown_false_accept_rate": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "wrong_person_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "claim_level": {
+          "type": "string",
+          "enum": [
+            "mainline",
+            "future",
+            "studio_only",
+            "not_claimed"
+          ]
+        },
+        "risk_role": {
+          "type": "string",
+          "enum": [
+            "evidence_only",
+            "convenience",
+            "safety_critical",
+            "actuation",
+            "safety_support"
+          ]
+        },
+        "depth": {
+          "type": "string",
+          "enum": [
+            "deep",
+            "thin",
+            "future"
+          ]
+        },
+        "dependency_role": {
+          "type": "string",
+          "enum": [
+            "trigger",
+            "content",
+            "safety_guard",
+            "actuation",
+            "evidence"
+          ]
+        },
+        "brain_allowed": {
+          "type": "boolean"
+        },
+        "failure_reason": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/.claude/schemas/motion_sign_off.schema.json
+++ b/.claude/schemas/motion_sign_off.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pawai.local/schemas/motion_sign_off.schema.json",
+  "title": "PawAI Go2 Motion Sign-Off",
+  "description": "One append-only JSONL record for a Go2 motion HITL trial.",
+  "type": "object",
+  "required": [
+    "operator",
+    "timestamp",
+    "trial_id",
+    "commit_sha",
+    "safety_checks_passed",
+    "video_sha"
+  ],
+  "properties": {
+    "operator": {
+      "type": "string",
+      "minLength": 1
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "trial_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "commit_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{7,40}$"
+    },
+    "safety_checks_passed": {
+      "type": "boolean"
+    },
+    "video_sha": {
+      "type": "string",
+      "minLength": 1
+    }
+  },
+  "additionalProperties": false
+}

--- a/.claude/schemas/preflight_result.schema.json
+++ b/.claude/schemas/preflight_result.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pawai.local/schemas/preflight_result.schema.json",
+  "title": "PawAI Baseline Preflight Result",
+  "description": "Layer-0 preflight result consumed by current_run_meta(layer0_preflight=...). Only status is required by the scoreboard code.",
+  "type": "object",
+  "required": [
+    "status"
+  ],
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "pass",
+        "pass_with_warnings",
+        "fail"
+      ]
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/docs/agents/hitl-verification-protocol.md
+++ b/docs/agents/hitl-verification-protocol.md
@@ -1,0 +1,67 @@
+# HITL 驗證協定
+
+本文件定義 Issue #86 的 HITL 驗證與 artifact 版本化規則。範圍只含文件與 JSON Schema，不改 runtime code、不做 T3/T4 自動 CI gate、不做 artifact dashboard / web UI。
+
+## 外部邊界
+
+- #73 `demo.yaml`：Layer-0 preflight checks 的內容與 runner 由 #73 定義；本文件只消費其輸出 `artifacts/baseline/preflight_result.json`。
+- #87 freeze：frozen demo snapshot、readiness freeze 流程與 demo 當天讀取策略由 #87 定義；本文件只要求 sign-off 與 snapshot 綁定 commit。
+- SPEC §9：路徑與 readiness fail-closed 規則引用 `docs/pawai-brain/specs/2026-06-18-capability-baseline-spec.md:380` 到 `:420`，不在此重寫。
+
+## 驗證分級
+
+| 分級 | 何時需要 | 最小產物 |
+|---|---|---|
+| Jetson smoke | 涉及 Jetson runtime、ROS2 topic、D435、camera、mic、baseline observer、preflight 輸出或 Jetson 上的 `build_scoreboard` 產物 | `preflight_result.json`、`baseline_result.jsonl`、`baseline_snapshot.json`、logs 或 screenshots |
+| Go2 motion | 測試會送出或驗證 Go2 實體移動、停止、禁自動恢復、避障或任何 actuation 行為 | Jetson smoke 產物 + `motion_sign_offs.jsonl` + video evidence sha |
+
+不涉及硬體的純文件、schema、fixture 或 dry-run 驗證不需要 Jetson smoke。voice / face / gesture / object 的感知測試需要 Jetson smoke；只有當結果直接驅動 Go2 移動時，才升級成 Go2 motion。
+
+## 逐能力硬體對照
+
+| capability_id | 必要硬體 | 驗證分級 | Go2 motion sign-off |
+|---|---|---|---|
+| `face.recognition` | Jetson + D435 | Jetson smoke | 否 |
+| `voice.command` | Jetson + mic | Jetson smoke | 否 |
+| `voice.stop` | Jetson + mic | Jetson smoke；若用於實體停車 trial，跟隨 `nav.safe_stop` | 視 nav trial 而定 |
+| `gesture.wave` | Jetson + camera | Jetson smoke | 否 |
+| `object.cup` | Jetson + camera | Jetson smoke | 否 |
+| `nav.safe_stop` | Go2 + 安全場地 | Go2 motion | 是 |
+| `nav.no_auto_resume` | Go2 + 安全場地 | Go2 motion | 是 |
+| `nav.short_move` | Go2 + 安全場地 | Go2 motion | 是 |
+| `nav.dynamic_avoidance` | Go2 + 安全場地 | Go2 motion；future 能力若測才簽 | 是 |
+| `pose.basic` | Jetson + camera | Jetson smoke | 否 |
+| `pose.fall` | Jetson + camera | Jetson smoke；future 能力若測才產 evidence | 否 |
+| `brain.skill_gate` | Jetson + baseline snapshot / replay evidence | Jetson smoke 或 dry-run，依輸入來源 | 若 gate 放行 motion，簽在對應 nav trial |
+| `brain.trace` | Jetson / Studio evidence | Jetson smoke 或 dry-run，依輸入來源 | 否 |
+| `studio.evidence` | Studio + baseline snapshot | dry-run 或 Jetson smoke，依 snapshot 來源 | 否 |
+| `cli.readiness` | WSL + Jetson artifact 讀取 | Jetson smoke | 否 |
+
+## Go2 Motion Sign-Off
+
+`artifacts/baseline/motion_sign_offs.jsonl` 是 append-only JSONL。每一行代表一個 Go2 實體 motion trial 的人工安全簽核，必須符合 `.claude/schemas/motion_sign_off.schema.json`。
+
+簽核規則：
+
+- 誰簽：現場 operator 簽，`operator` 必須是可追溯的人名或帳號。
+- 何時簽：每次 Go2 motion trial 結束後、確認安全檢查通過與 video evidence 已保存後簽；失敗或不安全 trial 不拿來當 baseline pass evidence。
+- 簽在哪個 commit：`commit_sha` 必須是該 trial 實際部署在 Jetson / Go2 上的 commit。若 commit 變更，舊 sign-off 不得沿用。
+- 如何留痕：只 append 新行，不編輯、不刪除舊行；重新測試用新的 `trial_id` 與新的 sign-off 行。
+- 必要欄位：`operator`、`timestamp`、`trial_id`、`commit_sha`、`safety_checks_passed`、`video_sha`。
+
+sample 不放在 `artifacts/`，因為 `artifacts/` 被 `.gitignore` 忽略；git-tracked sample 位於 `docs/agents/samples/motion_sign_offs.sample.jsonl`。
+
+## Artifact Layout
+
+`artifacts/baseline/` 是 Jetson / WSL 量測產物目錄，不進 git。Issue #86 只定義 layout 與 schema；實際產出由各 baseline run、#73 preflight、#87 freeze 消費。
+
+| 路徑 | 內容 | schema |
+|---|---|---|
+| `artifacts/baseline/preflight_result.json` | #73 `demo.yaml` preflight 結果；至少含 `status` | `.claude/schemas/preflight_result.schema.json` |
+| `artifacts/baseline/baseline_result.jsonl` | 各能力 scenario-run 原始 JSONL | 由現有 benchmark record schema / observer 定義，本 issue 不新增 |
+| `artifacts/baseline/baseline_snapshot.json` | `benchmarks.core.scoreboard.to_snapshot()` 聚合結果；`run_meta` 欄位攤平成 top-level | `.claude/schemas/baseline_snapshot.schema.json` |
+| `artifacts/baseline/motion_sign_offs.jsonl` | Go2 motion HITL 簽核 append-only JSONL | `.claude/schemas/motion_sign_off.schema.json` |
+| `artifacts/baseline/logs/` | preflight、observer、scoreboard、Jetson smoke logs | N/A |
+| `artifacts/baseline/screenshots/` | Studio / Foxglove / terminal evidence 截圖 | N/A |
+
+`baseline_snapshot.json` 的版本綁定使用現有程式輸出的 `wsl_commit`、`jetson_install_sha`、`version_mismatch`、`version_stale`、`run_trusted`、`layer0_preflight_status`。dry-run 可額外帶 `git_commit`，但正式 readiness evidence 應以 `current_run_meta()` 產出的欄位為準。

--- a/docs/agents/samples/motion_sign_offs.sample.jsonl
+++ b/docs/agents/samples/motion_sign_offs.sample.jsonl
@@ -1,0 +1,1 @@
+{"operator":"roy","timestamp":"2026-06-02T12:00:00+08:00","trial_id":"nav-short-move-001","commit_sha":"e2f3c40b2d1f05c1be563cd2deeeaef31e1e8c90","safety_checks_passed":true,"video_sha":"sha256:4c8f9f0b9f0b7b0a2d6f7b4e2f4c6d8a9b1c3d5e7f90123456789abcdef012345"}


### PR DESCRIPTION
## Linked issue

- [x] Closes #86
- [x] Refs #89

## Test command + output

```text
# jsonschema 4.25.1 dry-run (independently re-verified):
FULL trusted snapshot (current_run_meta 16 fields) validate 通過
FAIL-CLOSED snapshot (run_trusted=False -> failure_reason) validate 通過
負面: bad grade 被 schema 擋 ✓
build_scoreboard 端到端產出檔 validate 通過
motion_sign_off: 6 欄齊 validate 通過; 缺 commit_sha -> raise ✓
```

## Hardware needed

- [x] none
- [ ] Jetson
- [ ] Go2

## Evidence

- [x] `docs/agents/hitl-verification-protocol.md` — 逐能力硬體對照 + Jetson-smoke/Go2-motion 分級 + sign-off(commit_sha 綁定) + artifacts/baseline layout。
- [x] `.claude/schemas/{baseline_snapshot,preflight_result,motion_sign_off}.schema.json` — baseline_snapshot 對齊 #79 to_snapshot（含 fail-closed failure_reason + 永遠 15 列），獨立驗證 full/fail-closed/負面 全過。
- [x] sample 放 `docs/agents/samples/`（artifacts/ 被 gitignore）。

## Out of scope

- [x] 不做 T3/T4 自動 CI gate（6/18 手動 checklist）/ dashboard / web UI。
- [x] 不重填 demo.yaml check 內容（屬 #73，只引用）。HITL 上機 sample 驗證待 baseline run。

🤖 Generated with [Claude Code](https://claude.com/claude-code)