### PR TITLE
feat(baseline): P2 runnable perception baseline observer node (gesture/object)

### DIFF
--- a/benchmarks/core/perception_baseline_observer.py
+++ b/benchmarks/core/perception_baseline_observer.py
@@ -16,7 +16,7 @@ unknown_false_accept_rate = 誤觸窗數/總窗數。positive round 則每次「
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 _IDLE_LABELS = {"none", "idle", ""}
 
@@ -29,6 +29,86 @@ class RoundMeta:
     distance_m: Optional[float] = None
     distance_source: str = "manual_declared"
     window_start_ts: float = 0.0
+    scenario_kind: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.scenario_kind is None:
+            self.scenario_kind = "idle" if self.expected_label in _IDLE_LABELS else "positive"
+
+
+def normalize_gesture_event(data: dict) -> list[tuple]:
+    """把 gesture event JSON 正規化成 evaluate_round 可吃的觀測 tuple。"""
+    gesture = data.get("gesture")
+    if not gesture:
+        return []
+    return [(gesture, data.get("confidence"), data.get("stamp"))]
+
+
+def normalize_object_event(data: dict) -> list[tuple]:
+    """把 object event JSON 正規化成 evaluate_round 可吃的觀測 tuple。"""
+    stamp = data.get("stamp")
+    observations = []
+    for obj in data.get("objects") or []:
+        if not isinstance(obj, dict):
+            continue
+        label = obj.get("class_name")
+        if label:
+            observations.append((label, obj.get("confidence"), stamp))
+    return observations
+
+
+def filter_window(observations: list[tuple], start_ts: float, end_ts: float | None) -> list[tuple]:
+    """回傳 ts 落在 [start_ts, end_ts] 的觀測；end_ts=None 表示不設上界。"""
+    windowed = []
+    for observation in observations:
+        if len(observation) < 3:
+            continue
+        ts = observation[2]
+        if ts is None:
+            continue
+        if ts < start_ts:
+            continue
+        if end_ts is not None and ts > end_ts:
+            continue
+        windowed.append(observation)
+    return sorted(windowed, key=lambda observation: observation[2])
+
+
+def load_round_meta(path: str) -> list[RoundMeta]:
+    """讀取 operator 宣告的 round meta YAML，轉成 RoundMeta list。"""
+    import yaml
+
+    with open(path, encoding="utf-8") as f:
+        raw = yaml.safe_load(f) or {}
+
+    rounds = raw.get("rounds", [])
+    return [
+        RoundMeta(
+            capability_id=round_data["capability_id"],
+            scenario_id=round_data["scenario_id"],
+            expected_label=str(round_data.get("expected_label") or ""),
+            distance_m=(
+                float(round_data["distance_m"])
+                if round_data.get("distance_m") is not None
+                else None
+            ),
+            distance_source=round_data.get("distance_source", "manual_declared"),
+            window_start_ts=float(round_data.get("window_start_ts") or 0.0),
+            scenario_kind=round_data.get("scenario_kind"),
+        )
+        for round_data in rounds
+    ]
+
+
+def enrich_record(record: dict, run_id: str, git_commit: str | None) -> dict:
+    """補 baseline run 欄位，但不覆蓋 record 既有 key。"""
+    from datetime import datetime, timezone
+
+    enriched = dict(record)
+    enriched.setdefault("run_id", run_id)
+    enriched.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
+    enriched.setdefault("git_commit", git_commit)
+    return enriched
 
 
 def evaluate_round(meta: RoundMeta, observations: list) -> dict:
@@ -76,10 +156,136 @@ def count_false_triggers(round_records: list[dict]) -> int:
     return sum(1 for r in round_records if r.get("false_trigger"))
 
 
