### PR TITLE
docs(north-star): gate nav.safe_stop claim behind baseline pass (no overclaim)

### DIFF
--- a/docs/mission/2026-06-18-demo-north-star.md
+++ b/docs/mission/2026-06-18-demo-north-star.md
@@ -125,7 +125,7 @@ Go2 機體大、重（**十多公斤級，約 15–20kg**），**居家空間不
 - **voice.command**：固定指令輸入
 - **brain.skill_gate**：Brain 不亂執行不可靠能力（fail-closed）
 - **studio.evidence**：Studio 顯示每步證據（差異化全押可驗證，這是硬前提）
-- **nav.short_move + nav.safe_stop**：6/18 的具身證明——「機器狗非噱頭」靠這一條。完整自主導航、動態繞障、跟隨人**不屬於 6/18 主張**。（隱含前置：F7 `cmd_vel_nav` 不出的 root cause 須在 fresh stack 上定位；未定位前 nav 相關 claim 一律不講。）
+- **nav.short_move + nav.safe_stop**：6/18 具身證明的**目標**——「機器狗非噱頭」要靠這一條，但**baseline pass 後才宣稱**。完整自主導航、動態繞障、跟隨人**不屬於 6/18 主張**。（前置鎖：① F7 `cmd_vel_nav` 不出的 root cause 須在 fresh stack 上定位；② `nav.safe_stop` / `nav.no_auto_resume` 在 nav baseline run **pass（或明確人工安全 override）前，scoreboard 一律 `insufficient_data`**——未 pass 前文件 / demo 不得宣稱已具備安全停車或具身導航能力，nav 相關 claim 一律不講。）
 - **object.cup**：至少一類 demo 物件可靠辨識
 - **gesture.wave**：**P0 target / candidate**——需 baseline 驗證誤觸率後才鎖定（不寫「P0 必成」，否則與「先量化」矛盾）
 


### PR DESCRIPTION
## Linked issue

- [x] Refs #88（North Star overclaim 防線收尾）

## Test command + output

```text
N/A 純文件（docs only）
```

## Hardware needed

- [x] none
- [ ] Jetson
- [ ] Go2

## Evidence

- [x] §7 line 128 `nav.short_move + nav.safe_stop`：由斷言式「具身證明靠這一條」改為「目標、baseline pass 後才宣稱」+ 明確鎖（safe_stop/no_auto_resume baseline pass 前 scoreboard insufficient_data、未 pass 不得宣稱安全停車/具身導航）。
- [x] 另 2 主題 v2 已 hedge、未改：capability-health-gate（L167「capability_health 尚未存在不是現成品」）、fallback（L177「需 baseline 驗證後…不寫成已驗證完成品」）。
- [x] 與 spec §6 nav overclaim lock 對齊。

## Out of scope

- [x] 不動其他 mission 已確認決策（僅依 goal 收緊 overclaim 語氣）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)