### PR TITLE
docs(north-star): harden 3 overclaim sentences + first-trusted-face README

### DIFF
--- a/docs/mission/2026-06-18-demo-north-star.md
+++ b/docs/mission/2026-06-18-demo-north-star.md
@@ -96,7 +96,7 @@ Go2 機體大、重（**十多公斤級，約 15–20kg**），**居家空間不
 分兩層講，避免提前宣稱未經 baseline 的能力：
 
 - **目前（baseline 前）可說的「價值 / 角色語言」**：守望、提醒、回報、非接觸、可解釋互動、Studio evidence；以及「借鑑導盲犬的非接觸守望價值，但 6/18 不宣稱導盲能力」。
-- **通過 baseline（scoreboard 標 pass）後才說的「能力宣稱」**：短距安全移動、遇障安全停車、揮手互動、物件辨識——**每一項都要在 scoreboard 標 pass，才進旁白**；未 pass 前只在 Studio 顯示，不口頭宣稱。
+- **通過 baseline（scoreboard 標 pass）後才說的「能力宣稱」**：短距安全移動、遇障安全停車、揮手互動、物件辨識——**每一項都僅在該能力於 scoreboard 標 pass 後才進旁白**；其中「遇障安全停車」需 nav baseline run 標 pass（或明確人工安全 override）後才宣稱，未 pass 前一律 `insufficient_data`、只在 Studio 顯示、不口頭宣稱。
 
 ---
 
@@ -164,7 +164,7 @@ Go2 機體大、重（**十多公斤級，約 15–20kg**），**居家空間不
 - **fail**：不宣稱、不觸發
 - **insufficient_data**：不放行高風險動作（motion / nav）
 
-> **Brain 必須 fail-closed**：當能力為 `degraded` / `fail` / `insufficient_data` 時，**不得用該能力觸發 motion / nav 類動作**。**預計落點**是 `pawai_brain` 既有的 capability / effective_status 純函式——**目前該純函式有 gate 骨架但缺 health 維度，需補上 `capability_health` 分支後單測**（尚未存在，不是現成品）；不在 LLM prompt 層做。
+> **Brain 必須 fail-closed**：當能力為 `degraded` / `fail` / `insufficient_data` 時，**不得用該能力觸發 motion / nav 類動作**。此 health gate 落在 `pawai_brain` 既有的 effective_status 純函式（新增 `capability_health` 分支，#85 v0.2）——**6/18 預設關閉（fail-closed）、不接 runtime motion 觸發**，僅作為能力分級的設計落點，非現成的強制 gate，也不在 LLM prompt 層做。
 
 這也是 §4 demo promise 的執行機制：scoreboard 決定 Brain 能不能用某能力，而不是「功能寫了就用」。
 
@@ -174,7 +174,7 @@ Go2 機體大、重（**十多公斤級，約 15–20kg**），**居家空間不
 
 > PawAI 的 Edge AI 價值在於 **Jetson 端即時感知、ROS2 狀態整合、安全 gate、fallback 行為與 Studio evidence**。雲端 LLM / TTS 是**互動品質加分，不是系統可靠性的唯一來源**。
 
-具體證明：感知（face / pose / gesture / object）+ 安全層 + reactive_stop 全在 Jetson 邊緣跑。斷網時**可降級到本地感知 + 固定指令 / RuleBrain / Piper 的守望模式**，**需 baseline 驗證後**作為 Edge AI 證據（repo 已有 `sensevoice_local` / `whisper_local` / `piper` / RuleBrain fallback 線索，但語音主線含 Studio / Gateway / Cloud path，完整斷網閉環尚待 current-path baseline，不寫成已驗證完成品）。不要用桌機 GPU 標準評估 Jetson 表現。
+具體證明：感知（face / pose / gesture / object）+ 安全層 + reactive_stop 全在 Jetson 邊緣跑。斷網守望（本地感知 + 固定指令 / RuleBrain / Piper）是**設計上的目標路徑，尚未經 current-path baseline 驗證，因此目前只作為「設計意圖」陳述、不作為已成立的 Edge AI 證據**（repo 雖有 `sensevoice_local` / `whisper_local` / `piper` / RuleBrain fallback 線索，但現行語音主線仍走 Studio / Gateway / Cloud path，完整斷網閉環尚未在 current path 跑通；通過 baseline 後才升級為已驗證證據）。不要用桌機 GPU 標準評估 Jetson 表現。
 
 ---
 

