### PR TITLE
fix(baseline): review fixes — voice match=hit + snapshot fail-closed on version_mismatch

### DIFF
--- a/benchmarks/core/scoreboard.py
+++ b/benchmarks/core/scoreboard.py
@@ -158,6 +158,13 @@ def _empty_score_dict(capability_id: str) -> dict:
 
 def to_snapshot(scores: dict[str, CapabilityScore], run_meta: dict) -> dict:
     run_trusted = bool(run_meta.get("run_trusted", False))
+    # fail-closed：preflight 非 pass，或無法確認 Jetson 跑的是被評分的這版 code
+    # （version_mismatch=True，含缺 manifest / SHA 不符）→ 全能力覆寫 insufficient_data。
+    # run_trusted（preflight）與 version_mismatch（deploy provenance）是兩個獨立旗標，
+    # 任一不可信即覆寫 grade（對齊 scoreboard_schema docstring「version_mismatch fail-closed」
+    # + spec §9 sha-mismatch 硬擋）。
+    version_mismatch = bool(run_meta.get("version_mismatch", False))
+    trusted = run_trusted and not version_mismatch
     capabilities = {}
 
     for capability_id, meta in CAPABILITY_META.items():
@@ -166,11 +173,12 @@ def to_snapshot(scores: dict[str, CapabilityScore], run_meta: dict) -> dict:
         else:
             capability = _empty_score_dict(capability_id)
 
-        if not run_trusted:
+        if not trusted:
             capability["grade"] = GRADE_INSUFFICIENT
-            capability["failure_reason"] = (
-                f"layer0_preflight={run_meta.get('layer0_preflight_status', 'unknown')}"
-            )
+            reason = f"layer0_preflight={run_meta.get('layer0_preflight_status', 'unknown')}"
+            if version_mismatch:
+                reason += ";version_mismatch=true"
+            capability["failure_reason"] = reason
 
         capability["claim_level"] = meta["claim_level"]
         capability["risk_role"] = meta["risk_role"]

--- a/benchmarks/scripts/voice_csv_to_jsonl.py
+++ b/benchmarks/scripts/voice_csv_to_jsonl.py
@@ -38,7 +38,9 @@ def csv_row_to_record(
         "scenario_kind": "positive",
         "expected_label": expected_intent,
         "predicted_label": row.get("intent", ""),
-        "pass_fail": "pass" if row.get("match") == "match" else "fail",
+        # speech_test_observer 的成功值是 "hit"（speech_test_observer.py:228）；
+        # 兼容歷史誤用值 "match"（從未真實輸出，僅防呆）。
+        "pass_fail": "pass" if row.get("match") in ("hit", "match") else "fail",
         "false_trigger": False,
         "latency_ms": _positive_float_or_none(row.get("e2e_latency_ms")),
     }

--- a/benchmarks/test/test_build_scoreboard.py
+++ b/benchmarks/test/test_build_scoreboard.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 
 from benchmarks.core.build_scoreboard import DEFAULT_CRITERIA, build_scoreboard
 
@@ -35,6 +36,21 @@ def _trusted_preflight(path):
     return preflight
 
 
+def _matching_manifest(path):
+    """寫一個 git_sha_full 與當前 HEAD 相符的 manifest → version_mismatch=False（trusted run）。
+
+    fail-closed 修正後，trusted snapshot 同時需要 preflight pass 且 deploy provenance 相符；
+    這個 helper 模擬「Jetson 跑的就是被評分的這版 code」。
+    """
+    full_sha = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    manifest = path / "manifest.json"
+    manifest.write_text(
+        json.dumps({"git_sha_full": full_sha, "when": "2026-06-03T10:00:00+00:00"}),
+        encoding="utf-8",
+    )
+    return manifest
+
+
 def test_build_scoreboard_preflight_pass_produces_snapshot(tmp_path):
     jsonl = tmp_path / "baseline_result.jsonl"
     _write_jsonl(
@@ -44,9 +60,15 @@ def test_build_scoreboard_preflight_pass_produces_snapshot(tmp_path):
     )
     preflight = _trusted_preflight(tmp_path)
     out = tmp_path / "snap.json"
-    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+    build_scoreboard(
+        str(jsonl),
+        manifest_path=str(_matching_manifest(tmp_path)),
+        preflight_path=str(preflight),
+        out_path=str(out),
+    )
     snap = json.loads(out.read_text(encoding="utf-8"))
     assert snap["run_trusted"] is True
+    assert snap["version_mismatch"] is False
     assert len(snap["capabilities"]) == 15
     assert snap["capabilities"]["gesture.wave"]["grade"] == "pass"
 
@@ -65,6 +87,30 @@ def test_build_scoreboard_missing_preflight_is_failclosed(tmp_path):
     assert snap["capabilities"]["gesture.wave"]["grade"] == "insufficient_data"
 
 
+def test_build_scoreboard_version_mismatch_is_failclosed(tmp_path):
+    # preflight pass 但無 manifest（無法確認 Jetson 跑的是被評分的這版 code）
+    # → version_mismatch=True → 即使 preflight pass，全能力仍覆寫 insufficient_data。
+    jsonl = tmp_path / "baseline_result.jsonl"
+    _write_jsonl(
+        jsonl,
+        [_positive_round("gesture.wave") for _ in range(3)]
+        + [_idle_round("gesture.wave") for _ in range(2)],
+    )
+    preflight = _trusted_preflight(tmp_path)
+    out = tmp_path / "snap.json"
+    build_scoreboard(
+        str(jsonl),
+        manifest_path=None,
+        preflight_path=str(preflight),
+        out_path=str(out),
+    )
+    snap = json.loads(out.read_text(encoding="utf-8"))
+    assert snap["version_mismatch"] is True
+    cap = snap["capabilities"]["gesture.wave"]
+    assert cap["grade"] == "insufficient_data"
+    assert "version_mismatch" in cap["failure_reason"]
+
+
 def test_gesture_wave_false_accept_gate_uses_idle_only_metric(tmp_path):
     jsonl = tmp_path / "baseline_result.jsonl"
     _write_jsonl(
@@ -74,7 +120,12 @@ def test_gesture_wave_false_accept_gate_uses_idle_only_metric(tmp_path):
     )
     preflight = _trusted_preflight(tmp_path)
     out = tmp_path / "snap.json"
