### PR TITLE
feat(baseline): #73-A Layer-0 preflight gate (demo.yaml + run_preflight wrapper)

### DIFF
--- a/.claude/skills/jetson-verify/profiles/demo.yaml
+++ b/.claude/skills/jetson-verify/profiles/demo.yaml
@@ -1,5 +1,73 @@
-# TODO: v2 — demo readiness checklist, go/no-go report
-# This profile is intentionally empty. verify.py will refuse to run it.
 profile: demo
-description: "展示前 readiness check"
-checks: []
+description: "Layer-0 baseline preflight：展示前 hard-blocker gate"
+min_checks: 1
+
+checks:
+  # -- 第一組：連線與 demo 入口（硬性阻擋）--
+
+  - id: jetson.ssh_reachable
+    command: "echo ok"
+    expect: "nonempty"
+    blocking: true
+    timeout_sec: 5
+    message_template: "Jetson SSH 可達：{value}"
+
+  - id: go2.ethernet_ping
+    command: "ping -c1 -W1 192.168.123.161 >/dev/null 2>&1 && echo 1 || echo 0"
+    expect: ">= 1"
+    blocking: true
+    timeout_sec: 5
+    message_template: "Go2 乙太網路連線狀態：{value}（需要 1）"
+
+  - id: demo.entrypoint_started
+    command: "tmux has-session -t demo 2>/dev/null && echo 1 || echo 0"
+    expect: ">= 1"
+    blocking: true
+    timeout_sec: 5
+    message_template: "Demo tmux session 狀態：{value}（需要 demo）"
+
+  # -- 第二組：ROS2 與 Go2 執行期（硬性阻擋）--
+
+  - id: ros.runtime_started
+    command: "source /opt/ros/humble/setup.bash && source install/setup.bash && ros2 node list 2>/dev/null | wc -l"
+    expect: ">= 5"
+    blocking: true
+    timeout_sec: 15
+    message_template: "{value} 個 ROS2 nodes 已啟動（至少 5）"
+
+  - id: go2.driver_alive
+    command: "source /opt/ros/humble/setup.bash && source install/setup.bash && ros2 node list 2>/dev/null | grep -c go2_driver || true"
+    expect: ">= 1"
+    blocking: true
+    timeout_sec: 15
+    message_template: "go2_driver 節點數：{value}（至少 1）"
+
+  - id: topic_contract_ok
+    command: "source /opt/ros/humble/setup.bash && source install/setup.bash && ros2 topic list 2>/dev/null | wc -l"
+    expect: ">= 20"
+    blocking: false
+    timeout_sec: 15
+    message_template: "{value} 個 ROS2 topics 已發現（建議至少 20）"
+
+  # -- 第三組：系統狀態與部署證據 --
+
+  - id: system.memory
+    command: "awk '/MemAvailable:/ {print int($2/1024)}' /proc/meminfo"
+    expect: ">= 800"
+    blocking: true
+    timeout_sec: 5
+    message_template: "{value}MB 可用記憶體（至少 800MB）"
+
+  - id: system.gpu_temp
+    command: "cat /sys/devices/virtual/thermal/thermal_zone1/temp 2>/dev/null | awk '{print int($1/1000)}'"
+    expect: "<= 70"
+    blocking: false
+    timeout_sec: 5
+    message_template: "GPU {value}°C（警告門檻 >70°C）"
+
+  - id: version_snapshot
+    command: "cat ~/elder_and_dog/.pawai-last-deploy 2>/dev/null | wc -c"
+    expect: ">= 1"
+    blocking: false
+    timeout_sec: 5
+    message_template: "deploy manifest 大小：{value} bytes"

--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -67,6 +67,7 @@ jobs:
             benchmarks/test/test_perception_baseline_observer.py \
             benchmarks/test/test_face_baseline_observer.py \
             benchmarks/test/test_readiness.py \
+            benchmarks/test/test_run_preflight.py \
             -v --tb=short \
             --cov=speech_processor/speech_processor \
             --cov=vision_perception/vision_perception \

