### PR TITLE
fix(baseline): #82-prep align gesture/object false-accept to idle-only unknown_false_accept_rate

### DIFF
--- a/benchmarks/core/build_scoreboard.py
+++ b/benchmarks/core/build_scoreboard.py
@@ -23,11 +23,13 @@ DEFAULT_CRITERIA: dict[str, list[Criterion]] = {
     ],
     "gesture.wave": [
         Criterion("success_rate", 0.90, 0.80, higher_is_better=True),
-        Criterion("false_trigger_rate", 0.10, 0.30, higher_is_better=False),
+        # 規格 §4：手勢 idle 誤觸只看 scenario_kind=idle 的 unknown_false_accept_rate。
+        Criterion("unknown_false_accept_rate", 0.10, 0.30, higher_is_better=False),
     ],
     "object.cup": [
         Criterion("success_rate", 0.80, 0.60, higher_is_better=True),
-        Criterion("false_trigger_rate", 0.01, 0.10, higher_is_better=False),
+        # 規格 §5：物件 idle 誤觸只看 scenario_kind=idle 的 unknown_false_accept_rate。
+        Criterion("unknown_false_accept_rate", 0.01, 0.10, higher_is_better=False),
     ],
 }
 

--- a/benchmarks/test/test_build_scoreboard.py
+++ b/benchmarks/test/test_build_scoreboard.py
@@ -9,23 +9,40 @@ def _write_jsonl(path, rows):
             f.write(json.dumps(row) + "\n")
 
 
+def _positive_round(capability_id, latency_ms=100):
+    return {
+        "capability_id": capability_id,
+        "pass_fail": "pass",
+        "false_trigger": False,
+        "latency_ms": latency_ms,
+        "scenario_kind": "positive",
+    }
+
+
+def _idle_round(capability_id, false_trigger=False):
+    return {
+        "capability_id": capability_id,
+        "pass_fail": "pass",
+        "false_trigger": false_trigger,
+        "latency_ms": None,
+        "scenario_kind": "idle",
+    }
+
+
+def _trusted_preflight(path):
+    preflight = path / "preflight.json"
+    preflight.write_text(json.dumps({"status": "pass"}), encoding="utf-8")
+    return preflight
+
+
 def test_build_scoreboard_preflight_pass_produces_snapshot(tmp_path):
     jsonl = tmp_path / "baseline_result.jsonl"
     _write_jsonl(
         jsonl,
-        [
-            {
-                "capability_id": "gesture.wave",
-                "pass_fail": "pass",
-                "false_trigger": False,
-                "latency_ms": 100,
-                "scenario_kind": "positive",
-            }
-            for _ in range(3)
-        ],
+        [_positive_round("gesture.wave") for _ in range(3)]
+        + [_idle_round("gesture.wave") for _ in range(2)],
     )
-    preflight = tmp_path / "preflight.json"
-    preflight.write_text(json.dumps({"status": "pass"}), encoding="utf-8")
+    preflight = _trusted_preflight(tmp_path)
     out = tmp_path / "snap.json"
     build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
     snap = json.loads(out.read_text(encoding="utf-8"))
@@ -38,19 +55,47 @@ def test_build_scoreboard_missing_preflight_is_failclosed(tmp_path):
     jsonl = tmp_path / "baseline_result.jsonl"
     _write_jsonl(
         jsonl,
-        [
-            {
-                "capability_id": "gesture.wave",
-                "pass_fail": "pass",
-                "false_trigger": False,
-                "latency_ms": 100,
-                "scenario_kind": "positive",
-            }
-            for _ in range(3)
-        ],
+        [_positive_round("gesture.wave") for _ in range(3)]
+        + [_idle_round("gesture.wave") for _ in range(2)],
     )
     out = tmp_path / "snap.json"
     build_scoreboard(str(jsonl), preflight_path=None, out_path=str(out))
     snap = json.loads(out.read_text(encoding="utf-8"))
     assert snap["run_trusted"] is False
     assert snap["capabilities"]["gesture.wave"]["grade"] == "insufficient_data"
+
+
+def test_gesture_wave_false_accept_gate_uses_idle_only_metric(tmp_path):
+    jsonl = tmp_path / "baseline_result.jsonl"
+    _write_jsonl(
+        jsonl,
+        [_positive_round("gesture.wave") for _ in range(10)]
+        + [_idle_round("gesture.wave", false_trigger=True), _idle_round("gesture.wave")],
+    )
+    preflight = _trusted_preflight(tmp_path)
+    out = tmp_path / "snap.json"
+    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+
+    cap = json.loads(out.read_text(encoding="utf-8"))["capabilities"]["gesture.wave"]
+    assert cap["success_rate"] == 1.0
+    assert cap["false_trigger_rate"] <= DEFAULT_CRITERIA["gesture.wave"][1].pass_min
+    assert cap["unknown_false_accept_rate"] == 0.5
+    assert cap["grade"] == "fail"
+
+
+def test_object_cup_false_accept_gate_uses_idle_only_metric(tmp_path):
+    jsonl = tmp_path / "baseline_result.jsonl"
+    _write_jsonl(
+        jsonl,
+        [_positive_round("object.cup") for _ in range(98)]
+        + [_idle_round("object.cup", false_trigger=True), _idle_round("object.cup")],
+    )
+    preflight = _trusted_preflight(tmp_path)
+    out = tmp_path / "snap.json"
+    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+
+    cap = json.loads(out.read_text(encoding="utf-8"))["capabilities"]["object.cup"]
+    assert cap["success_rate"] == 1.0
+    assert cap["false_trigger_rate"] <= DEFAULT_CRITERIA["object.cup"][1].pass_min
+    assert cap["unknown_false_accept_rate"] == 0.5
+    assert cap["grade"] == "fail"


### PR DESCRIPTION
## 來由
#79（DEFAULT_CRITERIA）PR #94 review 時 Roy 同意先 merge as-is、由 #82 baseline run 對齊。本 PR 是 **#82 跑 idle round 前的 criteria 對齊（#82-prep）**，讓 #82 算出的 grade 對齊 spec。

## 問題
`build_scoreboard.py` 的 `DEFAULT_CRITERIA` gesture.wave / object.cup 的 false-accept 用 `false_trigger_rate`（跨**全部** round 算，被 positive round 稀釋），但 spec §4（gesture idle 誤觸硬 gate）/§5（object idle false-positive）要求 **idle-only** 的 `unknown_false_accept_rate`（aggregator `scoreboard.py:99-102` 已產此 key）。face.recognition 早已正確用 idle-only。

## 改動
- **`benchmarks/core/build_scoreboard.py`**：gesture.wave（0.10/0.30）+ object.cup（0.01/0.10）第二 Criterion → `unknown_false_accept_rate` + spec 註解。face/voice 不動。
- **`benchmarks/test/test_build_scoreboard.py`**：
  - 既有 `test_..._preflight_pass_produces_snapshot` 補 idle round（否則 0 idle → `unknown_false_accept_rate=None` → `grade_one(None)=FAIL` 打爆 grade==pass 斷言）
  - 新增「指標只讀 idle」證明測試（positive 全 pass、idle `false_trigger=True` → grade 非 pass）gesture + object 各一

## 驗證
- `pytest benchmarks/test/test_build_scoreboard.py test_scoreboard.py test_grader.py` → 21 passed
- `pytest benchmarks/test/` 全套 → 88 passed, 2 skipped
- grep 確認 DEFAULT_CRITERIA 只被 build_scoreboard.py + test 引用

## scope guard
只動這兩檔，不碰 scoreboard.py / grader.py（aggregator 已產 metric）。

Refs #82, #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)