### PR TITLE
feat(studio): /api/scoreboard frozen snapshot endpoint + unblock studio-ci

### DIFF
--- a/pawai-studio/frontend/components/chat/brain/dev-button.tsx
+++ b/pawai-studio/frontend/components/chat/brain/dev-button.tsx
@@ -8,12 +8,12 @@ import { useSheetStore } from "@/stores/sheet-store";
 function DevButtonInner() {
   const sp = useSearchParams();
   const pathname = usePathname();
+  const open = useSheetStore((s) => s.openSheet);
   // Guard 1: only render when ?dev=1 is present.
   if (sp.get("dev") !== "1") return null;
   // Guard 2: hide on /studio/dev itself — that page IS the dev panel,
   // a floating ⚙ would be redundant / confusing.
   if (pathname === "/studio/dev") return null;
-  const open = useSheetStore((s) => s.openSheet);
   return (
     <button
       type="button"

--- a/pawai-studio/frontend/package-lock.json
+++ b/pawai-studio/frontend/package-lock.json
@@ -95,7 +95,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -681,7 +680,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -731,6 +729,28 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1825,7 +1845,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2663,7 +2682,6 @@
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2674,7 +2692,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2746,7 +2763,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -3424,7 +3440,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3879,7 +3894,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4872,7 +4886,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5058,7 +5071,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5392,7 +5404,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -6099,7 +6110,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
       "integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8448,7 +8458,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8458,7 +8467,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9623,7 +9631,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9882,7 +9889,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10094,7 +10100,6 @@
       "integrity": "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -10886,7 +10891,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -541,6 +541,68 @@ async def get_capability():
     return {"ok": True, "capabilities": node.capability_snapshot()}
 
 
+# ── Baseline Scoreboard (read-only frozen snapshot, issue #76) ──────
+# Reads a frozen baseline_snapshot.json; NO live recompute, NO runtime
+# Brain gate. Path from PAWAI_SCOREBOARD_PATH (env override) else the repo
+# default artifacts/baseline/baseline_snapshot.json. Mirrors the resolution
+# in tools/pawai_cli/pawai_cli/readiness.py.
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_SCOREBOARD_REL = Path("artifacts/baseline/baseline_snapshot.json")
+
+
+def _scoreboard_path() -> Path:
+    override = os.environ.get("PAWAI_SCOREBOARD_PATH")
+    if override:
+        p = Path(override).expanduser()
+        return p if p.is_absolute() else _REPO_ROOT / p
+    return _REPO_ROOT / _DEFAULT_SCOREBOARD_REL
+
+
+def _read_scoreboard(path: Path) -> dict:
+    """Return a UI-ready scoreboard payload with explicit provenance.
+
+    provenance:
+      - "missing": file absent or unreadable/invalid JSON
+      - "frozen":  valid snapshot read from disk (always frozen — never live recompute)
+    last_tested_at is the snapshot-level timestamp (no per-capability time exists).
+    """
+    if not path.exists():
+        return {"provenance": "missing", "source_path": str(path), "capabilities": []}
+    try:
+        snap = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {"provenance": "missing", "source_path": str(path), "capabilities": []}
+
+    timestamp = snap.get("timestamp")
+    caps_in = snap.get("capabilities", {})
+    capabilities = []
+    for cap_id, cap in caps_in.items():
+        capabilities.append({
+            "capability_id": cap.get("capability_id", cap_id),
+            "grade": cap.get("grade"),
+            "failure_reason": cap.get("failure_reason", ""),
+            "brain_allowed": cap.get("brain_allowed"),
+            "last_tested_at": timestamp,
+        })
+    return {
+        "provenance": "frozen",
+        "source_path": str(path),
+        "schema_version": snap.get("schema_version"),
+        "run_trusted": snap.get("run_trusted"),
+        "version_mismatch": snap.get("version_mismatch"),
+        "git_commit": snap.get("git_commit") or snap.get("wsl_commit"),
+        "generated_at": timestamp,
+        "capabilities": capabilities,
+    }
+
+
+@app.get("/api/scoreboard")
+async def get_scoreboard():
+    """Read-only frozen baseline_snapshot.json (issue #76). No live recompute."""
+    return _read_scoreboard(_scoreboard_path())
+
+
 class PlanModePayload(BaseModel):
     mode: str  # "A" or "B"
 

--- a/pawai-studio/gateway/test_gateway.py
+++ b/pawai-studio/gateway/test_gateway.py
@@ -311,3 +311,48 @@ class TestTextNormalizationGateway:
         result = tn.to_traditional_tw("网络")
         assert result == "网络"
         tn._converter = None  # restore
+
+
+class TestScoreboardEndpoint:
+    """Tests for _read_scoreboard helper (issue #76 GET /api/scoreboard)."""
+
+    def test_missing_file_returns_missing_provenance(self, tmp_path):
+        from studio_gateway import _read_scoreboard
+        out = _read_scoreboard(tmp_path / "nope.json")
+        assert out["provenance"] == "missing"
+        assert out["capabilities"] == []
+
+    def test_frozen_snapshot_maps_fields(self, tmp_path):
+        from studio_gateway import _read_scoreboard
+        snap = {
+            "schema_version": "scoreboard-0.1",
+            "timestamp": "2026-06-03T06:49:40.049762+00:00",
+            "wsl_commit": "2e00914",
+            "run_trusted": True,
+            "version_mismatch": False,
+            "capabilities": {
+                "face.recognition": {
+                    "capability_id": "face.recognition",
+                    "grade": "fail",
+                    "brain_allowed": False,
+                },
+            },
+        }
+        p = tmp_path / "baseline_snapshot.json"
+        p.write_text(json.dumps(snap), encoding="utf-8")
+        out = _read_scoreboard(p)
+        assert out["provenance"] == "frozen"
+        assert out["run_trusted"] is True
+        assert out["version_mismatch"] is False
+        assert out["git_commit"] == "2e00914"
+        cap = out["capabilities"][0]
+        assert cap["capability_id"] == "face.recognition"
+        assert cap["grade"] == "fail"
+        assert cap["failure_reason"] == ""
+        assert cap["last_tested_at"] == snap["timestamp"]
+
+    def test_env_override_respected(self, tmp_path, monkeypatch):
+        from studio_gateway import _scoreboard_path
+        target = tmp_path / "custom.json"
+        monkeypatch.setenv("PAWAI_SCOREBOARD_PATH", str(target))
+        assert _scoreboard_path() == target


### PR DESCRIPTION
## What
- **`GET /api/scoreboard`** on the live studio gateway (`pawai-studio/gateway/studio_gateway.py`): read-only, serves a frozen `baseline_snapshot.json`. Returns `{provenance, run_trusted, version_mismatch, git_commit, generated_at, capabilities:[{capability_id, grade, failure_reason, brain_allowed, last_tested_at}]}`. **No live recompute, no runtime Brain gate** (that's #85). Path via `PAWAI_SCOREBOARD_PATH` else repo default `artifacts/baseline/baseline_snapshot.json`. `missing` provenance returns 200 (file absent is a normal case — `artifacts/baseline/` is gitignored).
- **Fix `dev-button.tsx` rules-of-hooks error** — `useSheetStore` was called after two early returns. Moved above the guards (behaviour-preserving). This is what was actually failing studio-ci's frontend lint since `a55f83a`; the prior `@emnapi/runtime` lockfile diagnosis was **wrong** (`npm ci` + `npm run build` both pass locally).

## Verify
- `pytest pawai-studio/gateway/test_gateway.py` → **28 passed, 1 skipped** (+3 new: missing/frozen/env-override).
- Functional: endpoint against the git-tracked frozen snapshot → `provenance=frozen git_commit=2e00914 run_trusted=True 15 caps face.recognition=fail`.
- `npm run lint` → **0 errors** (2 pre-existing unrelated warnings remain).

## Scope
Issue #76 gateway half + CI unblock. Frontend rendering (provenance badge / trace drawer / scoreboard chip) deferred to a fast-follow issue. Code by Codex; planned + reviewed by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)