### PR TITLE
fix(baseline): per-capability failure_reason for trusted non-pass grades

### DIFF
--- a/benchmarks/core/scoreboard.py
+++ b/benchmarks/core/scoreboard.py
@@ -10,7 +10,7 @@ import json
 from dataclasses import asdict, dataclass
 from typing import Optional
 
-from .grader import Criterion, GRADE_INSUFFICIENT, brain_allowed, grade_capability
+from .grader import Criterion, GRADE_INSUFFICIENT, GRADE_PASS, brain_allowed, grade_capability
 from .scoreboard_schema import CAPABILITY_META
 
 
@@ -156,6 +156,34 @@ def _empty_score_dict(capability_id: str) -> dict:
     }
 
 
+def _grade_reason(capability: dict) -> str:
+    """Honest, threshold-free reason for a non-pass grade.
+
+    The grader returns only a grade tier (no rationale), so we summarise the
+    already-computed metrics rather than re-deriving thresholds. Readiness
+    requires every non-pass mainline capability to carry a failure_reason.
+    """
+    grade = capability["grade"]
+    sample_count = capability.get("sample_count", 0) or 0
+    if sample_count == 0:
+        return f"{grade}:no_samples"
+    if not capability.get("confirmed", False):
+        return f"{grade}:insufficient_samples(n={sample_count})"
+    metric_bits = []
+    for key in (
+        "success_rate",
+        "false_trigger_rate",
+        "registered_recall",
+        "unknown_false_accept_rate",
+        "wrong_person_count",
+    ):
+        value = capability.get(key)
+        if value is not None:
+            metric_bits.append(f"{key}={value}")
+    detail = ",".join(metric_bits) if metric_bits else "metrics_below_threshold"
+    return f"{grade}:{detail}"
+
+
 def to_snapshot(scores: dict[str, CapabilityScore], run_meta: dict) -> dict:
     run_trusted = bool(run_meta.get("run_trusted", False))
     # fail-closed：preflight 非 pass，或無法確認 Jetson 跑的是被評分的這版 code
@@ -179,6 +207,8 @@ def to_snapshot(scores: dict[str, CapabilityScore], run_meta: dict) -> dict:
             if version_mismatch:
                 reason += ";version_mismatch=true"
             capability["failure_reason"] = reason
+        elif capability["grade"] != GRADE_PASS:
+            capability["failure_reason"] = _grade_reason(capability)
 
         capability["claim_level"] = meta["claim_level"]
         capability["risk_role"] = meta["risk_role"]

--- a/benchmarks/test/test_scoreboard.py
+++ b/benchmarks/test/test_scoreboard.py
@@ -131,3 +131,32 @@ def test_layer0_preflight_fail_forces_all_insufficient():
     assert cap["failure_reason"] == "layer0_preflight=fail"
     assert cap["success_rate"] is not None
     assert all(c["grade"] == "insufficient_data" for c in snap["capabilities"].values())
+
+
+def test_trusted_fail_capability_carries_failure_reason():
+    # false-trigger forces fail under a trusted run -> must carry a reason
+    recs = [_rec("gesture.wave", True, ft=True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": True})
+    cap = snap["capabilities"]["gesture.wave"]
+    assert cap["grade"] == GRADE_FAIL
+    reason = cap.get("failure_reason", "")
+    assert reason.startswith("fail:") and reason.strip()
+
+
+def test_trusted_pass_capability_has_no_failure_reason():
+    recs = [_rec("gesture.wave", True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": True})
+    cap = snap["capabilities"]["gesture.wave"]
+    assert cap["grade"] == GRADE_PASS
+    assert "failure_reason" not in cap
+
+
+def test_trusted_untested_capability_carries_reason():
+    recs = [_rec("gesture.wave", True) for _ in range(4)]
+    scores = aggregate(recs, CRIT, confirm_min=3)
+    snap = to_snapshot(scores, {"git_commit": "abc", "run_trusted": True})
+    cap = snap["capabilities"]["face.recognition"]
+    assert cap["grade"] == "insufficient_data"
+    assert cap.get("failure_reason", "").startswith("insufficient_data:")


### PR DESCRIPTION
## What
`to_snapshot` only set `failure_reason` when the *whole* snapshot was untrusted. Under a **trusted** run, an individual capability graded `fail`/`degraded`/`insufficient_data` carried **no** `failure_reason` — so `readiness` correctly flagged `mainline_failure_reason_missing` but the producer never supplied the reason (structurally incomplete snapshot).

## Change
- Add threshold-free `_grade_reason()` in `benchmarks/core/scoreboard.py` — summarises **already-computed** metrics, does NOT re-derive grader thresholds (single source of truth stays in `grader.py`).
- Apply it to every non-pass capability under a trusted run.
- e.g. `face.recognition` fail now carries `fail:registered_recall=0.5,unknown_false_accept_rate=1.0` (also better material for the 6/18 report).

## Tests
- +3 tests in `test_scoreboard.py` (trusted-fail carries reason / trusted-pass has none / trusted-untested carries reason).
- Full `benchmarks/test` suite: **112 passed, 2 skipped** under system python3.

## Notes
- Resolves the `mainline_failure_reason_missing` readiness follow-up (the other follow-up — venv missing `jsonschema` — fixed by `uv pip install jsonschema` into `/home/roy422/.venv`, env-only, no code change).
- Code by Codex; planned + reviewed by Claude (Linus-style: scope-clean, no test deletions, no threshold duplication).

🤖 Generated with [Claude Code](https://claude.com/claude-code)