--- a/docs/runbook/baseline-evidence/2026-06-03-first-trusted-face/README.md
+++ b/docs/runbook/baseline-evidence/2026-06-03-first-trusted-face/README.md
@@ -1,0 +1,53 @@
+# First Trusted Baseline Evidence — 2026-06-03 (face)
+
+專案第一份 **trusted** capability baseline 證據。這份資料夾把當天 HITL run 的 artifacts 永久固定進 git（`artifacts/baseline/` 本身是 gitignore，不可靠），讓今天的結果**可重現、可被 6/18 報告引用**。
+
+> 完整工程敘事（含上機坑、6/18 報告寫法、follow-up）見 [`../../2026-06-03-first-trusted-baseline-evidence.md`](../../2026-06-03-first-trusted-baseline-evidence.md)。
+
+## 一句話結論
+
+整條鏈路 `demo → preflight → observer → baseline_result.jsonl → build_scoreboard → trusted snapshot → readiness` **端到端打通並用真人驗證**。第一份 trusted snapshot：`run_trusted=True` / `version_mismatch=False` / `face.recognition=fail`（誠實揭露）/ readiness=`not_ready`（正確 fail-closed）。
+
+## 檔案清單
+
+| 檔案 | 內容 |
+|------|------|
+| `preflight_result.json` | Layer-0 preflight **pass** 案例（demo 起來、9/9 checks、warn=0） |
+| `preflight_result.fail.json` | Layer-0 preflight **fail** 案例（demo 沒開 → 3 blocking fail → snapshot 全 insufficient，驗 fail-closed） |
+| `baseline_result.jsonl` | 3 筆真 face record（roy_1m_01 positive→fail、roy_1m_02 positive→pass@1.67m、idle_01 idle→false-accept） |
+| `baseline_snapshot.json` | build_scoreboard 產出的 trusted snapshot（15 能力；face=fail，其餘 14 insufficient_data） |
+| `readiness_output.json` | `pawai readiness --json` 輸出（verdict=`not_ready`，誠實 fail-closed） |
+| `jetson_manifest.json` | 當次 Jetson `.pawai-last-deploy`（git_sha 對齊 WSL，version_mismatch=False 的依據） |
+
+## 為什麼 `face.recognition=fail` 也是可信證據
+
+`fail`（`registered_recall=0.5`、`unknown_false_accept_rate=1.0`、n=3）不是失敗，是**能力分級制度在運作的證明**：scoreboard 誠實標出「這項還不能進 Brain 主線」，Brain 依 §4 demo promise 對 fail 能力**不觸發、不宣稱**。6/18 的可信度來自 scoreboard 的誠實，不是嘴上說「我們有做」。
+
+## 重現指令
+
+```bash
+# 1) 工具（非互動固定時間窗 capture helper，取代 SSH 一行 capture 的引號/時序惡夢）
+benchmarks/scripts/capture_baseline_round.py        # 由 /tmp/bcap.py 正式化（PR #113）
+#   face  吃 /state/perception/face；percep 吃 gesture+object event
+
+# 2) Jetson 端產 JSONL（demo 起著、相機拉近 ~1.6m）
+python3 benchmarks/scripts/capture_baseline_round.py face \
+  --capability face.recognition --scenario-id roy_1m_02 \
+  --expected roy --kind positive --window 8 \
+  --out artifacts/baseline/baseline_result.jsonl
+
+# 3) 拉回 WSL 跑 build_scoreboard（必須在 WSL：Jetson git 在 rsync 後是壞的）
+python3 -m benchmarks.core.build_scoreboard <jsonl> \
+  --manifest <jetson .pawai-last-deploy> \
+  --preflight artifacts/baseline/preflight_result.json \
+  --out artifacts/baseline/baseline_snapshot.json
+
+# 4) readiness（pawai 在 WSL /home/roy422/.venv/bin/pawai，不在 PATH）
+PAWAI_SCOREBOARD_PATH=baseline_snapshot.json /home/roy422/.venv/bin/pawai readiness --json
+```
+
+## 已知關鍵坑（寫進工程筆記）
+
+- **build_scoreboard 必須在 WSL 跑**：Jetson git 在 rsync 後 `fatal: not a git repository` → version_mismatch 永遠 True → 全 insufficient。流程：observer 在 Jetson 產 JSONL → `scp` 回 WSL → WSL build。
+- **相機角度/距離是 face 偵測關鍵**（Go2/D435 移近 ~1.6m 才穩定認 roy）。
+- **face idle round**：round 前需離開鏡頭並等 5–8s 清 track（tracker 有 2.5s grace + hold，否則 idle false-accept 被汙染）。


### PR DESCRIPTION
## What
Per Roy's review of North Star v2 — tighten 3 sentences that read as premature claims of un-baselined capabilities, and add the missing evidence-folder README (Batch 3 polish).

**North Star v2 (`docs/mission/2026-06-18-demo-north-star.md`)**
- **§5 Non-Claims**: `遇障安全停車` now explicitly conditional on nav baseline `pass` (or explicit manual safety override); `insufficient_data` until then → display-only, no narration.
- **§9 Scoreboard-First**: capability health gate reframed as **#85 v0.2 — default-off, fail-closed, NOT wired to runtime motion at 6/18**. It's a design landing point, not a ready enforcing gate.
- **§10 Edge AI**: offline watch downgraded from a stated capability to **design-intent, not-yet-verified** (no current-path baseline) — upgrades to evidence only after baseline pass.

**Evidence README** (`docs/runbook/baseline-evidence/2026-06-03-first-trusted-face/README.md`)
- File index (6 artifacts), why `face=fail` is trustworthy evidence, reproduce commands, known gotchas (WSL-only build_scoreboard, camera distance, idle track-clear protocol).

## Why
Anti-overclaim discipline for the 6/18 report. No code touched; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)