### PR TITLE
feat(baseline): P3 runnable face baseline observer node (/state/perception/face)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
-        run: pip install pytest pytest-cov flake8 numpy opencv-python-headless jsonschema
+        run: pip install pytest pytest-cov flake8 numpy opencv-python-headless jsonschema pyyaml
       - name: Flake8 lint (report-only)
         run: |
           flake8 speech_processor/ go2_robot_sdk/ face_perception/ \

--- a/benchmarks/core/face_baseline_observer.py
+++ b/benchmarks/core/face_baseline_observer.py
@@ -1,8 +1,7 @@
-"""Face baseline observer pure logic for /state/perception/face streams.
+"""人臉 baseline observer：針對 /state/perception/face 連續狀態流做 baseline 評估。
 
-The face benchmark is intentionally split from the gesture/object event observer.
-Face identity events only emit stable transitions, so this module evaluates the
-continuous face state stream where each snapshot contains all current tracks.
+人臉 benchmark 刻意和手勢/物件事件 observer 分開。人臉身份事件只在穩定身份轉換時發出，
+因此這裡評估的是每個 tick 含全部 tracks 的連續狀態流。
 """
 from __future__ import annotations
 
@@ -26,6 +25,102 @@ class FaceRoundMeta:
     distance_m: float | None = None
     distance_source: str = "manual_declared"
     window_start_ts: float = 0.0
+    scenario_kind: str = "positive"
+
+
+def parse_face_state(data: dict[str, Any]) -> FaceStateSnapshot:
+    """把人臉狀態 JSON dict 轉成快照；缺 stamp 時保守落到 0.0。"""
+    return FaceStateSnapshot(
+        ts=float(data.get("stamp", 0.0)),
+        tracks=list(data.get("tracks", [])),
+    )
+
+
+def filter_face_window(
+    snapshots: list[FaceStateSnapshot],
+    start_ts: float,
+    end_ts: float | None,
+) -> list[FaceStateSnapshot]:
+    """取出落在 [start_ts, end_ts] 的快照；end_ts=None 代表沒有上界。"""
+    return sorted(
+        (
+            snap
+            for snap in snapshots
+            if snap.ts >= start_ts and (end_ts is None or snap.ts <= end_ts)
+        ),
+        key=lambda snap: snap.ts,
+    )
+
+
+def load_face_round_meta(path: str) -> list[FaceRoundMeta]:
+    """讀取人臉 round_meta YAML，轉成 FaceRoundMeta list。"""
+    return _rounds_from_meta_document(_load_round_meta_document(path))
+
+
+def enrich_record(record: dict[str, Any], run_id: str, git_commit: str | None) -> dict[str, Any]:
+    """補 baseline JSONL 共用欄位；既有 key 不覆蓋。"""
+    from datetime import datetime, timezone
+
+    enriched = dict(record)
+    enriched.setdefault("run_id", run_id)
+    enriched.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
+    enriched.setdefault("git_commit", git_commit)
+    return enriched
+
+
+def _load_round_meta_document(path: str) -> dict[str, Any]:
+    """延後載入 yaml，讓 module import 不依賴 ROS 執行環境。"""
+    from pathlib import Path
+
+    import yaml
+
+    with Path(path).open("r", encoding="utf-8") as file:
+        document = yaml.safe_load(file) or {}
+
+    if not isinstance(document, dict):
+        raise ValueError(f"round_meta YAML 必須是 mapping：{path}")
+    return document
+
+
+def _rounds_from_meta_document(document: dict[str, Any]) -> list[FaceRoundMeta]:
+    rounds = document.get("rounds", [])
+    if not isinstance(rounds, list):
+        raise ValueError("round_meta YAML 的 rounds 必須是 list")
+
+    return [_round_from_mapping(round_data) for round_data in rounds]
+
+
+def _round_from_mapping(round_data: dict[str, Any]) -> FaceRoundMeta:
+    if not isinstance(round_data, dict):
+        raise ValueError("round_meta.rounds 每一筆都必須是 mapping")
+
+    expected_label = str(round_data.get("expected_label") or "")
+    distance_m = round_data.get("distance_m")
+    return FaceRoundMeta(
+        capability_id=str(round_data.get("capability_id") or ""),
+        scenario_id=str(round_data.get("scenario_id") or ""),
+        expected_label=expected_label,
+        distance_m=float(distance_m) if distance_m is not None else None,
+        distance_source=str(round_data.get("distance_source", "manual_declared")),
+        window_start_ts=float(round_data.get("window_start_ts", 0.0)),
+        scenario_kind=str(
+            round_data.get("scenario_kind")
+            or ("idle" if expected_label in _IDLE_LABELS else "positive")
+        ),
+    )
+
+
+def _round_meta_run_id(path: str) -> str:
+    document = _load_round_meta_document(path)
+    return str(document.get("run_id", "face-baseline") or "face-baseline")
+
+
+def _append_jsonl(path: Path, record: dict[str, Any]) -> None:
+    import json
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as file:
+        file.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
 
 
 def _known_tracks(snap: FaceStateSnapshot) -> list[dict[str, Any]]:
@@ -119,10 +214,116 @@ def _face_record(
     }
 
 
-# --- ROS node wrapper sketch (Jetson runtime; not implemented in CI) ---
-# class FaceBaselineObserver(Node):
-#   - subscribe to /state/perception/face and parse each tick into FaceStateSnapshot
-#   - collect snapshots inside the operator-declared round window
-#   - call evaluate_face_round(meta, snapshots) when the round ends
-#   - enrich the record with run_id/timestamp/git_commit before appending JSONL output
-#   * Keep this wrapper thin; do not change face_identity_node and do not connect Brain here.
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    import json
+    import subprocess
+    import threading
+    import time
+    from dataclasses import replace
+    from pathlib import Path
+
+    import rclpy
+    from rclpy.node import Node
+    from std_msgs.msg import String
+
+    parser = argparse.ArgumentParser(
+        description="Jetson runtime 的 /state/perception/face baseline observer。"
+    )
+    parser.add_argument("--round-meta", required=True)
+    parser.add_argument("--out", default="artifacts/baseline/baseline_result.jsonl")
+    parser.add_argument("--state-topic", default="/state/perception/face")
+    args = parser.parse_args(argv)
+
+    rounds = load_face_round_meta(args.round_meta)
+    run_id = _round_meta_run_id(args.round_meta)
+    output_path = Path(args.out)
+    try:
+        git_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path.cwd(),
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        git_commit = git_result.stdout.strip() or None
+    except (OSError, subprocess.CalledProcessError):
+        git_commit = None
+
+    class FaceBaselineObserver(Node):
+        """訂閱人臉狀態，將每個 tick 的全部 tracks 存進時間排序 buffer。"""
+
+        def __init__(self, state_topic: str) -> None:
+            super().__init__("face_baseline_observer")
+            self._lock = threading.Lock()
+            self._buffer: list[FaceStateSnapshot] = []
+            self._subscription = self.create_subscription(
+                String,
+                state_topic,
+                self._on_face_state,
+                10,
+            )
+            self.get_logger().info(f"訂閱 face state topic：{state_topic}")
+
+        def _on_face_state(self, msg: Any) -> None:
+            try:
+                payload = json.loads(msg.data)
+                if not isinstance(payload, dict):
+                    raise ValueError("face state JSON 必須是 object")
+                snapshot = parse_face_state(payload)
+            except (json.JSONDecodeError, TypeError, ValueError) as exc:
+                self.get_logger().warning(f"略過無效 face state：{exc}")
+                return
+
+            with self._lock:
+                self._buffer.append(snapshot)
+                self._buffer.sort(key=lambda snap: snap.ts)
+
+        def snapshot(self) -> list[FaceStateSnapshot]:
+            with self._lock:
+                return list(self._buffer)
+
+    rclpy.init(args=None)
+    node = FaceBaselineObserver(args.state_topic)
+    spin_thread = threading.Thread(target=rclpy.spin, args=(node,), daemon=True)
+    spin_thread.start()
+
+    try:
+        total = len(rounds)
+        for index, meta in enumerate(rounds, start=1):
+            kind = meta.scenario_kind
+            input(
+                f"Round {index}/{total}：{meta.capability_id} "
+                f"expect={meta.expected_label} kind={kind} — 按 Enter 開始"
+            )
+            window_start = time.time()
+            print("按 Enter 結束")
+            input()
+            window_end = time.time()
+
+            snapshots = filter_face_window(node.snapshot(), window_start, window_end)
+            record = evaluate_face_round(
+                replace(meta, window_start_ts=window_start),
+                snapshots,
+            )
+            enriched = enrich_record(record, run_id, git_commit)
+            _append_jsonl(output_path, enriched)
+            print(
+                "結果："
+                f"pass_fail={enriched.get('pass_fail')} "
+                f"false_trigger={enriched.get('false_trigger')} "
+                f"predicted_label={enriched.get('predicted_label')}"
+            )
+    except KeyboardInterrupt:
+        print("收到中斷，準備關閉 face baseline observer。")
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+        spin_thread.join(timeout=2.0)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/core/round_meta.face.example.yaml
+++ b/benchmarks/core/round_meta.face.example.yaml
@@ -1,0 +1,5 @@
+run_id: face-2026-06-03
+rounds:
+  - {capability_id: face.recognition, scenario_id: alice_1m_01, expected_label: alice, scenario_kind: positive, distance_m: 1.0}
+  - {capability_id: face.recognition, scenario_id: alice_2m_01, expected_label: alice, scenario_kind: positive, distance_m: 2.0}
+  - {capability_id: face.recognition, scenario_id: stranger_idle_01, expected_label: unknown, scenario_kind: idle}

--- a/benchmarks/test/test_face_baseline_observer.py
+++ b/benchmarks/test/test_face_baseline_observer.py
@@ -1,10 +1,101 @@
 from benchmarks.core.face_baseline_observer import (
     FaceRoundMeta,
     FaceStateSnapshot,
+    enrich_record,
     evaluate_face_round,
+    filter_face_window,
+    load_face_round_meta,
+    parse_face_state,
 )
 
 
+def test_parse_face_state_normal() -> None:
+    payload = {
+        "stamp": 123.4,
+        "face_count": 1,
+        "tracks": [
+            {
+                "track_id": 7,
+                "stable_name": "alice",
+                "sim": 0.91,
+                "distance_m": 1.2,
+                "bbox": [1, 2, 3, 4],
+                "mode": "recognized",
+            }
+        ],
+    }
+
+    snapshot = parse_face_state(payload)
+
+    assert snapshot == FaceStateSnapshot(ts=123.4, tracks=payload["tracks"])
+
+
+def test_parse_face_state_missing_tracks_defaults_to_empty_list() -> None:
+    snapshot = parse_face_state({"stamp": "5.5", "face_count": 0})
+
+    assert snapshot == FaceStateSnapshot(ts=5.5, tracks=[])
+
+
+def test_filter_face_window_includes_boundaries_sorts_and_supports_open_end() -> None:
+    snapshots = [
+        FaceStateSnapshot(ts=3.0, tracks=[]),
+        FaceStateSnapshot(ts=1.0, tracks=[]),
+        FaceStateSnapshot(ts=2.0, tracks=[]),
+        FaceStateSnapshot(ts=4.0, tracks=[]),
+    ]
+
+    bounded = filter_face_window(snapshots, 2.0, 3.0)
+    open_ended = filter_face_window(snapshots, 2.0, None)
+
+    assert [snapshot.ts for snapshot in bounded] == [2.0, 3.0]
+    assert [snapshot.ts for snapshot in open_ended] == [2.0, 3.0, 4.0]
+
+
+def test_load_face_round_meta_reads_example_yaml() -> None:
+    rounds = load_face_round_meta("benchmarks/core/round_meta.face.example.yaml")
+
+    assert rounds == [
+        FaceRoundMeta(
+            capability_id="face.recognition",
+            scenario_id="alice_1m_01",
+            expected_label="alice",
+            distance_m=1.0,
+            scenario_kind="positive",
+        ),
+        FaceRoundMeta(
+            capability_id="face.recognition",
+            scenario_id="alice_2m_01",
+            expected_label="alice",
+            distance_m=2.0,
+            scenario_kind="positive",
+        ),
+        FaceRoundMeta(
+            capability_id="face.recognition",
+            scenario_id="stranger_idle_01",
+            expected_label="unknown",
+            scenario_kind="idle",
+        ),
+    ]
+
+
+def test_enrich_record_adds_common_fields_without_overwriting() -> None:
+    record = {
+        "pass_fail": "pass",
+        "run_id": "existing-run",
+        "timestamp": "2026-06-03T00:00:00+00:00",
+        "git_commit": "existing-commit",
+    }
+
+    enriched = enrich_record(record, run_id="new-run", git_commit="new-commit")
+
+    assert enriched["pass_fail"] == "pass"
+    assert enriched["run_id"] == "existing-run"
+    assert enriched["timestamp"] == "2026-06-03T00:00:00+00:00"
+    assert enriched["git_commit"] == "existing-commit"
+    assert enriched is not record
+
+
+# --- 復原：原 #75 的 evaluate_face_round 核心測試（Codex 誤刪，review 補回）---
 def _snap(ts, tracks):
     return FaceStateSnapshot(ts=ts, tracks=tracks)
 


### PR DESCRIPTION
## 來由
#75 的 `face_baseline_observer` 只有純邏輯 + 註解掉的 ROS node sketch。本 PR 實作成**可在 Jetson 跑的 observer**，讓 #81 face baseline run 能產出 JSONL。吃 `/state/perception/face` **連續 state 流**（每 tick 全 tracks），與 gesture/object 的 event-based observer 不同。

## 改動
- **`benchmarks/core/face_baseline_observer.py`**：純函式 `parse_face_state`/`filter_face_window`/`load_face_round_meta`/`enrich_record` + `main()` 內 lazy-import rclpy 的 `FaceBaselineObserver(Node)` + operator 互動 loop。`evaluate_face_round` 判定邏輯**未動**。`FaceRoundMeta` 加 optional `scenario_kind`（預設 positive）。
- **`benchmarks/core/round_meta.face.example.yaml`**：registered 1m/2m + stranger idle 範例
- **`benchmarks/test/test_face_baseline_observer.py`**：+5 純函式測試

## ⚠️ review 補強
Codex 初版**誤刪了原 #75 的 5 個 evaluate_face_round 核心測試**（idle-known-person→false_trigger、idle-unknown→pass、positive-match、positive-miss、wrong-person→false_accept）。已從 git 復原，與新測試並存 → **共 10 tests 全綠**，人臉評分覆蓋不倒退。

## 上機跑法（#81）
\`\`\`
python3 benchmarks/core/face_baseline_observer.py --round-meta <yaml> --out artifacts/baseline/baseline_result.jsonl
\`\`\`

## 驗證
- CI-safe import（無 rclpy 也能 import）✓
- `pytest benchmarks/test/test_face_baseline_observer.py` → 10 passed
- 完整 benchmarks 套件 → 93 passed, 2 skipped

Refs #81, #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)