### PR TITLE
docs: sync baseline scoreboard implementation status (6/2-6/3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -421,7 +421,7 @@ ln -sf ../../scripts/hooks/git-pre-commit.sh .git/hooks/pre-commit
 
 - **Claude Code hooks**：Edit/Write 後即時 py_compile + commit 時 colcon build 提醒
 - **Git pre-commit**：commit 時 py_compile + contract check + smart-scope tests
-- **GitHub Actions**：push/PR 時 flake8 + 16 test files + contract check（blocking）+ colcon build
+- **GitHub Actions**：push/PR 時 Fast Gate（flake8 report-only + 新 core code blocking flake8 + pure-Python tests：speech/vision/benchmarks **+ scoreboard core + pawai_brain**，兩 invocation 避 `test` package 撞名）+ test_environment + contract check（blocking）+ colcon build
 
 ### 雙平台架構
 

--- a/docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md
+++ b/docs/pawai-brain/plans/2026-06-01-scoreboard-implementation-plan.md
@@ -1,5 +1,7 @@
 # Scoreboard Implementation Plan（TDD，給工程師照做）
 
+> **✅ 實作狀態（2026-06-03）**：核心 deliverable 全部實作 + merged 進 main。Task 1 schema(#71, PR #92) / Task 2 grader(#72, #93) / Task 3 aggregator(#79, #94) / Task 3b build_scoreboard(#79, #94) / Task 4 perception_baseline_observer(#74, #98) / Task 4b face_baseline_observer(#75, #99) 全綠進 Fast Gate CI。另 readiness verdict + freeze（#87, PR #100，`benchmarks/core/readiness.py` + `pawai readiness` CLI）已 merged。**ROS node wrapper（Task 4/4b 的 Jetson 端）維持薄 sketch、v0.1 不在 CI**；actual baseline run（產真 JSONL）是 HITL（#80-#84）。下方 checkbox 為原始 TDD 指引、保留作參考。
+
 > **For agentic workers:** REQUIRED SUB-SKILL: 用 superpowers:subagent-driven-development 或 executing-plans 逐 task 實作。Steps use checkbox (`- [ ]`) syntax。
 > **性質**：6 個 deliverable 的 TDD skeleton（test→impl→commit）。這份是「**怎麼寫 code**」的唯一真相源。
 > **不放**：架構決策（見 Master Plan）、逐功能門檻（見 Capability Baseline Spec）、上機步驟（見 Runbook）。


### PR DESCRIPTION
## Linked issue

- [x] Refs #88（baseline 實作收工 docs sync）

## Test command + output

```text
N/A 純文件
```

## Hardware needed

- [x] none

## Evidence

- [x] impl plan: 加實作狀態 banner（Task 1/2/3/3b/4/4b + readiness 全 merged，PR #92-#100）。
- [x] CLAUDE.md: 更新過時 CI 行（Fast Gate 現含 scoreboard core + pawai_brain 兩 invocation + blocking flake8）。

## Out of scope

- [x] 不碰 references/project-status.md（main 版停在 5-15、nav workstream 在 feat 持續更新它，加 baseline 段會製造 merge 衝突；今天進度已記在 GitHub issues + plans + 記憶檔）。
- [x] 不碰 mission/README、interaction_contract（凍結）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)