### PR TITLE
feat(scoreboard): #75 face baseline observer (state stream)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -65,6 +65,7 @@ jobs:
             benchmarks/test/test_scoreboard.py \
             benchmarks/test/test_build_scoreboard.py \
             benchmarks/test/test_perception_baseline_observer.py \
+            benchmarks/test/test_face_baseline_observer.py \
             -v --tb=short \
             --cov=speech_processor/speech_processor \
             --cov=vision_perception/vision_perception \

--- a/benchmarks/core/face_baseline_observer.py
+++ b/benchmarks/core/face_baseline_observer.py
@@ -1,0 +1,128 @@
+"""Face baseline observer pure logic for /state/perception/face streams.
+
+The face benchmark is intentionally split from the gesture/object event observer.
+Face identity events only emit stable transitions, so this module evaluates the
+continuous face state stream where each snapshot contains all current tracks.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+_IDLE_LABELS = {"unknown", "none", "idle", ""}
+
+
+@dataclass
+class FaceStateSnapshot:
+    ts: float
+    tracks: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class FaceRoundMeta:
+    capability_id: str
+    scenario_id: str
+    expected_label: str
+    distance_m: float | None = None
+    distance_source: str = "manual_declared"
+    window_start_ts: float = 0.0
+
+
+def _known_tracks(snap: FaceStateSnapshot) -> list[dict[str, Any]]:
+    return [track for track in snap.tracks if track.get("stable_name", "unknown") != "unknown"]
+
+
+def evaluate_face_round(meta: FaceRoundMeta, snapshots: list[FaceStateSnapshot]) -> dict[str, Any]:
+    is_idle = meta.expected_label in _IDLE_LABELS
+
+    if is_idle:
+        for snap in snapshots:
+            known = _known_tracks(snap)
+            if known:
+                track = known[0]
+                return _face_record(
+                    meta,
+                    predicted_label=track["stable_name"],
+                    pass_fail="fail",
+                    false_trigger=True,
+                    confidence=track.get("sim"),
+                    distance_m=track.get("distance_m"),
+                )
+
+        return _face_record(
+            meta,
+            predicted_label="unknown",
+            pass_fail="pass",
+            false_trigger=False,
+            confidence=None,
+            distance_m=None,
+        )
+
+    for snap in snapshots:
+        for track in snap.tracks:
+            if track.get("stable_name") == meta.expected_label:
+                return _face_record(
+                    meta,
+                    predicted_label=meta.expected_label,
+                    pass_fail="pass",
+                    false_trigger=False,
+                    confidence=track.get("sim"),
+                    distance_m=track.get("distance_m"),
+                    latency_ms=(snap.ts - meta.window_start_ts) * 1000.0,
+                )
+
+    for snap in snapshots:
+        known = _known_tracks(snap)
+        if known:
+            track = known[0]
+            return _face_record(
+                meta,
+                predicted_label=track["stable_name"],
+                pass_fail="fail",
+                false_trigger=True,
+                confidence=track.get("sim"),
+                distance_m=track.get("distance_m"),
+            )
+
+    return _face_record(
+        meta,
+        predicted_label="unknown",
+        pass_fail="fail",
+        false_trigger=False,
+        confidence=None,
+        distance_m=None,
+    )
+
+
+def _face_record(
+    meta: FaceRoundMeta,
+    *,
+    predicted_label: str,
+    pass_fail: str,
+    false_trigger: bool,
+    confidence: float | None,
+    distance_m: float | None,
+    latency_ms: float | None = None,
+) -> dict[str, Any]:
+    return {
+        "capability_id": meta.capability_id,
+        "scenario_id": meta.scenario_id,
+        "scenario_kind": "idle" if meta.expected_label in _IDLE_LABELS else "positive",
+        "expected_label": meta.expected_label,
+        "predicted_label": predicted_label,
+        "pass_fail": pass_fail,
+        "false_trigger": false_trigger,
+        "confidence": round(confidence, 4) if confidence is not None else None,
+        "latency_ms": latency_ms,
+        "distance_m": distance_m if distance_m is not None else meta.distance_m,
+        "distance_source": "d435_depth" if distance_m is not None else meta.distance_source,
+    }
+
+
+# --- ROS node wrapper sketch (Jetson runtime; not implemented in CI) ---
+# class FaceBaselineObserver(Node):
+#   - subscribe to /state/perception/face and parse each tick into FaceStateSnapshot
+#   - collect snapshots inside the operator-declared round window
+#   - call evaluate_face_round(meta, snapshots) when the round ends
+#   - enrich the record with run_id/timestamp/git_commit before appending JSONL output
+#   * Keep this wrapper thin; do not change face_identity_node and do not connect Brain here.

--- a/benchmarks/test/test_face_baseline_observer.py
+++ b/benchmarks/test/test_face_baseline_observer.py
@@ -1,0 +1,148 @@
+from benchmarks.core.face_baseline_observer import (
+    FaceRoundMeta,
+    FaceStateSnapshot,
+    evaluate_face_round,
+)
+
+
+def _snap(ts, tracks):
+    return FaceStateSnapshot(ts=ts, tracks=tracks)
+
+
+def test_idle_round_with_known_person_is_false_trigger():
+    meta = FaceRoundMeta(
+        "face.recognition",
+        "idle_unknown_1.5m",
+        expected_label="unknown",
+        distance_m=1.5,
+        window_start_ts=100.0,
+    )
+    snaps = [
+        _snap(
+            101.0,
+            [
+                {
+                    "track_id": 1,
+                    "stable_name": "roy",
+                    "sim": 0.9,
+                    "distance_m": 1.5,
+                    "mode": "stable",
+                }
+            ],
+        )
+    ]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is True
+    assert rec["predicted_label"] == "roy"
+
+
+def test_idle_round_only_unknown_tracks_is_pass():
+    meta = FaceRoundMeta(
+        "face.recognition",
+        "idle_unknown_1.5m",
+        expected_label="unknown",
+        window_start_ts=100.0,
+    )
+    snaps = [
+        _snap(
+            101.0,
+            [
+                {
+                    "track_id": 1,
+                    "stable_name": "unknown",
+                    "sim": 0.2,
+                    "distance_m": 1.5,
+                    "mode": "hold",
+                }
+            ],
+        )
+    ]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+
+
+def test_positive_round_correct_match_is_pass_with_distance():
+    meta = FaceRoundMeta(
+        "face.recognition",
+        "known_roy_1.5m",
+        expected_label="roy",
+        distance_m=1.5,
+        window_start_ts=100.0,
+    )
+    snaps = [
+        _snap(
+            100.5,
+            [
+                {
+                    "track_id": 1,
+                    "stable_name": "roy",
+                    "sim": 0.92,
+                    "distance_m": 1.48,
+                    "mode": "stable",
+                }
+            ],
+        )
+    ]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "pass"
+    assert rec["false_trigger"] is False
+    assert rec["confidence"] == 0.92
+    assert rec["distance_m"] == 1.48
+    assert rec["distance_source"] == "d435_depth"
+
+
+def test_positive_round_miss_is_fail_not_false_trigger():
+    meta = FaceRoundMeta(
+        "face.recognition",
+        "known_roy_3m",
+        expected_label="roy",
+        distance_m=3.0,
+        window_start_ts=100.0,
+    )
+    snaps = [
+        _snap(
+            101.0,
+            [
+                {
+                    "track_id": 1,
+                    "stable_name": "unknown",
+                    "sim": 0.3,
+                    "distance_m": 3.0,
+                    "mode": "hold",
+                }
+            ],
+        )
+    ]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is False
+
+
+def test_positive_round_wrong_person_is_false_accept():
+    meta = FaceRoundMeta(
+        "face.recognition",
+        "known_roy_1.5m",
+        expected_label="roy",
+        distance_m=1.5,
+        window_start_ts=100.0,
+    )
+    snaps = [
+        _snap(
+            101.0,
+            [
+                {
+                    "track_id": 1,
+                    "stable_name": "alice",
+                    "sim": 0.88,
+                    "distance_m": 1.5,
+                    "mode": "stable",
+                }
+            ],
+        )
+    ]
+    rec = evaluate_face_round(meta, snaps)
+    assert rec["pass_fail"] == "fail"
+    assert rec["false_trigger"] is True
+    assert rec["predicted_label"] == "alice"


### PR DESCRIPTION
## Linked issue

- [x] Closes #75
- [x] Refs #88

## Test command + output

```text
$ python3 -m pytest benchmarks/test/test_face_baseline_observer.py -q
5 passed
# full benchmarks: 73 passed, 2 skipped
```

## Hardware needed

- [x] none

## Evidence

- [x] evaluate_face_round (state-stream)：idle→任一註冊者 stable = false_trigger；positive→命中 pass(sim+d435_depth)、認錯人 false_accept、只 unknown/no-track miss(非 false_trigger)；scenario_kind 供 #79 分離。
- [x] 獨立驗證：wrong-person→fail/false_trigger/alice；命中→d435_depth/latency 500ms。CI-safe（無 top-level rclpy，ROS node 註解 sketch）。已接進 Fast Gate。
- [x] face 走 state 流（非 event）因 /event/face_identity 從不發 unknown。

## Out of scope

- [x] 不做 gesture/object（#74）；不改 face_identity_node、不接 Brain；ROS node wrapper 留薄 sketch。

🤖 Generated with [Claude Code](https://claude.com/claude-code)