-# --- ROS node wrapper（Jetson 跑，v0.1 不在 CI；保持薄）---
-# class PerceptionBaselineObserver(Node):
-#   - 訂 /event/gesture_detected, /event/object_detected（face 見 Task 4b）
-#   - _normalize(topic, msg) -> list[(label, confidence, ts)]
-#   - 依 round_meta 檔（operator 宣告 capability/scenario/expected/window_start/window_end）切窗
-#   - round 結束時 evaluate_round(meta, obs) → 補 run_id/timestamp/git_commit（current_run_meta）
-#     → CapabilityResult(...).to_record() → append baseline_result.jsonl
+def main(argv: list[str] | None = None) -> None:
+    import argparse
+    import json
+    import subprocess
+    import threading
+    import time
+    from dataclasses import replace
+    from pathlib import Path
+
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import String
+
+    def _load_run_id(path: str) -> str:
+        import yaml
+
+        with open(path, encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or {}
+        return str(raw.get("run_id", "perception-baseline"))
+
+    def _git_commit() -> str | None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        commit = result.stdout.strip()
+        return commit or None
+
+    def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+        with path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+
+    class PerceptionBaselineObserver(Node):
+        def __init__(self, gesture_topic: str, object_topic: str) -> None:
+            super().__init__("perception_baseline_observer")
+            self._lock = threading.Lock()
+            self._observations: list[tuple] = []
+            self.create_subscription(String, gesture_topic, self._on_gesture, 10)
+            self.create_subscription(String, object_topic, self._on_object, 10)
+            self.get_logger().info(
+                f"PerceptionBaselineObserver 訂閱 {gesture_topic} 與 {object_topic}"
+            )
+
+        def snapshot(self) -> list[tuple]:
+            with self._lock:
+                return list(self._observations)
+
+        def _on_gesture(self, msg: String) -> None:
+            self._ingest(msg.data, normalize_gesture_event, "gesture")
+
+        def _on_object(self, msg: String) -> None:
+            self._ingest(msg.data, normalize_object_event, "object")
+
+        def _ingest(self, payload: str, normalizer: Any, source: str) -> None:
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError as exc:
+                self.get_logger().warning(f"{source} event JSON 解析失敗：{exc}")
+                return
+            if not isinstance(data, dict):
+                self.get_logger().warning(f"{source} event JSON root 不是 object，略過")
+                return
+
+            observations = []
+            for label, confidence, ts in normalizer(data):
+                if label is None or ts is None:
+                    continue
+                try:
+                    observations.append((str(label), confidence, float(ts)))
+                except (TypeError, ValueError):
+                    self.get_logger().warning(f"{source} event stamp 非數值，略過：{ts!r}")
+            if not observations:
+                return
+
+            with self._lock:
+                self._observations.extend(observations)
+                self._observations.sort(key=lambda observation: observation[2])
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--round-meta", required=True)
+    parser.add_argument("--out", default="artifacts/baseline/baseline_result.jsonl")
+    parser.add_argument("--gesture-topic", default="/event/gesture_detected")
+    parser.add_argument("--object-topic", default="/event/object_detected")
+    args = parser.parse_args(argv)
+
+    round_meta = load_round_meta(args.round_meta)
+    run_id = _load_run_id(args.round_meta)
+    git_commit = _git_commit()
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    rclpy.init(args=None)
+    node = PerceptionBaselineObserver(args.gesture_topic, args.object_topic)
+    spin_thread = threading.Thread(target=rclpy.spin, args=(node,), daemon=True)
+    spin_thread.start()
+
+    try:
+        total = len(round_meta)
+        for index, meta in enumerate(round_meta, start=1):
+            input(
+                f"Round {index}/{total}：{meta.capability_id} "
+                f"expect={meta.expected_label} kind={meta.scenario_kind} — 按 Enter 開始"
+            )
+            window_start = time.time()
+            print("按 Enter 結束")
+            input()
+            window_end = time.time()
+
+            observations = filter_window(node.snapshot(), window_start, window_end)
+            meta_with_window = replace(meta, window_start_ts=window_start)
+            record = evaluate_round(meta_with_window, observations)
+            enriched = enrich_record(record, run_id, git_commit)
+            _append_jsonl(out_path, enriched)
+            print(
+                f"結果：pass_fail={enriched['pass_fail']} "
+                f"false_trigger={enriched['false_trigger']} "
+                f"predicted={enriched['predicted_label']}"
+            )
+    except KeyboardInterrupt:
+        print("收到中斷，結束 perception baseline observer。")
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+        spin_thread.join(timeout=2.0)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/core/round_meta.perception.example.yaml
+++ b/benchmarks/core/round_meta.perception.example.yaml
@@ -1,0 +1,6 @@
+run_id: gesture-object-2026-06-03
+rounds:
+  - {capability_id: gesture.wave, scenario_id: wave_1m_01, expected_label: wave, scenario_kind: positive, distance_m: 1.0}
+  - {capability_id: gesture.wave, scenario_id: wave_idle_01, expected_label: none, scenario_kind: idle}
+  - {capability_id: object.cup, scenario_id: cup_1m_01, expected_label: cup, scenario_kind: positive, distance_m: 1.0}
+  - {capability_id: object.cup, scenario_id: cup_idle_01, expected_label: none, scenario_kind: idle}

--- a/benchmarks/test/test_perception_baseline_observer.py
+++ b/benchmarks/test/test_perception_baseline_observer.py
@@ -1,5 +1,11 @@
 from benchmarks.core.perception_baseline_observer import (
-    RoundMeta, evaluate_round, count_false_triggers,
+    RoundMeta,
+    count_false_triggers,
+    enrich_record,
+    evaluate_round,
+    filter_window,
+    normalize_gesture_event,
+    normalize_object_event,
 )
 
 
@@ -54,3 +60,94 @@ def test_count_false_triggers_over_idle_rounds():
                        observations=[("point", 0.8, 1.0)]),
     ]
     assert count_false_triggers(rounds) == 1