--- a/benchmarks/scripts/run_preflight.py
+++ b/benchmarks/scripts/run_preflight.py
@@ -1,0 +1,107 @@
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+
+def classify_status(overall: str, warn_count: int) -> str:
+    if overall == "PASS" and warn_count == 0:
+        return "pass"
+    if overall == "PASS" and warn_count > 0:
+        return "pass_with_warnings"
+    if overall in {"FAIL", "ERROR"}:
+        return "fail"
+    raise ValueError(f"未知的 verify overall：{overall!r}")
+
+
+def build_preflight_result(report: dict, version_snapshot: str | None,
+                           verify_report_path: str) -> dict:
+    summary = report.get("summary", {})
+    return {
+        "status": classify_status(report["overall"], int(summary.get("warn", 0))),
+        "checks": report.get("checks", []),
+        "details": {
+            "overall": report["overall"],
+            "summary": summary,
+            "version_snapshot": version_snapshot,
+            "verify_report_path": verify_report_path,
+        },
+    }
+
+
+def read_version_snapshot(repo: Path, manifest_arg: str | None) -> str | None:
+    env_manifest = os.environ.get("PAWAI_DEPLOY_MANIFEST")
+    if manifest_arg:
+        candidates = [Path(manifest_arg).expanduser()]
+    elif env_manifest:
+        candidates = [Path(env_manifest).expanduser()]
+    else:
+        candidates = [Path("~/elder_and_dog/.pawai-last-deploy").expanduser(),
+                      repo / ".pawai-last-deploy"]
+    for path in candidates:
+        try:
+            return path.read_text(encoding="utf-8")
+        except OSError:
+            pass
+    return None
+
+
+def parse_verify_stdout(stdout: str) -> dict:
+    try:
+        report = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"verify.py stdout 不是合法 JSON：{exc}") from exc
+    overall = report.get("overall")
+    if overall not in {"PASS", "FAIL", "ERROR"}:
+        raise RuntimeError(f"verify.py report overall 不合法：{overall!r}")
+    if not isinstance(report.get("summary"), dict) or not isinstance(report.get("checks"), list):
+        raise RuntimeError("verify.py report 缺少 summary 或 checks")
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="產生 PawAI baseline Layer-0 preflight 結果")
+    parser.add_argument("--out", default="artifacts/baseline/preflight_result.json")
+    parser.add_argument("--profile", default="demo")
+    parser.add_argument("--skill-dir")
+    parser.add_argument("--manifest")
+    args = parser.parse_args()
+
+    repo = Path(__file__).resolve().parents[2]
+    skill_dir = Path(args.skill_dir).resolve() if args.skill_dir else repo / ".claude/skills/jetson-verify"
+    verify_py = skill_dir / "scripts/verify.py"
+    log_dir = Path("artifacts/baseline/logs")
+    completed = subprocess.run(
+        ["python3", str(verify_py), "--profile", args.profile, "--output-dir", str(log_dir)],
+        cwd=repo, capture_output=True, text=True, check=False,
+    )
+    if completed.stderr:
+        sys.stderr.write(completed.stderr)
+
+    try:
+        result = build_preflight_result(
+            parse_verify_stdout(completed.stdout),
+            read_version_snapshot(repo, args.manifest),
+            str(log_dir / "latest.json"),
+        )
+        schema_path = repo / ".claude/schemas/preflight_result.schema.json"
+        validate(instance=result, schema=json.loads(schema_path.read_text(encoding="utf-8")))
+    except (RuntimeError, ValidationError, OSError, ValueError) as exc:
+        print(f"ERROR: preflight_result 驗證失敗：{exc}", file=sys.stderr)
+        return 2
+
+    out_path = Path(args.out)
+    out_path = out_path if out_path.is_absolute() else repo / out_path
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0 if result["status"] in {"pass", "pass_with_warnings"} else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/test/test_run_preflight.py
+++ b/benchmarks/test/test_run_preflight.py
@@ -1,0 +1,44 @@
+import importlib.util
+import json
+from pathlib import Path
+
+from jsonschema import validate
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "benchmarks/scripts/run_preflight.py"
+SCHEMA_PATH = REPO_ROOT / ".claude/schemas/preflight_result.schema.json"
+
+
+def _load_run_preflight():
+    spec = importlib.util.spec_from_file_location("run_preflight", SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_classify_status_all_branches():
+    run_preflight = _load_run_preflight()
+    assert run_preflight.classify_status("PASS", 0) == "pass"
+    assert run_preflight.classify_status("PASS", 2) == "pass_with_warnings"
+    assert run_preflight.classify_status("FAIL", 0) == "fail"
+    assert run_preflight.classify_status("ERROR", 0) == "fail"
+
+
+def test_mock_preflight_result_validates_against_schema():
+    run_preflight = _load_run_preflight()
+    report = {
+        "overall": "PASS",
+        "summary": {"pass": 2, "warn": 1, "fail": 0, "skip": 0, "error": 0},
+        "checks": [
+            {"id": "jetson.ssh_reachable", "status": "PASS", "blocking": True},
+            {"id": "topic_contract_ok", "status": "WARN", "blocking": False},
+        ],
+    }
+    result = run_preflight.build_preflight_result(
+        report,
+        version_snapshot='{"git_sha_full":"abc123"}',
+        verify_report_path="artifacts/baseline/logs/latest.json",
+    )
+    schema = json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+    validate(instance=result, schema=schema)


### PR DESCRIPTION
## 來由
Issue #73 的 **#73-A（AFK 可跑性）階段**：把 `jetson-verify` 的 `demo.yaml` 從空 stub（`checks: []`）填成 Layer-0 preflight gate，並加薄 wrapper 產出 `preflight_result.json`。#73-B（Jetson 上驗三態 + 斷 ethernet fail-closed）另行上機。

## 改動
- **`.claude/skills/jetson-verify/profiles/demo.yaml`**：9 個 Layer-0 checks（複用既有 `verify.py` runner，**不自寫 check runner**）
  - hard-blocker：`jetson.ssh_reachable` / `go2.ethernet_ping` / `demo.entrypoint_started`(真實 tmux session 名 `demo`) / `ros.runtime_started` / `go2.driver_alive` / `system.memory`
  - WARN（off-path）：`topic_contract_ok` / `system.gpu_temp` / `version_snapshot`
- **`benchmarks/scripts/run_preflight.py`**：呼叫 verify.py → `classify_status` 映射 `PASS&warn=0→pass` / `PASS&warn>0→pass_with_warnings` / `FAIL|ERROR→fail` → 寫 `artifacts/baseline/preflight_result.json`（jsonschema 對 `.claude/schemas/preflight_result.schema.json` 驗證）。exit 0=pass/pwW、1=fail、2=驗證錯。
- **`benchmarks/test/test_run_preflight.py`**：純函式測試（classify_status 全分支 + mock report schema 驗證），接進 `ros_build.yaml` Fast Gate 白名單。

## fail-closed 串接（#73-B 上機驗）
`go2.ethernet_ping` / `demo.entrypoint_started` 為 blocking → 斷 Go2 ethernet 或無 demo session → verify FAIL → `status=fail` → `build_scoreboard --preflight <fail>.json` → snapshot 全 15 能力 `insufficient_data`。

## 驗證
- `pytest benchmarks/test/` → 88 passed, 2 skipped（含新 test_run_preflight 2 + P5 共存）
- CI-mode `PYTHONPATH=...:benchmarks` → 綠
- py_compile OK
- 未對真實 Jetson 跑（那是 #73-B HITL）

## scope guard
不自寫 check runner、不改 verify.py/transport.py、不碰 Brain/Studio/模型。

Closes #73 的 A 階段（issue 待 #73-B HITL 後關）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)