### PR TITLE
feat(brain): capability health gate (#85 v0.2) — default-OFF gate + truth-table + allowlist single-source

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -79,6 +79,7 @@ jobs:
           # the duplicate top-level 'test' package collision with speech_processor/test
           PYTHONPATH=pawai_brain pytest \
             pawai_brain/test/test_effective_status.py \
+            pawai_brain/test/test_capability_health_gate.py \
             pawai_brain/test/test_mode_classifier.py \
             pawai_brain/test/test_response_repair.py \
             pawai_brain/test/test_skill_policy_gate.py \

--- a/pawai_brain/pawai_brain/capability/effective_status.py
+++ b/pawai_brain/pawai_brain/capability/effective_status.py
@@ -23,7 +23,64 @@ class _SkillLike(Protocol):
     kind: str
 
 
-def compute_effective_status(skill: _SkillLike, world: WorldFlags) -> tuple[str, str]:
+# -- Capability health gate (issue #85, v0.2 -- default-OFF, fail-closed) --
+@dataclass(frozen=True)
+class CapabilityHealth:
+    """Per-capability baseline health. All-None => gate inert (default-OFF)."""
+    grade: str | None = None            # pass | degraded | fail | insufficient_data | None
+    claim_level: str | None = None      # mainline | future | studio_only | not_claimed
+    dependency_role: str | None = None  # trigger | content | safety_guard | actuation | evidence
+    risk_role: str | None = None        # evidence_only | convenience | safety_critical | actuation | safety_support
+    brain_allowed: bool | None = None   # precomputed by grader; None = not wired
+
+
+_GATE_OFF = CapabilityHealth()
+# dependency_role values that gate motion/nav-class actions.
+_MOTION_KINDS = ("trigger", "safety_guard", "actuation")
+
+
+def _grade_gate(skill: _SkillLike, h: CapabilityHealth) -> tuple[str | None, str]:
+    """Fail-closed capability-health gate.
+
+    Returns (status, reason). status is None when the gate ABSTAINS -- either
+    default-OFF (no health wired) or a non-motion content/evidence passthrough --
+    letting the normal rule table continue. Never returns a less-restrictive
+    status. Unknown/missing grade is treated as insufficient_data (fail-closed).
+    """
+    # Default-OFF: no grade wired => abstain entirely (current behaviour preserved).
+    if h.grade is None and h.brain_allowed is None:
+        return None, ""
+
+    grade = h.grade if h.grade in ("pass", "degraded", "fail", "insufficient_data") else "insufficient_data"
+    dep = h.dependency_role
+    motion = bool(skill.has_motion_step or skill.has_nav_step)
+
+    if grade == "pass":
+        if h.brain_allowed is True:
+            return None, ""                      # healthy mainline => normal flow
+        # pass but not mainline-claimed (studio_only / future): block motion-class.
+        if dep in _MOTION_KINDS:
+            return "disabled", f"capability_not_mainline:{h.claim_level}"
+        return None, ""
+
+    if grade == "fail":
+        if dep == "trigger":
+            return "disabled", "capability_grade_fail:trigger"
+        if dep in ("safety_guard", "actuation"):
+            return "blocked", f"capability_grade_fail:{dep}"
+        if dep in ("content", "evidence"):
+            return None, ""                      # non-motion content/evidence => passthrough
+        return ("blocked", "capability_grade_fail:unknown_dep") if motion else (None, "")
+
+    # grade in {degraded, insufficient_data}: motion/nav class all blocked.
+    if dep in _MOTION_KINDS:
+        return "blocked", f"capability_{grade}:{dep}"
+    if motion and h.risk_role == "safety_critical":
+        return "blocked", f"capability_{grade}:safety_critical"
+    return None, ""
+
+
+def compute_effective_status(skill: _SkillLike, world: WorldFlags, health: CapabilityHealth = _GATE_OFF) -> tuple[str, str]:
     """Return (effective_status, reason). First match wins.
 
     Priority (matches Plan §4.5):
@@ -43,6 +100,12 @@ def compute_effective_status(skill: _SkillLike, world: WorldFlags) -> tuple[str,
         return "explain_only", ""
     if baseline == "explain_only":
         return "explain_only", ""
+
+    # Capability health gate (issue #85, default-OFF). Runs after hard-disable
+    # baselines so a healthy grade can never resurrect a disabled skill.
+    gated, gate_reason = _grade_gate(skill, health)
+    if gated is not None:
+        return gated, gate_reason
 
     if not skill.static_enabled:
         return "disabled", "靜態未啟用"

--- a/pawai_brain/pawai_brain/nodes/skill_policy_gate.py
+++ b/pawai_brain/pawai_brain/nodes/skill_policy_gate.py
@@ -14,7 +14,8 @@ from __future__ import annotations
 from ..state import ConversationState
 
 
-# Mirrors brain_node.LLM_PROPOSABLE_SKILLS — keep in sync.
+# Canonical LLM proposal allowlist (single source of truth, issue #85).
+# brain_node.py mirrors this; test_allowlist_single_source_of_truth enforces parity.
 LLM_PROPOSABLE_SKILLS: frozenset[str] = frozenset({
     "show_status",
     "self_introduce",

--- a/pawai_brain/test/test_capability_health_gate.py
+++ b/pawai_brain/test/test_capability_health_gate.py
@@ -42,33 +42,44 @@ def H(**kw):
 # -- _grade_gate unit truth table --
 
 def test_pass_mainline_abstains():
-    assert _grade_gate(_motion(), H(grade="pass", dependency_role="trigger", claim_level="mainline", brain_allowed=True)) == (None, "")
+    h = H(grade="pass", dependency_role="trigger",
+          claim_level="mainline", brain_allowed=True)
+    assert _grade_gate(_motion(), h) == (None, "")
 
 
 def test_pass_safety_guard_mainline_abstains():
-    assert _grade_gate(_motion(), H(grade="pass", dependency_role="safety_guard", claim_level="mainline", brain_allowed=True)) == (None, "")
+    h = H(grade="pass", dependency_role="safety_guard",
+          claim_level="mainline", brain_allowed=True)
+    assert _grade_gate(_motion(), h) == (None, "")
 
 
 def test_pass_not_mainline_blocks_motion_class():
-    s, r = _grade_gate(_motion(), H(grade="pass", dependency_role="trigger", claim_level="studio_only", brain_allowed=False))
+    h = H(grade="pass", dependency_role="trigger",
+          claim_level="studio_only", brain_allowed=False)
+    s, r = _grade_gate(_motion(), h)
     assert s == "disabled" and "not_mainline" in r
 
 
 def test_pass_future_actuation_disabled():
-    s, _ = _grade_gate(_motion(), H(grade="pass", dependency_role="actuation", claim_level="future", brain_allowed=False))
+    h = H(grade="pass", dependency_role="actuation",
+          claim_level="future", brain_allowed=False)
+    s, _ = _grade_gate(_motion(), h)
     assert s == "disabled"
 
 
 def test_fail_trigger_disabled():
-    assert _grade_gate(_motion(), H(grade="fail", dependency_role="trigger")) == ("disabled", "capability_grade_fail:trigger")
+    h = H(grade="fail", dependency_role="trigger")
+    assert _grade_gate(_motion(), h) == ("disabled", "capability_grade_fail:trigger")
 
 
 def test_fail_safety_guard_blocked():
-    assert _grade_gate(_motion(), H(grade="fail", dependency_role="safety_guard")) == ("blocked", "capability_grade_fail:safety_guard")
+    h = H(grade="fail", dependency_role="safety_guard")
+    assert _grade_gate(_motion(), h) == ("blocked", "capability_grade_fail:safety_guard")
 
 
 def test_fail_actuation_blocked():
-    assert _grade_gate(_motion(), H(grade="fail", dependency_role="actuation")) == ("blocked", "capability_grade_fail:actuation")
+    h = H(grade="fail", dependency_role="actuation")
+    assert _grade_gate(_motion(), h) == ("blocked", "capability_grade_fail:actuation")
 
 
 def test_fail_content_passthrough():
@@ -85,7 +96,8 @@ def test_fail_unknown_dep_motion_failclosed():
 
 
 def test_degraded_trigger_blocked():
-    assert _grade_gate(_motion(), H(grade="degraded", dependency_role="trigger")) == ("blocked", "capability_degraded:trigger")
+    h = H(grade="degraded", dependency_role="trigger")
+    assert _grade_gate(_motion(), h) == ("blocked", "capability_degraded:trigger")
 
 
 def test_degraded_safety_guard_blocked():
@@ -94,17 +106,20 @@ def test_degraded_safety_guard_blocked():
 
 
 def test_insufficient_trigger_blocked():
-    assert _grade_gate(_motion(), H(grade="insufficient_data", dependency_role="trigger")) == ("blocked", "capability_insufficient_data:trigger")
+    h = H(grade="insufficient_data", dependency_role="trigger")
+    assert _grade_gate(_motion(), h) == ("blocked", "capability_insufficient_data:trigger")
 
 
 def test_insufficient_safety_critical_corner_blocked():
-    # corner case: insufficient_data + motion + safety_critical (non-motion dep) => fail-closed block
-    s, r = _grade_gate(_motion(), H(grade="insufficient_data", dependency_role=None, risk_role="safety_critical"))
+    # corner: insufficient_data + motion + safety_critical (non-motion dep) => block
+    h = H(grade="insufficient_data", dependency_role=None, risk_role="safety_critical")
+    s, r = _grade_gate(_motion(), h)
     assert s == "blocked" and "safety_critical" in r
 
 
 def test_insufficient_content_passthrough():
-    assert _grade_gate(_say(), H(grade="insufficient_data", dependency_role="content")) == (None, "")
+    h = H(grade="insufficient_data", dependency_role="content")
+    assert _grade_gate(_say(), h) == (None, "")
 
 
 def test_unknown_grade_is_failclosed_insufficient():
@@ -129,11 +144,14 @@ def test_default_off_grade_none_brain_none_abstains():
 def test_hard_disable_wins_over_healthy_grade():
     # baseline disabled must NOT be resurrected by a passing grade.
     s = FakeSkill(baseline="disabled", has_motion_step=True)
-    status, _ = compute_effective_status(s, WorldFlags(), H(grade="pass", dependency_role="trigger", claim_level="mainline", brain_allowed=True))
+    h = H(grade="pass", dependency_role="trigger",
+          claim_level="mainline", brain_allowed=True)
+    status, _ = compute_effective_status(s, WorldFlags(), h)
     assert status == "disabled"
 
 
 def test_gate_blocks_through_compute_effective_status():
     # available skill + fail trigger grade => gate disables it.
-    status, reason = compute_effective_status(_motion(), WorldFlags(), H(grade="fail", dependency_role="trigger"))
+    h = H(grade="fail", dependency_role="trigger")
+    status, reason = compute_effective_status(_motion(), WorldFlags(), h)
     assert status == "disabled" and "grade_fail" in reason

--- a/pawai_brain/test/test_capability_health_gate.py
+++ b/pawai_brain/test/test_capability_health_gate.py
@@ -1,0 +1,139 @@
+"""Truth-table for the capability health gate (issue #85, v0.2)."""
+from dataclasses import dataclass
+
+from pawai_brain.capability.effective_status import (
+    CapabilityHealth,
+    WorldFlags,
+    _GATE_OFF,
+    _grade_gate,
+    compute_effective_status,
+)
+
+
+@dataclass
+class FakeSkill:
+    name: str = "x"
+    baseline: str = "available"
+    static_enabled: bool = True
+    enabled_when: list = None
+    cooldown_remaining_s: float = 0.0
+    has_say_step: bool = False
+    has_motion_step: bool = False
+    has_nav_step: bool = False
+    kind: str = "reactive"
+
+    def __post_init__(self):
+        if self.enabled_when is None:
+            self.enabled_when = []
+
+
+def _motion():
+    return FakeSkill(has_motion_step=True)
+
+
+def _say():
+    return FakeSkill(has_say_step=True)
+
+
+def H(**kw):
+    return CapabilityHealth(**kw)
+
+
+# -- _grade_gate unit truth table --
+
+def test_pass_mainline_abstains():
+    assert _grade_gate(_motion(), H(grade="pass", dependency_role="trigger", claim_level="mainline", brain_allowed=True)) == (None, "")
+
+
+def test_pass_safety_guard_mainline_abstains():
+    assert _grade_gate(_motion(), H(grade="pass", dependency_role="safety_guard", claim_level="mainline", brain_allowed=True)) == (None, "")
+
+
+def test_pass_not_mainline_blocks_motion_class():
+    s, r = _grade_gate(_motion(), H(grade="pass", dependency_role="trigger", claim_level="studio_only", brain_allowed=False))
+    assert s == "disabled" and "not_mainline" in r
+
+
+def test_pass_future_actuation_disabled():
+    s, _ = _grade_gate(_motion(), H(grade="pass", dependency_role="actuation", claim_level="future", brain_allowed=False))
+    assert s == "disabled"
+
+
+def test_fail_trigger_disabled():
+    assert _grade_gate(_motion(), H(grade="fail", dependency_role="trigger")) == ("disabled", "capability_grade_fail:trigger")
+
+
+def test_fail_safety_guard_blocked():
+    assert _grade_gate(_motion(), H(grade="fail", dependency_role="safety_guard")) == ("blocked", "capability_grade_fail:safety_guard")
+
+
+def test_fail_actuation_blocked():
+    assert _grade_gate(_motion(), H(grade="fail", dependency_role="actuation")) == ("blocked", "capability_grade_fail:actuation")
+
+
+def test_fail_content_passthrough():
+    assert _grade_gate(_say(), H(grade="fail", dependency_role="content")) == (None, "")
+
+
+def test_fail_evidence_passthrough():
+    assert _grade_gate(_say(), H(grade="fail", dependency_role="evidence")) == (None, "")
+
+
+def test_fail_unknown_dep_motion_failclosed():
+    s, r = _grade_gate(_motion(), H(grade="fail", dependency_role=None))
+    assert s == "blocked" and "unknown_dep" in r
+
+
+def test_degraded_trigger_blocked():
+    assert _grade_gate(_motion(), H(grade="degraded", dependency_role="trigger")) == ("blocked", "capability_degraded:trigger")
+
+
+def test_degraded_safety_guard_blocked():
+    s, _ = _grade_gate(_motion(), H(grade="degraded", dependency_role="safety_guard"))
+    assert s == "blocked"
+
+
+def test_insufficient_trigger_blocked():
+    assert _grade_gate(_motion(), H(grade="insufficient_data", dependency_role="trigger")) == ("blocked", "capability_insufficient_data:trigger")
+
+
+def test_insufficient_safety_critical_corner_blocked():
+    # corner case: insufficient_data + motion + safety_critical (non-motion dep) => fail-closed block
+    s, r = _grade_gate(_motion(), H(grade="insufficient_data", dependency_role=None, risk_role="safety_critical"))
+    assert s == "blocked" and "safety_critical" in r
+
+
+def test_insufficient_content_passthrough():
+    assert _grade_gate(_say(), H(grade="insufficient_data", dependency_role="content")) == (None, "")
+
+
+def test_unknown_grade_is_failclosed_insufficient():
+    # bogus grade => treated as insufficient_data => motion-class blocked
+    s, _ = _grade_gate(_motion(), H(grade="bogus", dependency_role="safety_guard"))
+    assert s == "blocked"
+
+
+# -- default-OFF + integration with compute_effective_status --
+
+def test_default_off_gate_is_inert():
+    # No health wired => identical to today (2-arg call path).
+    world = WorldFlags()
+    assert compute_effective_status(_motion(), world) == ("available", "")
+    assert compute_effective_status(_motion(), world, _GATE_OFF) == ("available", "")
+
+
+def test_default_off_grade_none_brain_none_abstains():
+    assert _grade_gate(_motion(), H()) == (None, "")
+
+
+def test_hard_disable_wins_over_healthy_grade():
+    # baseline disabled must NOT be resurrected by a passing grade.
+    s = FakeSkill(baseline="disabled", has_motion_step=True)
+    status, _ = compute_effective_status(s, WorldFlags(), H(grade="pass", dependency_role="trigger", claim_level="mainline", brain_allowed=True))
+    assert status == "disabled"
+
+
+def test_gate_blocks_through_compute_effective_status():
+    # available skill + fail trigger grade => gate disables it.
+    status, reason = compute_effective_status(_motion(), WorldFlags(), H(grade="fail", dependency_role="trigger"))
+    assert status == "disabled" and "grade_fail" in reason

--- a/pawai_brain/test/test_skill_policy_gate.py
+++ b/pawai_brain/test/test_skill_policy_gate.py
@@ -84,13 +84,40 @@ def test_skill_with_surrounding_whitespace_stripped():
 
 # ── allowlist contract ──────────────────────────────────────────────────
 
-def test_allowlist_matches_spec():
-    """Sync check: keep allowlist aligned with brain_node.LLM_PROPOSABLE_SKILLS."""
-    assert LLM_PROPOSABLE_SKILLS == frozenset({
+def _brain_node_allowlist() -> frozenset:
+    """Extract LLM_PROPOSABLE_SKILLS from interaction_executive.brain_node WITHOUT
+    importing it — the IE node pulls in rclpy, absent in the pure-Python Fast Gate.
+    AST keeps the cross-package parity check while preserving IE's decoupling."""
+    import ast
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    src = (repo_root / "interaction_executive" / "interaction_executive" / "brain_node.py").read_text(encoding="utf-8")
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "LLM_PROPOSABLE_SKILLS" for t in node.targets
+        ):
+            value = node.value
+            if isinstance(value, ast.Call):          # frozenset({...})
+                return frozenset(ast.literal_eval(value.args[0]))
+            return frozenset(ast.literal_eval(value))  # bare {...}
+    raise AssertionError("LLM_PROPOSABLE_SKILLS not found in brain_node.py")
+
+
+def test_allowlist_single_source_of_truth():
+    """Single source of truth for the LLM proposal allowlist (issue #85, Option A).
+
+    Both real copies — skill_policy_gate.LLM_PROPOSABLE_SKILLS (canonical, imported)
+    and interaction_executive.brain_node.LLM_PROPOSABLE_SKILLS (AST-extracted, no
+    import) — must equal the spec set. Drift in EITHER copy fails CI.
+    """
+    expected = frozenset({
         "show_status", "self_introduce",
         "wave_hello", "sit_along", "stand", "greet_known_person",
         "careful_remind", "wiggle", "stretch",
     })
+    assert LLM_PROPOSABLE_SKILLS == expected, "skill_policy_gate allowlist drifted from spec"
+    assert _brain_node_allowlist() == expected, "brain_node allowlist drifted from spec"
 
 
 # ── skill_policy_gate node integration ──────────────────────────────────


### PR DESCRIPTION
## What (issue #85 v0.2)
A fail-closed **capability health gate** that maps baseline `grade` → runtime ALLOW/BLOCK, so an unreliable capability cannot trigger motion/nav. **Default-OFF** — no runtime behaviour change at 6/18; this adds the capability + exhaustive tests + opt-in.

### 1. Gate logic (`pawai_brain/.../capability/effective_status.py`)
- `CapabilityHealth` dataclass + `_grade_gate()` added to the pure `effective_status` function (3rd param `health=_GATE_OFF`).
- Truth table: `grade × dependency_role × claim_level → status`.
- **Safety invariants (all tested):**
  - **default-OFF**: no health wired (2-arg call / `_GATE_OFF`) ⇒ behaviour identical to today.
  - **hard-disable wins**: disabled/studio_only/explain_only baselines checked BEFORE the gate ⇒ a passing grade can't resurrect a disabled skill.
  - **fail-closed**: unknown/missing grade ⇒ insufficient_data ⇒ motion blocked.
  - motion classes (trigger/safety_guard/actuation) blocked on fail/degraded/insufficient; `insufficient_data + motion + safety_critical` ⇒ blocked.
  - content/evidence (non-motion) pass through.

### 2. Truth-table tests (`pawai_brain/test/test_capability_health_gate.py`, NEW)
20 cases (unit `_grade_gate` + integration via `compute_effective_status` incl. default-OFF + hard-disable-wins). Wired into Fast Gate Invocation 2.

### 3. Allowlist single-source (Option A)
`test_allowlist_single_source_of_truth` now asserts **both** copies (skill_policy_gate canonical + brain_node mirror, AST-extracted so no rclpy import) equal the spec set — drift in either fails CI. IE stays decoupled (no new package dependency).

## Verify
- `test_capability_health_gate.py` 20 passed; `test_effective_status.py` 12 passed (regression, default-OFF unchanged); CI Invocation 2 set **216 passed**.

## Deferred (documented v0.3, NOT 6/18)
The **IE runtime second-gate** (brain_node dispatch consuming grade) + the **grade loader** (reads `baseline_snapshot.json` → health) + skill→capability_id map. These are the enforcing path — default-OFF means 6/18 doesn't need them, and they carry the real motion-leak risk (skill-map gaps), so they land separately after review. The gate logic + truth-table + allowlist single-source (this PR) are the verifiable core.

Code by Codex; safety logic authored + reviewed by Claude (Linus-style: fail-closed, no test deletions, hard-disable precedence proven).

🤖 Generated with [Claude Code](https://claude.com/claude-code)