+
+
+def test_normalize_gesture_event_returns_observation_tuple():
+    data = {
+        "stamp": 100.5,
+        "event_type": "gesture_detected",
+        "gesture": "wave",
+        "confidence": 0.9,
+        "hand": "right",
+    }
+
+    assert normalize_gesture_event(data) == [("wave", 0.9, 100.5)]
+
+
+def test_normalize_gesture_event_without_gesture_returns_empty():
+    data = {
+        "stamp": 100.5,
+        "event_type": "gesture_detected",
+        "confidence": 0.9,
+        "hand": "right",
+    }
+
+    assert normalize_gesture_event(data) == []
+
+
+def test_normalize_object_event_returns_multiple_observation_tuples():
+    data = {
+        "stamp": 200.0,
+        "event_type": "object_detected",
+        "objects": [
+            {"class_name": "cup", "confidence": 0.8, "bbox": [1, 2, 3, 4], "color": "red"},
+            {"class_name": "bottle", "confidence": 0.6, "bbox": [5, 6, 7, 8], "color": "blue"},
+        ],
+    }
+
+    assert normalize_object_event(data) == [
+        ("cup", 0.8, 200.0),
+        ("bottle", 0.6, 200.0),
+    ]
+
+
+def test_normalize_object_event_without_objects_returns_empty():
+    data = {"stamp": 200.0, "event_type": "object_detected"}
+
+    assert normalize_object_event(data) == []
+
+
+def test_filter_window_is_inclusive_sorts_and_supports_open_end():
+    observations = [
+        ("late", 0.7, 3.0),
+        ("start", 0.8, 1.0),
+        ("before", 0.5, 0.9),
+        ("end", 0.9, 2.0),
+        ("after", 0.4, 2.1),
+    ]
+
+    assert filter_window(observations, 1.0, 2.0) == [
+        ("start", 0.8, 1.0),
+        ("end", 0.9, 2.0),
+    ]
+    assert filter_window(observations, 2.0, None) == [
+        ("end", 0.9, 2.0),
+        ("after", 0.4, 2.1),
+        ("late", 0.7, 3.0),
+    ]
+
+
+def test_enrich_record_adds_run_fields_without_mutating_input():
+    record = {"pass_fail": "pass"}
+
+    enriched = enrich_record(record, "gesture-object-run", "abc123")
+
+    assert record == {"pass_fail": "pass"}
+    assert enriched["pass_fail"] == "pass"
+    assert enriched["run_id"] == "gesture-object-run"
+    assert enriched["git_commit"] == "abc123"
+    assert "timestamp" in enriched
+
+
+def test_enrich_record_does_not_overwrite_existing_keys():
+    record = {
+        "run_id": "existing-run",
+        "timestamp": "existing-ts",
+        "git_commit": "existing-commit",
+    }
+
+    enriched = enrich_record(record, "new-run", "new-commit")
+
+    assert enriched["run_id"] == "existing-run"
+    assert enriched["timestamp"] == "existing-ts"
+    assert enriched["git_commit"] == "existing-commit"


### PR DESCRIPTION
## 來由
#74 的 `perception_baseline_observer` 之前只有純邏輯 + 註解掉的 ROS node sketch（不可跑）。本 PR 把它實作成**可在 Jetson 跑的 observer**，讓 #82 gesture/object baseline run 能實際產出 JSONL。

## 改動
- **`benchmarks/core/perception_baseline_observer.py`**
  - 新增純函式（CI-testable）：`normalize_gesture_event` / `normalize_object_event` / `filter_window` / `load_round_meta` / `enrich_record`
  - `main()` 內 **lazy import rclpy** + `PerceptionBaselineObserver(Node)` + operator 互動 loop（按 Enter 起訖切窗、即時印 pass/fail/false_trigger）
  - **CI-safe 鐵則維持**：module top-level 無 rclpy import
  - `evaluate_round` 判定邏輯**未動**
- **`benchmarks/core/round_meta.perception.example.yaml`**：operator round 宣告範例
- **`benchmarks/test/test_perception_baseline_observer.py`**：+4 組純函式測試

## 上機跑法（#82 用）
\`\`\`
python3 benchmarks/core/perception_baseline_observer.py \
  --round-meta <round_meta.yaml> --out artifacts/baseline/baseline_result.jsonl
\`\`\`
（demo entrypoint 起感知 lane 後，operator 依 round 切窗。）

## 驗證
- `python3 -c "import benchmarks.core.perception_baseline_observer"` → CI-safe（無 rclpy 也能 import）
- `pytest benchmarks/test/test_perception_baseline_observer.py` → 13 passed
- scope：只動 observer + test + 新範例 yaml

Refs #82, #74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)