-    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+    build_scoreboard(
+        str(jsonl),
+        manifest_path=str(_matching_manifest(tmp_path)),
+        preflight_path=str(preflight),
+        out_path=str(out),
+    )
 
     cap = json.loads(out.read_text(encoding="utf-8"))["capabilities"]["gesture.wave"]
     assert cap["success_rate"] == 1.0
@@ -93,7 +144,12 @@ def test_voice_stop_requires_zero_false_negatives(tmp_path):
     )
     preflight = _trusted_preflight(tmp_path)
     out = tmp_path / "snap.json"
-    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+    build_scoreboard(
+        str(jsonl),
+        manifest_path=str(_matching_manifest(tmp_path)),
+        preflight_path=str(preflight),
+        out_path=str(out),
+    )
 
     cap = json.loads(out.read_text(encoding="utf-8"))["capabilities"]["voice.stop"]
     assert cap["success_rate"] < DEFAULT_CRITERIA["voice.stop"][0].pass_min
@@ -109,7 +165,12 @@ def test_object_cup_false_accept_gate_uses_idle_only_metric(tmp_path):
     )
     preflight = _trusted_preflight(tmp_path)
     out = tmp_path / "snap.json"
-    build_scoreboard(str(jsonl), preflight_path=str(preflight), out_path=str(out))
+    build_scoreboard(
+        str(jsonl),
+        manifest_path=str(_matching_manifest(tmp_path)),
+        preflight_path=str(preflight),
+        out_path=str(out),
+    )
 
     cap = json.loads(out.read_text(encoding="utf-8"))["capabilities"]["object.cup"]
     assert cap["success_rate"] == 1.0

--- a/benchmarks/test/test_voice_csv_to_jsonl.py
+++ b/benchmarks/test/test_voice_csv_to_jsonl.py
@@ -21,7 +21,7 @@ def test_csv_row_to_record_voice_command_pass_with_latency():
         "expected_intent": "sit",
         "intent": "sit",
         "e2e_latency_ms": "123.4",
-        "match": "match",
+        "match": "hit",
         "status": "complete",
     }
 
@@ -55,7 +55,7 @@ def test_csv_row_to_record_skips_orphan_and_empty_expected_intent():
         "expected_intent": "stop",
         "intent": "stop",
         "e2e_latency_ms": "100",
-        "match": "match",
+        "match": "hit",
         "status": "orphan",
     }
     empty_expected = {
@@ -63,7 +63,7 @@ def test_csv_row_to_record_skips_orphan_and_empty_expected_intent():
         "expected_intent": "",
         "intent": "stop",
         "e2e_latency_ms": "100",
-        "match": "match",
+        "match": "hit",
         "status": "complete",
     }
 
@@ -76,7 +76,7 @@ def test_csv_row_to_record_invalid_or_zero_latency_is_none():
         "round_id": "5",
         "expected_intent": "sit",
         "intent": "sit",
-        "match": "match",
+        "match": "hit",
         "status": "complete",
     }
     zero_latency = {**base_row, "e2e_latency_ms": "0"}


### PR DESCRIPTION
## 來由
Roy 對 main 上這批 baseline 工具做 static review，抓到兩個 bug。

## Bug 1（必修）：voice 轉換器成功值錯誤
`speech_test_observer` 的成功 `match` 值是 **`"hit"`**（`speech_test_observer.py:228`，observer 自己 aggregate 也用 `== "hit"`），但 `voice_csv_to_jsonl.py` 判 `"match"` → **所有真實語音命中都被轉成 `fail`，voice baseline 分數整份反向失真**。
- 修：`pass_fail = "pass" if match in ("hit","match") else "fail"`（`"match"` 從未真實輸出，僅防呆）
- 測試 fixture 改成真實值 `"hit"`

## Bug 2：snapshot fail-closed 漏洞
`to_snapshot` 的 grade 覆寫只看 `run_trusted`（preflight），但 `current_run_meta` 另有 `version_mismatch`（缺 manifest / SHA 不符）。preflight pass 但 `version_mismatch=True` 時，仍產出「可信 pass」grade —— 與 `scoreboard_schema` docstring「version_mismatch fail-closed」+ spec §9「snapshot sha != deploy sha → not_ready」矛盾。
- 修：`trusted = run_trusted and not version_mismatch`；任一不可信 → 全能力 `insufficient_data`，`failure_reason` 標 `version_mismatch=true`
- `run_trusted`（preflight）語意不變（兩個獨立旗標，對齊 docstring 設計）

## 測試
- 既有 trusted 測試補 matching manifest（git_sha_full = HEAD → version_mismatch=False）
- 新增 `test_build_scoreboard_version_mismatch_is_failclosed`（preflight pass + 無 manifest → 全 insufficient）
- 完整 benchmarks 套件 → **106 passed, 2 skipped**

## 影響
Bug 1 是上機跑 #80 voice 前**必須**修好，否則語音資料全反向。Bug 2 是 deploy provenance 的防線（demo 當天讀 snapshot grade 不會誤信非部署版本的分數）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)