### PR TITLE
feat(scoreboard): #74 perception baseline observer (gesture/object)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -64,6 +64,7 @@ jobs:
             benchmarks/test/test_grader.py \
             benchmarks/test/test_scoreboard.py \
             benchmarks/test/test_build_scoreboard.py \
+            benchmarks/test/test_perception_baseline_observer.py \
             -v --tb=short \
             --cov=speech_processor/speech_processor \
             --cov=vision_perception/vision_perception \

--- a/benchmarks/core/perception_baseline_observer.py
+++ b/benchmarks/core/perception_baseline_observer.py
@@ -1,0 +1,85 @@
+"""通用 perception baseline observer (v0.1, 選項 B)。
+
+純比對邏輯（dev-機 TDD）：把 operator 宣告的 round_meta（expected_label/scenario/distance）
+與該 round 內觀測到的 (label, confidence, ts) 比對，產一筆 CapabilityResult-shaped dict。
+idle round（expected_label in {"none",""}）：任何觀測 = false_trigger。
+positive round：observed 含 expected → pass（latency=首個命中相對 window_start）；否則 miss（fail）。
+
+ROS node wrapper（Jetson 跑，不在 CI）：訂 /event/{gesture_detected,object_detected}（face 見 Task 4b），
+依 round_meta 檔（operator 宣告每 round 的 capability/scenario/expected/window）切窗，
+把每 topic 正規化成 (label, confidence, ts) → evaluate_round → append JSONL。
+
+idle 切窗規則（spec §4/§5）：idle round 以**固定長度窗**為單位各生一筆 record（gesture=60s×10 段、
+object=60s/窗），每窗 `scenario_kind="idle"`、`false_trigger`=該窗內有無誤報；aggregator 的
+unknown_false_accept_rate = 誤觸窗數/總窗數。positive round 則每次「擺好→宣告→觀測」生一筆。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+_IDLE_LABELS = {"none", "idle", ""}
+
+
+@dataclass
+class RoundMeta:
+    capability_id: str
+    scenario_id: str
+    expected_label: str            # "none"/"" = idle round（預期零事件）
+    distance_m: Optional[float] = None
+    distance_source: str = "manual_declared"
+    window_start_ts: float = 0.0
+
+
+def evaluate_round(meta: RoundMeta, observations: list) -> dict:
+    """observations: list[(label:str, confidence:float|None, ts:float)]，限定該 round 窗內。"""
+    is_idle = meta.expected_label in _IDLE_LABELS
+
+    if is_idle:
+        ft = len(observations) > 0
+        predicted = observations[0][0] if observations else "none"
+        return _record(meta, predicted_label=predicted,
+                       pass_fail=("fail" if ft else "pass"),
+                       false_trigger=ft, confidence=None, latency_ms=None)
+
+    # positive round
+    matches = [o for o in observations if o[0] == meta.expected_label]
+    if matches:
+        label, conf, ts = matches[0]
+        return _record(meta, predicted_label=label, pass_fail="pass", false_trigger=False,
+                       confidence=conf, latency_ms=(ts - meta.window_start_ts) * 1000.0)
+    # miss（沒看到 expected）：認錯或沒看到都算 miss，不是 false_trigger
+    predicted = observations[0][0] if observations else "none"
+    return _record(meta, predicted_label=predicted, pass_fail="fail", false_trigger=False,
+                   confidence=None, latency_ms=None)
+
+
+def _record(meta: RoundMeta, *, predicted_label: str, pass_fail: str,
+            false_trigger: bool, confidence: Optional[float], latency_ms: Optional[float]) -> dict:
+    return {
+        "capability_id": meta.capability_id,
+        "scenario_id": meta.scenario_id,
+        # F2：scenario_kind 供 aggregate 分離算 recall vs false-accept（idle round=預期零事件）
+        "scenario_kind": "idle" if meta.expected_label in _IDLE_LABELS else "positive",
+        "expected_label": meta.expected_label,
+        "predicted_label": predicted_label,
+        "pass_fail": pass_fail,
+        "false_trigger": false_trigger,
+        "confidence": confidence,
+        "latency_ms": latency_ms,
+        "distance_m": meta.distance_m,
+        "distance_source": meta.distance_source,
+    }
+
+
+def count_false_triggers(round_records: list[dict]) -> int:
+    return sum(1 for r in round_records if r.get("false_trigger"))
+
+
+# --- ROS node wrapper（Jetson 跑，v0.1 不在 CI；保持薄）---
+# class PerceptionBaselineObserver(Node):
+#   - 訂 /event/gesture_detected, /event/object_detected（face 見 Task 4b）
+#   - _normalize(topic, msg) -> list[(label, confidence, ts)]
+#   - 依 round_meta 檔（operator 宣告 capability/scenario/expected/window_start/window_end）切窗
+#   - round 結束時 evaluate_round(meta, obs) → 補 run_id/timestamp/git_commit（current_run_meta）
+#     → CapabilityResult(...).to_record() → append baseline_result.jsonl

--- a/benchmarks/test/test_perception_baseline_observer.py
+++ b/benchmarks/test/test_perception_baseline_observer.py
@@ -1,0 +1,56 @@
+from benchmarks.core.perception_baseline_observer import (
+    RoundMeta, evaluate_round, count_false_triggers,
+)
+
+
+def test_idle_round_no_observation_is_pass_no_false_trigger():
+    meta = RoundMeta("gesture.wave", "idle_hand_60s", expected_label="none", window_start_ts=100.0)
+    rec = evaluate_round(meta, observations=[])
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["predicted_label"] == "none"
+
+
+def test_idle_round_with_observation_is_false_trigger_fail():
+    meta = RoundMeta("gesture.wave", "idle_hand_60s", expected_label="none", window_start_ts=100.0)
+    rec = evaluate_round(meta, observations=[("wave", 1.0, 103.0)])
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is True
+    assert rec["predicted_label"] == "wave"
+
+
+def test_positive_round_matched_is_pass_with_latency():
+    meta = RoundMeta("gesture.wave", "wave_1.5m", expected_label="wave",
+                     distance_m=1.5, window_start_ts=100.0)
+    rec = evaluate_round(meta, observations=[("wave", 1.0, 100.4)])
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["predicted_label"] == "wave"
+    assert abs(rec["latency_ms"] - 400.0) < 1e-6
+    assert rec["distance_m"] == 1.5
+
+
+def test_positive_round_no_observation_is_miss_not_false_trigger():
+    meta = RoundMeta("object.cup", "cup_1.5m", expected_label="cup", window_start_ts=0.0)
+    rec = evaluate_round(meta, observations=[])
+    assert rec["pass_fail"] == "fail"          # miss
+    assert rec["false_trigger"] is False       # 漏報不是誤觸
+    assert rec["predicted_label"] == "none"
+
+
+def test_positive_round_wrong_label_is_miss_not_false_trigger():
+    meta = RoundMeta("object.cup", "cup_1.5m", expected_label="cup", window_start_ts=0.0)
+    rec = evaluate_round(meta, observations=[("bottle", 0.7, 1.0)])
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is False       # 認錯類別算 miss，誤觸只用於 idle round
+    assert rec["predicted_label"] == "bottle"
+
+
+def test_count_false_triggers_over_idle_rounds():
+    rounds = [
+        evaluate_round(RoundMeta("gesture.wave", "idle", "none", window_start_ts=0.0),
+                       observations=[]),
+        evaluate_round(RoundMeta("gesture.wave", "idle", "none", window_start_ts=0.0),
+                       observations=[("point", 0.8, 1.0)]),
+    ]
+    assert count_false_triggers(rounds) == 1


### PR DESCRIPTION
## Linked issue

- [x] Closes #74
- [x] Refs #88

## Test command + output

```text
$ python3 -m pytest benchmarks/test/test_perception_baseline_observer.py -q
6 passed
# invocation-1 benchmarks block incl new test: 40 passed (default mode)
```

## Hardware needed

- [x] none

## Evidence

- [x] RoundMeta + evaluate_round（idle: 任何 obs→false_trigger/fail；positive: 命中→pass+latency、miss→fail 非 false_trigger）+ count_false_triggers + scenario_kind（供 #79 recall/false-accept 分離）。
- [x] CI-safe：module 無 top-level rclpy（ROS node 為註解 sketch，v0.1 不在 CI）。已接進 Fast Gate invocation 1（benchmarks.test，無撞名）。
- [x] face 不在此（#75 / Task 4b，走 state 流）。

## Out of scope

- [x] 不做 face observer（#75）；不改感知 node、不接 Brain；ROS node wrapper 留薄 sketch。

🤖 Generated with [Claude Code](https://claude.com/claude-code)