### PR TITLE
feat(baseline): P4 voice CSV->JSONL converter + voice.stop FN=0 criterion

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -68,6 +68,7 @@ jobs:
             benchmarks/test/test_face_baseline_observer.py \
             benchmarks/test/test_readiness.py \
             benchmarks/test/test_run_preflight.py \
+            benchmarks/test/test_voice_csv_to_jsonl.py \
             -v --tb=short \
             --cov=speech_processor/speech_processor \
             --cov=vision_perception/vision_perception \

--- a/benchmarks/core/build_scoreboard.py
+++ b/benchmarks/core/build_scoreboard.py
@@ -21,6 +21,10 @@ DEFAULT_CRITERIA: dict[str, list[Criterion]] = {
     "voice.command": [
         Criterion("success_rate", 0.80, 0.70, higher_is_better=True),
     ],
+    "voice.stop": [
+        # 規格 §2b：voice.stop FN 硬性=0 —— 任一漏聽即 fail，故 pass 需 success_rate==1.0。
+        Criterion("success_rate", 1.0, 1.0, higher_is_better=True),
+    ],
     "gesture.wave": [
         Criterion("success_rate", 0.90, 0.80, higher_is_better=True),
         # 規格 §4：手勢 idle 誤觸只看 scenario_kind=idle 的 unknown_false_accept_rate。

--- a/benchmarks/scripts/voice_csv_to_jsonl.py
+++ b/benchmarks/scripts/voice_csv_to_jsonl.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""將 speech_test CSV 離線轉成 baseline_result JSONL。"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+def _positive_float_or_none(value: object) -> float | None:
+    """只接受可轉成 float 且大於 0 的延遲值。"""
+    try:
+        latency_ms = float(value)
+    except (TypeError, ValueError):
+        return None
+    return latency_ms if latency_ms > 0 else None
+
+
+def csv_row_to_record(
+    row: dict,
+    stop_intents: set[str],
+    run_id: str,
+    git_commit: str | None,
+) -> dict | None:
+    """把單列 speech_test CSV 轉成 baseline result record。"""
+    expected_intent = row.get("expected_intent")
+    if row.get("status") == "orphan" or not expected_intent:
+        return None
+
+    capability_id = "voice.stop" if expected_intent in stop_intents else "voice.command"
+    record = {
+        "capability_id": capability_id,
+        "scenario_id": f'voice_{row.get("round_id", "")}',
+        "scenario_kind": "positive",
+        "expected_label": expected_intent,
+        "predicted_label": row.get("intent", ""),
+        "pass_fail": "pass" if row.get("match") == "match" else "fail",
+        "false_trigger": False,
+        "latency_ms": _positive_float_or_none(row.get("e2e_latency_ms")),
+    }
+
+    # 用 setdefault 補 metadata，保留未來呼叫端預先放進 record 的可能性。
+    record.setdefault("run_id", run_id)
+    record.setdefault("timestamp", datetime.now(timezone.utc).isoformat())
+    record.setdefault("git_commit", git_commit)
+    return record
+
+
+def convert(
+    csv_path: str,
+    out_path: str,
+    stop_intents: set[str],
+    run_id: str,
+    git_commit: str | None,
+) -> int:
+    """讀取 CSV，過濾非資料列後 append 成 JSONL，回傳寫入筆數。"""
+    out = Path(out_path)
+    if out.parent != Path("."):
+        out.parent.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    with open(csv_path, newline="", encoding="utf-8") as csv_file, open(
+        out,
+        "a",
+        encoding="utf-8",
+    ) as out_file:
+        for row in csv.DictReader(csv_file):
+            record = csv_row_to_record(row, stop_intents, run_id, git_commit)
+            if record is None:
+                continue
+            out_file.write(json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n")
+            count += 1
+    return count
+
+
+def _git_commit() -> str | None:
+    """從目前 repo 讀 HEAD commit；離線或非 git 目錄時回 None。"""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Convert speech_test CSV to baseline JSONL.")
+    parser.add_argument("--csv", required=True, help="speech_test_observer CSV path")
+    parser.add_argument(
+        "--out",
+        default="artifacts/baseline/baseline_result.jsonl",
+        help="output JSONL path",
+    )
+    parser.add_argument(
+        "--stop-intent",
+        action="append",
+        help="intent label treated as voice.stop; may be repeated",
+    )
+    parser.add_argument("--run-id", default="voice-baseline", help="baseline run id")
+    args = parser.parse_args(argv)
+
+    stop_intents = set(args.stop_intent or ["stop"])
+    count = convert(args.csv, args.out, stop_intents, args.run_id, _git_commit())
+    print(f"wrote {count} records -> {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/test/test_build_scoreboard.py
+++ b/benchmarks/test/test_build_scoreboard.py
@@ -83,6 +83,23 @@ def test_gesture_wave_false_accept_gate_uses_idle_only_metric(tmp_path):
     assert cap["grade"] == "fail"
 
 
+def test_voice_stop_requires_zero_false_negatives(tmp_path):
+    jsonl = tmp_path / "baseline_result.jsonl"
+    missed_stop = _positive_round("voice.stop")
+    missed_stop["pass_fail"] = "fail"
+    _write_jsonl(
+        jsonl,
+        [_positive_round("voice.stop"), _positive_round("voice.stop"), missed_stop],
+    )
+    preflight = _trusted_preflight(tmp_path)
+    out = tmp_path / "snap.json"
+    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+
+    cap = json.loads(out.read_text(encoding="utf-8"))["capabilities"]["voice.stop"]
+    assert cap["success_rate"] < DEFAULT_CRITERIA["voice.stop"][0].pass_min
+    assert cap["grade"] != "pass"
+
+
 def test_object_cup_false_accept_gate_uses_idle_only_metric(tmp_path):
     jsonl = tmp_path / "baseline_result.jsonl"
     _write_jsonl(

--- a/benchmarks/test/test_voice_csv_to_jsonl.py
+++ b/benchmarks/test/test_voice_csv_to_jsonl.py
@@ -1,0 +1,96 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_module():
+    # benchmarks/scripts 不是 package，測試用檔案路徑直接載入。
+    path = Path(__file__).resolve().parents[1] / "scripts" / "voice_csv_to_jsonl.py"
+    spec = importlib.util.spec_from_file_location("voice_csv_to_jsonl", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+voice_csv_to_jsonl = _load_module()
+
+
+def test_csv_row_to_record_voice_command_pass_with_latency():
+    row = {
+        "round_id": "1",
+        "expected_intent": "sit",
+        "intent": "sit",
+        "e2e_latency_ms": "123.4",
+        "match": "match",
+        "status": "complete",
+    }
+
+    record = voice_csv_to_jsonl.csv_row_to_record(row, {"stop"}, "run-1", "abc123")
+
+    assert record["capability_id"] == "voice.command"
+    assert record["scenario_id"] == "voice_1"
+    assert record["pass_fail"] == "pass"
+    assert record["latency_ms"] == 123.4
+
+
+def test_csv_row_to_record_voice_stop_miss_is_fail():
+    row = {
+        "round_id": "2",
+        "expected_intent": "stop",
+        "intent": "",
+        "e2e_latency_ms": "200",
+        "match": "miss",
+        "status": "complete",
+    }
+
+    record = voice_csv_to_jsonl.csv_row_to_record(row, {"stop"}, "run-1", None)
+
+    assert record["capability_id"] == "voice.stop"
+    assert record["pass_fail"] == "fail"
+
+
+def test_csv_row_to_record_skips_orphan_and_empty_expected_intent():
+    orphan = {
+        "round_id": "3",
+        "expected_intent": "stop",
+        "intent": "stop",
+        "e2e_latency_ms": "100",
+        "match": "match",
+        "status": "orphan",
+    }
+    empty_expected = {
+        "round_id": "4",
+        "expected_intent": "",
+        "intent": "stop",
+        "e2e_latency_ms": "100",
+        "match": "match",
+        "status": "complete",
+    }
+
+    assert voice_csv_to_jsonl.csv_row_to_record(orphan, {"stop"}, "run-1", None) is None
+    assert voice_csv_to_jsonl.csv_row_to_record(empty_expected, {"stop"}, "run-1", None) is None
+
+
+def test_csv_row_to_record_invalid_or_zero_latency_is_none():
+    base_row = {
+        "round_id": "5",
+        "expected_intent": "sit",
+        "intent": "sit",
+        "match": "match",
+        "status": "complete",
+    }
+    zero_latency = {**base_row, "e2e_latency_ms": "0"}
+    invalid_latency = {**base_row, "e2e_latency_ms": "not-a-number"}
+
+    assert (
+        voice_csv_to_jsonl.csv_row_to_record(zero_latency, {"stop"}, "run-1", None)[
+            "latency_ms"
+        ]
+        is None
+    )
+    assert (
+        voice_csv_to_jsonl.csv_row_to_record(invalid_latency, {"stop"}, "run-1", None)[
+            "latency_ms"
+        ]
+        is None
+    )


### PR DESCRIPTION
## 來由
#80 voice baseline run 需要把 `speech_test_observer` 的 CSV 轉成 `baseline_result.jsonl`，並補 voice.stop 的評分門檻。

## 改動
- **`benchmarks/scripts/voice_csv_to_jsonl.py`**（新，offline 無 ROS）：`csv_row_to_record` 映射每列 → record（`expected_intent ∈ stop_intents → voice.stop` 否則 `voice.command`；`match=="match" → pass`；orphan / 空 expected_intent → 跳過；e2e_latency 非正數 → None）+ `convert()` append JSONL
- **`benchmarks/core/build_scoreboard.py`**：DEFAULT_CRITERIA 加 `voice.stop`（`success_rate` pass=1.0/deg=1.0 = spec §2b **FN 硬性=0**，任一漏聽即非 pass）。其他 criteria 未動。
- **測試**：`test_voice_csv_to_jsonl.py`（4，importlib 載入）+ `test_build_scoreboard.py` voice.stop FN=0 一條
- **`ros_build.yaml`**：新測試接進 Fast Gate 白名單

## 上機跑法（#80）
\`\`\`
bash scripts/run_speech_test.sh --skip-driver --skip-build   # 產 CSV
python3 benchmarks/scripts/voice_csv_to_jsonl.py --csv <speech_test.csv> --out artifacts/baseline/baseline_result.jsonl
\`\`\`

## 驗證
- `pytest benchmarks/test/test_voice_csv_to_jsonl.py test_build_scoreboard.py` → 9 passed
- 完整 benchmarks 套件 → 93 passed, 2 skipped
- DEFAULT_CRITERIA 5 能力齊（face/voice.command/voice.stop/gesture/object），無刪改

Refs #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)