### PR TITLE
docs(baseline): fix preflight evidence mismatch + not-release-grade caveat

### DIFF
--- a/docs/runbook/2026-06-03-first-trusted-baseline-evidence.md
+++ b/docs/runbook/2026-06-03-first-trusted-baseline-evidence.md
@@ -22,7 +22,8 @@ scoreboard、readiness 產出可重現的工程證據**。
 
 | Artifact | 內容 |
 |---|---|
-| `preflight_result.json` | **pass**（demo 全起 9/9 checks）+ **fail**（demo 沒開 → 3 blocking fail）|
+| `preflight_result.json` | **pass** 版（demo 全起 9/9 checks）|
+| `preflight_result.fail.json` | **fail** 版（demo 沒開 → 3 blocking fail，示範 fail-closed）|
 | `baseline_result.jsonl` | 3 筆真 face record（含 D435 深度量測）|
 | `baseline_snapshot.json` | **trusted**：`run_trusted=True` / `version_mismatch=False`（wsl 2e00914 == jetson 2e00914）|
 | `readiness_output.json` | verdict **`not_ready`**（fail-closed：只測 face、其餘無數據）|
@@ -38,6 +39,8 @@ scoreboard、readiness 產出可重現的工程證據**。
 | 其餘 14 能力 | insufficient_data（無數據）|
 
 `roy_1m_02` pass：sim 0.45、313ms 鎖定、D435 深度 **1.67m**。
+
+> ⚠️ **定位 caveat（不要過度包裝）**：snapshot 的 `wsl_dirty=true` / `jetson_dirty=true`（repo 有未追蹤檔/本地改動）。這份是**「工程鏈路打通 + 第一次可信量測」的證據**，**不是乾淨的 release-grade baseline**。正式 release baseline 需：repo clean、完整 round 數（face 1m/2m × registered/stranger、object、gesture、voice）、idle protocol 修正後重測。
 
 ## 6/18 報告寫法（工程挑戰與突破）
 

--- a/docs/runbook/baseline-evidence/2026-06-03-first-trusted-face/preflight_result.fail.json
+++ b/docs/runbook/baseline-evidence/2026-06-03-first-trusted-face/preflight_result.fail.json
@@ -1,0 +1,89 @@
+{
+  "status": "fail",
+  "checks": [
+    {
+      "id": "jetson.ssh_reachable",
+      "status": "PASS",
+      "blocking": true,
+      "value": "ok",
+      "message": "Jetson SSH 可達：ok",
+      "duration_ms": 303
+    },
+    {
+      "id": "go2.ethernet_ping",
+      "status": "PASS",
+      "blocking": true,
+      "value": "1",
+      "message": "Go2 乙太網路連線狀態：1（需要 1）",
+      "duration_ms": 303
+    },
+    {
+      "id": "demo.entrypoint_started",
+      "status": "FAIL",
+      "blocking": true,
+      "value": "0",
+      "message": "Demo tmux session 狀態：0（需要 demo）",
+      "duration_ms": 303
+    },
+    {
+      "id": "ros.runtime_started",
+      "status": "FAIL",
+      "blocking": true,
+      "value": "0",
+      "message": "0 個 ROS2 nodes 已啟動（至少 5）",
+      "duration_ms": 1781
+    },
+    {
+      "id": "go2.driver_alive",
+      "status": "FAIL",
+      "blocking": true,
+      "value": "0",
+      "message": "go2_driver 節點數：0（至少 1）",
+      "duration_ms": 1789
+    },
+    {
+      "id": "topic_contract_ok",
+      "status": "WARN",
+      "blocking": false,
+      "value": "2",
+      "message": "2 個 ROS2 topics 已發現（建議至少 20）",
+      "duration_ms": 1816
+    },
+    {
+      "id": "system.memory",
+      "status": "PASS",
+      "blocking": true,
+      "value": "6036",
+      "message": "6036MB 可用記憶體（至少 800MB）",
+      "duration_ms": 300
+    },
+    {
+      "id": "system.gpu_temp",
+      "status": "PASS",
+      "blocking": false,
+      "value": "51",
+      "message": "GPU 51°C（警告門檻 >70°C）",
+      "duration_ms": 299
+    },
+    {
+      "id": "version_snapshot",
+      "status": "PASS",
+      "blocking": false,
+      "value": "499",
+      "message": "deploy manifest 大小：499 bytes",
+      "duration_ms": 303
+    }
+  ],
+  "details": {
+    "overall": "FAIL",
+    "summary": {
+      "pass": 5,
+      "warn": 1,
+      "fail": 3,
+      "skip": 0,
+      "error": 0
+    },
+    "version_snapshot": "{\"deployed_by\": \"roy422\", \"deployed_from_host\": \"DESKTOP-575ABRI\", \"branch\": \"main\", \"git_sha\": \"2e00914\", \"git_sha_full\": \"2e00914cd8eeef869664c8ed9acea681f237a39a\", \"dirty\": true, \"module\": \"all\", \"packages\": [\"face_perception\", \"go2_robot_sdk\", \"interaction_executive\", \"object_perception\", \"pawai_brain\", \"speech_processor\", \"vision_perception\"], \"when\": \"2026-06-03T06:24:20.519262+00:00\", \"sync_method\": \"sync-once\", \"user\": \"roy422@DESKTOP-575ABRI\", \"ts\": \"2026-06-03T06:24:20.519262+00:00\"}\n",
+    "verify_report_path": "artifacts/baseline/logs/latest.json"
+  }
+}


### PR DESCRIPTION
## 來由
Roy review #113 後抓到：工程筆記宣稱 `preflight_result.json` 含 pass + fail，但 tracked evidence 只有 pass 版。

## 修正
- 補 `preflight_result.fail.json`（demo 關閉時重生：status=fail、3 blocking fail，示範 fail-closed）進 tracked evidence
- docs 表格拆成 `preflight_result.json`(pass) / `preflight_result.fail.json`(fail) 兩列 → 與 evidence 一致
- 補 **caveat**（Roy 提）：snapshot `wsl_dirty=true`/`jetson_dirty=true` → 這份是「工程鏈路打通 + 第一次可信量測」證據，**不是乾淨 release-grade baseline**

Refs #73, #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)