### PR TITLE
fix(baseline): readiness hard-blocks non-pass mainline capability (false-ready regression)

### DIFF
--- a/benchmarks/core/readiness.py
+++ b/benchmarks/core/readiness.py
@@ -158,6 +158,11 @@ def _evaluate_capabilities(snapshot: dict[str, Any], reasons: list[str]) -> None
         if not grade:
             reasons.append(f"mainline_grade_missing:{capability_id}")
             continue
+        if grade != "pass":
+            # Hard fail-closed: a mainline capability that is not "pass" blocks
+            # readiness outright. Previously only the failure_reason-missing case
+            # was checked, so a documented non-pass grade leaked through as ready.
+            reasons.append(f"mainline_capability_not_pass:{capability_id}:{grade}")
         if grade != "pass" and not str(capability.get("failure_reason", "")).strip():
             reasons.append(f"mainline_failure_reason_missing:{capability_id}")
 

--- a/benchmarks/test/test_readiness.py
+++ b/benchmarks/test/test_readiness.py
@@ -86,6 +86,16 @@ def _hard_cases():
             DEPLOY_SHA,
             "mainline_failure_reason_missing:gesture.wave",
         ),
+        (
+            "mainline_not_pass_with_reason",
+            lambda: _mutated(
+                lambda snapshot: snapshot["capabilities"]["gesture.wave"].update(
+                    {"grade": "fail", "failure_reason": "fail:registered_recall=0.0"}
+                )
+            ),
+            DEPLOY_SHA,
+            "mainline_capability_not_pass:gesture.wave",
+        ),
     ]
 
 


### PR DESCRIPTION
## Bug (found by Roy)
`readiness.evaluate_readiness` returned **`verdict: ready`** when a MAINLINE capability was graded **non-pass** (e.g. `gesture.wave=fail`) as long as it carried a `failure_reason`.

`_evaluate_capabilities` only blocked on `grade != "pass" AND failure_reason missing` — it never blocked on `grade != "pass"` itself. PR #115 (per-capability `failure_reason`) began populating reasons for non-pass grades, which **unmasked this latent fail-open**: a documented fail/degraded/insufficient mainline capability leaked through as `ready`. This is the exact "failure_reason fix reverses fail-closed into false-ready" risk.

## Repro (before fix)
```
gesture.wave grade=fail + failure_reason set, all else valid
→ verdict = ready, reasons = []   ← WRONG
```

## Fix
- `benchmarks/core/readiness.py`: add an unconditional hard block `mainline_capability_not_pass:<id>:<grade>` for any mainline capability whose `grade != "pass"`. Keep the `failure_reason` check as a separate completeness signal.
- `benchmarks/test/test_readiness.py`: add the missing truth-table case (`mainline_not_pass_with_reason` — non-pass WITH reason) to `_hard_cases()`, so `test_fail_closed_truth_table_has_zero_fail_open` now catches this fail-open.

## Verify
- Repro now → `not_ready ['mainline_capability_not_pass:gesture.wave:fail']`.
- `test_all_checks_pass_is_ready` still **ready** (fixture's 11 mainline caps are all pass — no false block).
- `benchmarks/test` **113 passed, 2 skipped**.

Fixes a fail-open in the #87 readiness verdict logic (unmasked by #115). Bug found by Roy; fix planned + reviewed by Claude, code by Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)