### PR TITLE
feat(studio): #118 evidence UI (scoreboard chip + provenance badge + trace reason-guard) + route-paving docs

### DIFF
--- a/docs/pawai-brain/plans/2026-06-04-codex-workorders.md
+++ b/docs/pawai-brain/plans/2026-06-04-codex-workorders.md
@@ -1,0 +1,232 @@
+<!--
+來源：route-paving workflow synthesis @ HEAD 885728f，2026-06-04。行號/檔案皆 source-verified。
+執行狀態（Claude 維護）：
+- 工單 1 (#118 Studio 證據 UI)：✅ 授權、Codex 進行中（純前端，WSL 可驗，不碰 Jetson）。
+- 工單 2 (#120 gate→IE，default-OFF)：⏸ 待 Roy 授權（他明言「接之前要明確授權」；enforcement 是 motion-safety）。
+- 工單 3 (#80 mic_stop 接線)：⏸ 待 Roy 授權 + 須 demo stop 後才部署；會改 demo VAD 預設，現在做會污染本輪 voice baseline。
+- 工單 4 (schema_validator fail-closed 修正)：⏸ 低風險、非關鍵路徑（實際 blocker 是 sha_mismatch），待 Roy 一聲令下。
+-->
+
+# Codex Work-Orders — PawAI 軟體任務（2026-06-04，可在 WSL/dev 完成，無需 Jetson）
+
+> 前置事實（全部已在 HEAD `885728f` WSL 上驗證）：
+> - jetson SSH:22 目前 timeout（本批工單**完全不碰 Jetson/Go2**，純軟體）。
+> - 全部驗收指令在 WSL 跑：`cd /home/roy422/newLife/elder_and_dog`。
+> - frontend toolchain：node v24.11.0 / npm 11.6.1，`npm ci && npm run lint && npm run build` 在 HEAD 為綠。
+> - pawai_brain offline 測試 338、interaction_executive 221、`test_capability_health_gate.py` 20 —— **gate 預設 OFF 時三者必須維持綠**。
+> - `gh issue view` 無 `--json` 在本環境會 FETCH FAILED，要看 issue 一律加 `--json number,title,body,state,labels`。
+>
+> 誠實總則（North Star v2 §9 fail-closed）：能力分 pass/degraded/fail/insufficient_data；不可 over-claim；motion/nav 類 enforcement **預設關閉、未經 Roy 授權不得開啟**。
+
+---
+
+## 工單 1 — #118 Studio 證據 UI（provenance badge + scoreboard chip + trace reason-guard）
+
+### 目標
+在 Studio 前端把已經存在的後端 `GET /api/scoreboard`（frozen baseline 快照）顯示出來，並讓使用者一眼分辨資料來源是 **live(真 gateway) / mock(mock_server) / frozen(快照檔) / missing(檔不存在)**。Trace drawer 已大致建好，本工單只補「scoreboard chip + provenance badge + blocked/insufficient_data 一定要顯示 reason」三件事，**不重寫 drawer**。
+
+### 要動的檔案
+- 新增 `pawai-studio/frontend/hooks/use-scoreboard.ts`（GET `getGatewayHttpUrl()+"/api/scoreboard"`）
+- 新增 `pawai-studio/frontend/components/shared/scoreboard-chip.tsx`（mirror 既有 `components/shared/gate-chip.tsx`，用 `components/ui/badge.tsx`）
+- 新增 `pawai-studio/frontend/components/shared/provenance-badge.tsx`（4 態：live/mock/frozen/missing）
+- 改 `pawai-studio/frontend/contracts/types.ts`：新增 `ScoreboardResponse` + `ScoreboardCapability` + provenance/backend enum。**不要**重複定義已存在的 `ConversationTracePayload`（types.ts:431-464 已有）
+- 改 `pawai-studio/frontend/components/chat/brain/skill-trace-content.tsx`：對 `blocked` / `insufficient_data` 狀態，若 `detail` 為空則 render 一個可見警告（不可空白）。drawer 本體已建好，**只加這個 reason-guard**
+- 後端二選一加 backend 識別欄位（見下方契約決策）：改 `pawai-studio/backend/mock_server.py` + `pawai-studio/gateway/studio_gateway.py::_read_scoreboard`
+
+### 資料／API 契約
+後端 `GET /api/scoreboard`（studio_gateway.py:600-603，**已存在，不要重寫**）回傳：
+```
+{ provenance: "frozen"|"missing", source_path, schema_version, run_trusted,
+  version_mismatch, git_commit, generated_at,
+  capabilities: [ {capability_id, grade, failure_reason, brain_allowed, last_tested_at}, ... ] }
+```
+- **關鍵區分**：`provenance` 只表達「檔案身分」（frozen/missing），**不**表達 live/mock。live/mock 是「哪個 backend 在服務」這條獨立軸。
+- **契約決策（採用 Option B，符合 #118「mock 不得假裝 live」）**：
+  - gateway `_read_scoreboard` 回傳值新增 `"backend": "live"`。
+  - mock_server **新增** stub `GET /api/scoreboard`（目前 mock_server 沒有此 route，已驗證）回傳 `{"provenance":"mock","backend":"mock","capabilities":[]}`。
+- 前端 badge 邏輯：`backend==="mock"` → badge=mock；否則依 `provenance` 顯示 frozen/missing；fetch 失敗 → missing。
+- scoreboard-chip 4 欄：`capability_id` / `grade` / `failure_reason` / `last_tested_at`；fetch 失敗或 `provenance==="missing"` → 顯示 "missing"，**永不空白**。
+
+### 驗收（WSL，binary）
+```bash
+cd /home/roy422/newLife/elder_and_dog/pawai-studio/frontend && npm ci
+cd /home/roy422/newLife/elder_and_dog/pawai-studio/frontend && npm run lint      # 0 errors
+cd /home/roy422/newLife/elder_and_dog/pawai-studio/frontend && npm run build     # 12 routes 編譯成功，exit 0
+```
+- 三條全 exit 0 = 過。任何 lint error 或 build fail = 不過。
+- 後端 stub 驗證（在能起 backend 時）：`curl -s http://localhost:8080/api/scoreboard | python3 -m json.tool` 出現 `"backend"` 欄位；mock backend 回 `"backend":"mock"`。
+
+### 誠實/scope 護欄
+- chip/badge 只**顯示**快照，**不得**做 live recompute、不得觸發任何 motion/nav。
+- `grade==="fail"`/`insufficient_data` 的能力在 UI 必須清楚標示，不可用顏色或文案暗示「可用」。face 目前 committed 快照 = FAIL，UI 不得呈現為 pass。
+- mock 來源必須可見標記 mock，不得讓 demo 觀眾誤以為是真資料。
+
+### 不做（scope guard）
+- 不重寫 trace drawer（`skill-trace-content.tsx` 已 render 真 conversation_trace，只加 reason-guard）。
+- 不改 `use-event-stream.ts` / `stores/state-store.ts` 的既有 trace 流。
+- 不碰任何 Brain / IE / gate enforcement 邏輯（那是工單 4）。
+- 不動 gateway `/api/scoreboard` 的 frozen/missing 解析邏輯，只加一個 `backend` tag。
+
+---
+
+## 工單 2 — #120 capability health gate → IE runtime 接線（**預設 OFF，enforcement 未經 Roy 授權不得啟用**）
+
+### 目標
+把「已完成的」純 gate 邏輯（#85 v0.2，`effective_status._grade_gate` + `CapabilityHealth`）接到 IE runtime：新增 grade loader（讀 frozen 快照）、skill→capability_id 對照、IE 第二道 gate。**純 wiring，不新增 gate 數學。** 全部走 ROS param **預設 OFF**：OFF 時 runtime 與今天 byte-identical。
+
+> 紅旗：`capability_gate_enabled` 預設 `False`，且**不得**在任何 launch script / demo 入口設成 True。啟用是 motion-safety enforcement 變更，需 Roy 明確授權（CLAUDE.md「動 motion 先問」+ #120 RED-FLAG）。Codex 只寫 wiring 並保持 default-OFF。
+
+### 要動的檔案
+- 新增 `pawai_brain/pawai_brain/capability/health_loader.py`（讀快照 → `dict[capability_id → CapabilityHealth]` + skill→capability map）
+- 改 `interaction_executive/interaction_executive/brain_node.py`（第二道 gate + param 宣告 + 收斂 allowlist）
+- 改 `pawai_brain/pawai_brain/nodes/skill_policy_gate.py`（allowlist 收斂到單一來源）
+- 改 `pawai_brain/pawai_brain/capability/registry.py`（gate ON 時 `_skill_entry` 把 health 當第 3 引數傳給 `compute_effective_status`；目前 registry.py:81 是 2-arg default-OFF）
+- 新增 `pawai_brain/test/test_health_loader.py`
+
+### 資料／API 契約
+- **快照契約 = `pawai_brain/test/fixtures/baseline_snapshot.example.json`**（已讀，欄位與 `CapabilityHealth` 一一對應）：top-level `run_trusted` + `capabilities{cap_id:{capability_id, grade, claim_level, risk_role, dependency_role, brain_allowed, failure_reason?}}`。
+- `CapabilityHealth` 既有定義（effective_status.py:27-34）：`grade / claim_level / dependency_role / risk_role / brain_allowed`，欄位 1:1 map，**不可改這個 dataclass**。
+- **FAIL-CLOSED loader**：檔案不存在 / 不可讀 / JSON 壞 / schema invalid（schema 在 `.claude/schemas/baseline_snapshot.schema.json`，`jsonschema` 是 CI dep）/ `run_trusted==False` → 回傳「對每個 capability 都 yield `insufficient_data`」的 loader，**不得** try/except:pass 成空 dict（空 = 無意見 = 放行，禁止）。
+- **skill→capability_id 對照**（明確、小表）：`wave_hello→gesture.wave`；`sit_along/stand/wiggle/stretch→nav.short_move`；`show_status/self_introduce/careful_remind→content`（content 類非 motion，passthrough）。**未對照到的 motion skill → gate ON 時 fail-closed block**，不得 passthrough。
+- **IE 第二道 gate 位置**（brain_node.py `_on_chat_candidate`）：插在 allowlist 檢查（line 505）與 cooldown（line 515）之間。**必須同時 gate confirm 分支（line 541）與 trace_only 分支（line 563）**，不能只 gate execute（line 527）——否則 degraded motion skill 會被排進 OK-confirm 後執行。被 block 時用既有 `_emit_trace(stage="skill_gate", status="blocked", detail=reason)`（_emit_trace 簽名見 brain_node.py:886，kwargs-only）後 return。
+- **allowlist 收斂**：`brain_node.py:574-584` 與 `skill_policy_gate.py:19-29` 的 `LLM_PROPOSABLE_SKILLS` 重複，收斂成單一來源；parity 由 `test_skill_policy_gate.py` 保護，須維持綠。
+- **ROS param（default-OFF）**：`capability_gate_enabled`（bool，default `False`）+ `baseline_snapshot_path`（str，default `""`）。OFF = 不 load、不接 health、`compute_effective_status` 維持 2-arg 行為。
+
+### 驗收（WSL，binary）
+```bash
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest pawai_brain/test/test_capability_health_gate.py -q   # 20 passed
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest pawai_brain/test/ -q                                  # 338 passed（gate OFF 不得退）
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest interaction_executive/test/ -q                        # 221 passed（gate OFF 不得退）
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest pawai_brain/test/test_skill_policy_gate.py -q          # allowlist parity 綠
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest pawai_brain/test/test_health_loader.py -q             # 新測試全綠
+```
+新測試 `test_health_loader.py` 必須涵蓋（binary 斷言）：
+- loader 讀 `fixtures/baseline_snapshot.example.json` → 對應 capability 的 `CapabilityHealth` 欄位正確。
+- 檔案不存在 / `run_trusted=False` / JSON 壞 → **每個 capability 都回 `insufficient_data`**（不是空）。
+- skill→capability map：`wave_hello`→`gesture.wave`、`sit_along`→`nav.short_move`、未對照 motion skill → fail-closed。
+- gate ON + 把某 motion skill 對應到 fail/insufficient capability → IE 端產生 `skill_gate/blocked` trace（可用 IE unit test 斷言 `_emit_trace` 被以 status="blocked" 呼叫）。
+
+### 誠實/scope 護欄
+- `capability_gate_enabled` **預設 False**，OFF path 必須 byte-identical（既有 338+221 測試是這條的守門員）。
+- **不得**把 `capability_gate_enabled=True` 寫進任何 launch / demo / tmux 腳本，**不得**改 default。啟用需 Roy 授權。
+- gate 只在 IE / brain pure-function 層，**不在 LLM prompt 層**做（North Star §9）。
+- loader 不得 fail-open；任何不確定都退 `insufficient_data`。
+
+### 不做（scope guard）
+- 不改 `_grade_gate` / `CapabilityHealth` 數學（#85 v0.2 已凍結）。
+- 不真的去跑或產生 baseline 快照（那是 HITL，需 Jetson）。
+- 不接 Studio UI（那是工單 1）。
+- 不啟用 enforcement、不接真實 motion 觸發。
+
+---
+
+## 工單 3 — #80 mic_stop 訊號接線（手動斷句 → `/event/mic_boundary`）
+
+### 目標
+讓「Studio 按停止錄音」能立即發出手動斷句訊號，使 on-Jetson `stt_intent_node` 不必等 energy VAD timeout 就 finalize。新增 `/event/mic_boundary` topic：frontend stop → gateway WS handler → 發 `/event/mic_boundary` → `stt_intent_node` 訂閱 → finalize + 釋放 echo gate。約 4 檔、10–15 行核心邏輯。
+
+> ⚠️ 此工單動到語音主線。**只能在 demo 停掉後（`bash scripts/clean_full_demo.sh`）部署到 Jetson**——但部署/驗證是 Roy 的事，Codex 只寫 code 並讓 WSL 端編譯/測試過。
+>
+> ⚠️ 架構誠實提醒（已在 source 確認，務必讀懂再寫）：Studio 現行語音走 gateway `/ws/speech`（studio_gateway.py:742，前端送**整段 audio bytes** → gateway 端 cloud ASR），這與 on-Jetson `stt_intent_node` 的 energy_vad mic 路徑是**兩條不同管線**。mic_stop 的意義是給「on-Jetson stt mic 路徑 + 手動斷句」用的；不要把 `/ws/speech` 的整段上傳改造成串流。本工單只新增一條獨立的 `mic_stop` 控制訊號，不重構現有 `/ws/speech` 整段上傳流程。
+
+### 要動的檔案
+- `pawai-studio/frontend/hooks/use-audio-recorder.ts`：`stopRecording()`（line 239）在 `recorder.stop()` 後，透過 WS 送一筆 `{"type":"mic_stop", ...}` 控制訊息
+- `pawai-studio/gateway/studio_gateway.py`：新增 WS `mic_stop` handler；`GatewayNode` 新增 `mic_boundary_pub = create_publisher(String, "/event/mic_boundary", QOS_EVENT)`（mirror speech_pub at line 174）；收到 mic_stop 即 publish
+- `speech_processor/speech_processor/stt_intent_node.py`：新增 `create_subscription(String, "/event/mic_boundary", self._on_mic_boundary, 10)`（mirror line 387-401 既有訂閱）；callback 觸發 finalize 當前錄音 + 釋放 echo gate
+- `scripts/start_full_demo_tmux.sh`：stt_intent_node block 加 `-p energy_vad.enabled:=False`（目前未傳 → 預設 True，stt_intent_node.py:517）
+
+### 資料／API 契約
+- WS mic_stop 訊息（前端 → gateway）：`{"type":"mic_stop","session_id":<str optional>,"ts":<float>}`。
+- ROS topic `/event/mic_boundary`（gateway → stt）：`std_msgs/String`，payload JSON `{"event":"mic_stop","ts":<float>,"session_id":<str>}`。**此 topic 目前在全 source 為 0 引用（只存在 docs/plans），是全新增**。
+- `stt_intent_node._on_mic_boundary`：收到後立即結束當前 capture window 並送 ASR、釋放 echo gate（既有 echo gate 變數 `_tts_playing`/`_tts_gate_open_time` 在 stt_intent_node.py:395-396）。
+- 注意：mic_stop 接線後，e2e latency 才可能由手動斷句起算；**在 mic_stop 接好且 `energy_vad.enabled:=False` 前，baseline 量到的是 VAD-era latency**（從 speech_start_ts 起算，observer.py:219-222）。
+
+### 驗收（WSL，binary）
+```bash
+# Python 編譯（4 個 .py 都要過）
+cd /home/roy422/newLife/elder_and_dog && python3 -m py_compile speech_processor/speech_processor/stt_intent_node.py pawai-studio/gateway/studio_gateway.py
+# 語音模組單元測試不得退
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest speech_processor/test/ -q
+# 前端 lint+build（recorder 改動）
+cd /home/roy422/newLife/elder_and_dog/pawai-studio/frontend && npm ci && npm run lint && npm run build
+# grep 證明 topic 已接（3 端都要出現 /event/mic_boundary）
+cd /home/roy422/newLife/elder_and_dog && grep -rn "/event/mic_boundary" speech_processor/speech_processor/stt_intent_node.py pawai-studio/gateway/studio_gateway.py
+cd /home/roy422/newLife/elder_and_dog && grep -n "mic_stop" pawai-studio/frontend/hooks/use-audio-recorder.ts
+cd /home/roy422/newLife/elder_and_dog && grep -n "energy_vad.enabled:=False" scripts/start_full_demo_tmux.sh
+```
+- 全部 exit 0、grep 三端都命中 = 過。
+- （Jetson runtime 驗證屬 Roy，非本工單驗收）：部署後 `ros2 topic echo /event/mic_boundary`，按 Studio 停止 → 訊息立即出現、無 VAD timeout。
+
+### 誠實/scope 護欄
+- report 不得宣稱 "metric v2 (mic_stop 起算)" 或 "快 2 秒"，除非 mic_stop 已部署且 observer 真的改吃 mic_stop_ts。當前接線只是「讓 mic_stop 訊號存在並能 finalize」，latency 仍可能是 VAD-era，誠實標示為 OLD metric。
+- 若之後 e2e_median fail `≤3.5s`，那是 as-is-with-VAD 的誠實結果，不是 regression。
+- 不得在本工單就把 latency 改成 dual-record（mic_stop_ts / e2e_latency_ms_old 拆分）——那要等 observer 真的能拿到 mic_stop_ts（屬後續，不在此 scope）。
+
+### 不做（scope guard）
+- 不重構 `/ws/speech` 整段上傳為串流。
+- 不改 cloud ASR / intent classifier。
+- 不在本工單部署到 Jetson（部署需先停 demo，是 Roy 的步驟）。
+- 不改 `voice_csv_to_jsonl.py` 的 latency 記錄格式。
+
+---
+
+## 工單 4 — `schema_validator_unavailable` fail-closed 修正（readiness schema 驗證）
+
+### 目標
+修掉 `benchmarks/core/readiness.py` 的潛在 fail-OPEN：當 `import jsonschema` 失敗時，現行碼回 `schema_validator_unavailable:<Exc>`（verdict 正確 fail-closed），但 schema 驗證本身被**靜默跳過**——malformed 快照在沒有 jsonschema 時會「通過」schema 檢查。把 jsonschema 釘進 runtime deps（讓 import 在 readiness 環境永不失敗），並補測試鎖住 fail-closed 行為。
+
+### 要動的檔案
+- `benchmarks/core/readiness.py`（`_schema_error`，line 87-101；行為不必大改，重點是把 import 失敗變成不可能 + 補測試覆蓋）
+- 把 `jsonschema` 加進 pawai/benchmarks runtime 依賴宣告（找對應 `pyproject.toml` / `requirements*.txt` / `setup.py` 的 install_requires；以 repo 內真實存在的依賴宣告檔為準，**不要新建**慣例外的檔）
+- 新增/擴充 `benchmarks/test/test_readiness.py`：monkeypatch 模擬 `import jsonschema` 失敗，斷言 verdict 為 not_ready 且 reason 含 `schema_validator_unavailable`
+
+### 資料／API 契約
+- `_schema_error(snapshot, schema)` 回傳 `str | None`：
+  - import 失敗 → `"schema_validator_unavailable:<ExcClass>"`（保留 fail-closed）。
+  - schema 不符 → `"schema_invalid:<path>:<msg>"`（既有）。
+  - 通過 → `None`。
+- reason 一旦非 None 即進 `reasons` list → `evaluate_readiness` verdict = `not_ready`（fail-closed，**不可**改成 warning 或放行）。
+- schema 檔：`.claude/schemas/baseline_snapshot.schema.json`（已存在）。
+
+### 驗收（WSL，binary）
+```bash
+# jsonschema 在 readiness 環境可 import（系統 + venv 兩個都要）
+cd /home/roy422/newLife/elder_and_dog && python3 -c "import jsonschema; print('sys', jsonschema.__version__)"
+/home/roy422/.venv/bin/python -c "import jsonschema; print('venv', jsonschema.__version__)"
+# readiness 測試（含新 monkeypatch ImportError 案例）全綠
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest benchmarks/test/test_readiness.py -q
+# benchmarks 全套不得退
+cd /home/roy422/newLife/elder_and_dog && python3 -m pytest benchmarks/test/ -q
+# 對 frozen 6/3 快照跑真 readiness CLI，first reason 應為 sha 相關，不得是 schema_validator_unavailable
+cd /home/roy422/newLife/elder_and_dog && PAWAI_SCOREBOARD_PATH=artifacts/baseline/frozen/2026-06-03/baseline_snapshot.json /home/roy422/.venv/bin/pawai readiness --json
+```
+- 新測試斷言（binary）：patch `jsonschema` import 失敗時，`_schema_error` 回傳含 `schema_validator_unavailable` 的字串，且 `evaluate_readiness` verdict == not_ready。
+- 依賴宣告檔出現 `jsonschema`。
+- 上述全 exit 0 = 過。
+
+### 誠實/scope 護欄
+- 行為必須維持 **fail-closed**：缺 validator 時 verdict 不可變成 ready，也不可變成只是 warning。
+- 不可為了讓測試過就把 `schema_validator_unavailable` 降級成 pass-through。
+- 修的是「import 不該失敗 + 測試鎖住 fail-closed」，不是改變 readiness 的判定語意。
+
+### 不做（scope guard）
+- 不改 `_evaluate_sha` / version_mismatch / preflight 等其他 readiness reason 邏輯。
+- 不碰 `build_scoreboard` 的快照產生流程。
+- 不改 `.claude/schemas/baseline_snapshot.schema.json` 的 schema 內容（除非測試證明 schema 本身有 bug，那要另開工單）。
+- 不處理 `deploy_sha_missing` 的 SSH-down fallback（那是另一個獨立 code gap，不在本工單）。
+
+---
+
+### 四工單交付順序建議（無硬相依，可並行；若要排序）
+1. 工單 4（最小、純測試護欄）→ 2. 工單 1（前端，已驗證 toolchain 綠）→ 3. 工單 2（IE wiring，default-OFF）→ 4. 工單 3（語音主線，部署需 Roy 先停 demo）。
+
+相關檔案（絕對路徑）：
+- `/home/roy422/newLife/elder_and_dog/pawai-studio/gateway/studio_gateway.py`（`/api/scoreboard` line 600、`/ws/speech` line 742、publishers line 174）
+- `/home/roy422/newLife/elder_and_dog/pawai-studio/backend/mock_server.py`（缺 `/api/scoreboard`）
+- `/home/roy422/newLife/elder_and_dog/pawai_brain/pawai_brain/capability/effective_status.py`（`_grade_gate` line 42、2-arg default-OFF line 83）
+- `/home/roy422/newLife/elder_and_dog/pawai_brain/pawai_brain/capability/registry.py`（2-arg gate call line 81）
+- `/home/roy422/newLife/elder_and_dog/pawai_brain/test/fixtures/baseline_snapshot.example.json`（#120 loader 契約）
+- `/home/roy422/newLife/elder_and_dog/interaction_executive/interaction_executive/brain_node.py`（gate 插入點 line 505-570、allowlist line 574、`_emit_trace` line 886）
+- `/home/roy422/newLife/elder_and_dog/speech_processor/speech_processor/stt_intent_node.py`（訂閱 line 387、`energy_vad.enabled` default True line 517）
+- `/home/roy422/newLife/elder_and_dog/pawai-studio/frontend/hooks/use-audio-recorder.ts`（`stopRecording` line 239）
+- `/home/roy422/newLife/elder_and_dog/benchmarks/core/readiness.py`（`_schema_error` line 87-101）

--- a/docs/runbook/2026-06-18-hitl-oneshot-runbook.md
+++ b/docs/runbook/2026-06-18-hitl-oneshot-runbook.md
@@ -53,8 +53,13 @@ ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zs
 # 若 demo 沒在跑，冷啟（不要用 'pawai demo start' — 它會 P0-fail 於缺 brain .env）：
 # ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && bash scripts/start_full_demo_tmux.sh"'   # 等 ~50s
 
-# 0c. 在 Jetson 重生 PASS preflight（之後 run_trusted=True）。jsonschema 先裝（已知陷阱）：
-ssh jetson-nano 'python3 -m pip install --user jsonschema'
+# 0c-i. PRECHECK：jsonschema 是否在（run_preflight 需要）。不要在採集中途隱性裝環境。
+ssh jetson-nano 'python3 -c "import jsonschema" 2>/dev/null && echo JSONSCHEMA_OK || echo JSONSCHEMA_MISSING'
+#   若 JSONSCHEMA_MISSING → 在 GATE-0（採集前）補裝再繼續：
+#   - Jetson：`ssh jetson-nano 'python3 -m pip install --user jsonschema'`
+#     （專案慣例是 `uv pip install`，但 **Jetson 無 uv** 是已知例外，故 Jetson 端用 pip --user）
+#   - WSL 端若缺：`uv pip install jsonschema`（不要用裸 pip）
+# 0c-ii. 重生 PASS preflight（之後 run_trusted=True）：
 ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 benchmarks/scripts/run_preflight.py --profile demo --out artifacts/baseline/preflight_result.json"'   # status 必須 pass 或 pass_with_warnings
 
 # 0d. （建議）乾淨重起 JSONL（handoff 留了 ~9 筆 hitl-0603 face 記錄）。保留歷史、不刪除：
@@ -203,7 +208,7 @@ mkdir -p docs/runbook/baseline-evidence/2026-06-04-hitl && cp /tmp/baseline_resu
 ```
 **verdict 數學：** `ready` 只在 run_trusted=True AND preflight pass AND snapshot SHA == Jetson `.pawai-last-deploy`（WSL HEAD `885728f` 對得上）AND 15 caps 全在 AND 每個 mainline cap pass、非 pass 者帶 failure_reason。**本輪預期 NOT-ready**（face 可能轉 pass，但 nav/pose 仍 insufficient_data）— 這是正確的、誠實的 fail-closed 結果，不是失敗。
 
-**清掉 schema_validator_unavailable：** 已驗證**本輪非 blocker** — jsonschema 4.26.0 可在 `/home/roy422/.venv` import；對 stale snapshot 跑 readiness 第一個 reason 是 `sha_mismatch` 不是 schema_validator。**在 WSL 用該 venv 跑 build+readiness 就不會觸發。** 永久鎖法（Codex follow-up，非本輪）：把 jsonschema 釘進 pawai/benchmarks runtime deps + 加 ImportError 測試。若真看到 `schema_validator_unavailable:ModuleNotFoundError`：`/home/roy422/.venv/bin/pip install jsonschema`。
+**清掉 schema_validator_unavailable：** 已驗證**本輪非 blocker** — jsonschema 4.26.0 可在 `/home/roy422/.venv` import；對 stale snapshot 跑 readiness 第一個 reason 是 `sha_mismatch` 不是 schema_validator。**在 WSL 用該 venv 跑 build+readiness 就不會觸發。** 永久鎖法（Codex follow-up，非本輪）：把 jsonschema 釘進 pawai/benchmarks runtime deps + 加 ImportError 測試。若真看到 `schema_validator_unavailable:ModuleNotFoundError`：WSL 端 `uv pip install jsonschema`（裝進 `/home/roy422/.venv`，不要用裸 pip）。
 
 ---
 

--- a/docs/runbook/2026-06-18-hitl-oneshot-runbook.md
+++ b/docs/runbook/2026-06-18-hitl-oneshot-runbook.md
@@ -1,0 +1,239 @@
+<!--
+來源：route-paving workflow（audit×6 + Tournament 3 設計×3 評審 + synthesis）@ HEAD 885728f，2026-06-04。
+贏家 = 設計 #0（按物理場景分批，最省 Roy 時間），grafted #1 大樣本 / #2 GATE-0 BLOCKING。
+所有指令已對 repo source 實際驗證。
+
+⚠️ 順帶抓到 3 個既有「文件 bug」（本 runbook 已避開，修它們不在本 runbook 範圍）：
+1. baseline-runbook.md / capability-baseline-spec.md / baseline-issues-draft.md / 2026-05-31 plan 引用
+   topic `/event/nav/mission` 作 short_move 觀測 —— 此 topic 全 source 不存在，echo 它會永久 hang。
+   正確觀測 = `send_relative_goal.py` 的 action Result（success/message/actual_distance）。
+2. spec §4 gesture idle gate 寫 count-based（≤1/10min），build_scoreboard 實作是 rate-based
+   `unknown_false_accept_rate` —— 語意不一致；本 runbook 已標 rate-proxy。
+3. readiness 第一個 blocker 實測是 `sha_mismatch`（非先前以為的 `schema_validator_unavailable`）；
+   jsonschema 4.26.0 在 venv 可 import，schema 路徑本輪非 blocker（見 STEP 6 末）。
+-->
+
+# PawAI HITL Capability Baseline — 一次坐定 Runbook（Roy 回到 Jetson+Go2 後自己執行）
+
+**Repo HEAD:** main @ `885728f` · **pawai 路徑：** `/home/roy422/.venv/bin/pawai`（**不在 PATH**）
+**治理文件（嚴格遵守）：** `docs/mission/2026-06-18-demo-north-star.md`（North Star v2，fail-closed，誠實分級）
+**涵蓋：** #80 voice、#81 face、#82 gesture+object、#83 pose、#84 nav → build_scoreboard → readiness → freeze
+**估 Roy 體力時間：約 70 分鐘連續**（30 輪語音 ~12min 為最大宗；五次場景重配；idle 60s 窗 ×5；其餘 8s 窗）
+
+---
+
+## ⚠️ 先讀 — 誠實與安全護欄（不可違反）
+
+- **誠實鐵律：** 不追求全 pass，追求每個 issue 有真實結論（pass / degraded / fail / insufficient_data + reason）。不誇大、不擴張 scope。
+- **SSH 狀態與 brief 衝突：** brief 說 :22 timeout，但 audit 時 `ssh jetson-nano echo SSH_OK` 回 `SSH_OK`（port 22 是 UP）。**GATE-0 先實測**：通就照下面 `ssh` wrapper 跑；**若 SSH 已掛**，把 `ssh jetson-nano '...'` 外殼拿掉、直接在 Jetson `demo` tmux pane 貼內層 `zsh -lic "..."` 本體。**注意 readiness 與 scp 都吃 SSH（無離線 fallback）**，SSH 掛了 STEP 6 走不到 verdict=ready。
+- **face 已 commit 的真相 = FAIL**（n=3、registered_recall=0.5、unknown_false_accept_rate=1.0）。目標是**可信的重測**，不是保證 pass。即使乾淨 6/6 + 0 誤觸，每個 scenario_kind 若 n<3 仍被 grader 壓到 **degraded floor** → 所以 positive ≥3、idle ≥3。handoff 那份 n=9「expected PASS」**從未被 build 進 commit 的 snapshot**，不可據此宣稱 face PASS。
+- **voice e2e 是 VAD 時代，不是 metric-v2。** mic_stop **未接線**（`stt_intent_node.py` 只訂 vad/text/tts_playing；`energy_vad.enabled` 預設 True）。報告**不可**宣稱「mic_stop 起算」或「快 2 秒」。e2e_median 未達 ≤3.5s 是誠實的 as-is-with-VAD 結果，不是退步。mic_stop 接線（Codex，4 檔，動到語音主線）**延到 demo stop 後的另一場 session**，本輪不做。
+- **nav = 純 DRY-RUN，Go2 不可走。** **不要設 `/initialpose`**。**不要跑 `send_relative_goal.py --distance 0.5/1.0`**（那是真走的 KPI 行）。`/event/nav/mission` **不存在於 source** — 不要 `echo` 它（會永久 hang）。觀測值是 `send_relative_goal.py` 印出的 action Result（`success`/`message`/`actual_distance`）。
+- **pose = insufficient_data，不採集**（無 observer：`perception_baseline_observer` 只訂 gesture+object；`capture_baseline_round.py` 只有 `[face, percep]` 兩 mode，無 pose mode）。從 WSL 關閉。
+- **build_scoreboard + readiness 必須在 WSL 跑**（Jetson git 壞 → version_mismatch=True → 全部被壓 insufficient_data）。`--preflight` **強制**（省略 → run_trusted=False → 全部 insufficient_data）。
+- `run_speech_test.sh --nodes-running` 復用 demo 的 stt/tts/intent nodes — #80 voice 跑在**同一個正在跑的 demo** 上（perception demo 就是 speech demo，皆由 `start_full_demo_tmux.sh` 起）。**不要另起第二套 stack。**
+
+### SSH 指令樣板（handoff 驗證 — bash ssh 不帶 RMW env 會看到 0 nodes）
+```
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && <CMD>"'
+```
+> 所有 `===` echo 要加引號（zsh 把 `==` 當 glob）。遠端 for-loop 的 `\$i` 在遠端 zsh 展開。
+
+---
+
+## STEP 0 — PRECHECK GATE（BLOCKING；任何一項紅燈就停，不採集，~5 min，Roy 不用站到鏡頭前）
+
+```bash
+# 0a. SSH 連通 — 不印 SSH_OK 就 STOP（scp 與 readiness deploy-SHA 都吃 SSH，無離線 fallback）
+ssh -o ConnectTimeout=5 -o BatchMode=yes jetson-nano 'echo SSH_OK'   # 期望 SSH_OK exit 0
+
+# 0b. demo 是否還在跑（handoff：tmux session 'demo'，20 nodes）— 不要盲目重啟（會生重複 driver instance）
+ssh jetson-nano 'zsh -lic "tmux ls"'   # 期望有一個 session 叫：demo
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && timeout 6 ros2 topic hz /state/perception/face"'   # ~20Hz；幾行後 Ctrl-C
+# 若 demo 沒在跑，冷啟（不要用 'pawai demo start' — 它會 P0-fail 於缺 brain .env）：
+# ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && bash scripts/start_full_demo_tmux.sh"'   # 等 ~50s
+
+# 0c. 在 Jetson 重生 PASS preflight（之後 run_trusted=True）。jsonschema 先裝（已知陷阱）：
+ssh jetson-nano 'python3 -m pip install --user jsonschema'
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 benchmarks/scripts/run_preflight.py --profile demo --out artifacts/baseline/preflight_result.json"'   # status 必須 pass 或 pass_with_warnings
+
+# 0d. （建議）乾淨重起 JSONL（handoff 留了 ~9 筆 hitl-0603 face 記錄）。保留歷史、不刪除：
+ssh jetson-nano 'cd ~/elder_and_dog/artifacts/baseline && [ -f baseline_result.jsonl ] && mv baseline_result.jsonl baseline_result.$(date +%Y%m%d-%H%M%S).bak.jsonl || echo no-prior-jsonl'
+```
+**CHECKPOINT（三項全綠才往下）：** `SSH_OK` · `demo` tmux 在 · preflight status `pass`/`pass_with_warnings`。
+**若 preflight FAIL → 整條路線 STOP。** 沒有 pass preflight，build_scoreboard 會把每個能力壓成 insufficient_data。記錄：「GATE-0 preflight fail → 本輪無 trusted baseline」。
+
+---
+
+## SCENE 1 — Roy 坐在鏡頭+麥克風前（voice + face-positive）~18 min
+Roy 全程坐著面對鏡頭/麥克風。**Grade lane：voice.command → ≥80% pass（70-80 degraded、<70 fail，且 e2e_median≤3.5s、play_ok≥80%）；voice.stop → FN=0 才 pass（success_rate==1.0，任何一輪 miss = fail）；face positive 餵 registered_recall（≥0.80 pass / 0.60-0.80 degraded / <0.60 fail）。**
+
+```bash
+# --- #80 VOICE（跑在正在跑的 demo 上；復用其 stt/tts nodes，不 rebuild、不重啟 driver）---
+# 互動式：每輪提示，講出該句、按 Enter。30 輪含 6 stop 輪。
+ssh -t jetson-nano 'zsh -lic "cd ~/elder_and_dog && bash scripts/run_speech_test.sh --nodes-running"'
+# 輸出 CSV → ~/elder_and_dog/test_results/speech_test_<ts>.csv（+ _summary.json 含 grade/e2e median/play_ok）
+# 6 個 stop 輪（停/停止/不要動/請你停下來/別動別動別動/欸等一下先停住）每輪都要 match==hit → voice.stop FN=0
+
+# --- #81 FACE positive（Roy 不離座，只調距離）---
+# roy @ ~1m（鏡頭 1.0-1.2m，面對鏡頭，整個窗保持不動）×3：
+for s in 01 02 03; do
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 benchmarks/scripts/capture_baseline_round.py face --capability face.recognition --scenario-id roy_1m_'"$s"' --expected roy --kind positive --distance 1.0 --window 8 --run-id hitl-0604-face --out artifacts/baseline/baseline_result.jsonl"'
+done
+# roy @ ~2m（椅子退到 ~2.0m）×3：
+for s in 01 02 03; do
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 benchmarks/scripts/capture_baseline_round.py face --capability face.recognition --scenario-id roy_2m_'"$s"' --expected roy --kind positive --distance 2.0 --window 8 --run-id hitl-0604-face --out artifacts/baseline/baseline_result.jsonl"'
+done
+```
+> 提示：6/3 證據顯示 roy 實際鎖在 ~1.5-1.9m 深度；宣告 1.0m 可能 miss。1m 輪 miss 會誠實拉低 recall — **不要改模型/閾值**（#81 scope-guard 第 10 項：sim_threshold、YuNet/SFace、re-enroll 都不准動，除非零成本修正後 unknown_false_accept_rate 仍 >10%）。distance_m 只有在「命中」時才由 D435 深度覆寫；miss/idle 記的是宣告值（manual_declared），missed 輪別誇大量測距離。
+> **若失敗記這個：** voice 任何 stop 輪 match≠hit → voice.stop = **FAIL**（單一 miss 即 fail）。voice e2e_median>3.5s → 標「VAD 時代延遲，mic_stop 尚未接線」，非系統退步。face 1m 鎖不到 → 記 MISS（誠實拉低 recall，lane FAIL/DEGRADED）。
+
+---
+
+## SCENE 2 — Roy 離開畫面，再放鬆入鏡（所有 idle 輪一次打包）~14 min
+**Grade lane（全是硬性誤觸閘）：face unknown_false_accept_rate ≤0.03 pass / 0.03-0.10 degraded / >0.10 fail；gesture idle unknown_false_accept_rate ≤0.10 pass / 0.10-0.30 degraded（RATE proxy，非字面 count gate）；object idle ≤0.01 pass / 0.01-0.10 degraded。**
+
+```bash
+# 關鍵：每個 face/gesture idle 輪前，Roy 完全離開畫面並等 >=8s（tracker grace/hold ~2.5s；
+# 這 8s 離框正是修掉 6/3 false_accept_rate=1.0 污染的關鍵）。發 idle 窗前先確認沒有 roy track：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && timeout 4 ros2 topic echo /state/perception/face --once"'   # tracks 空 或 stable_name!=roy
+
+# --- #81 FACE idle = 空畫面 ×3（expected=unknown、kind=idle）---
+for s in 01 02 03; do
+# Roy：離框、等 8s、才發：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 benchmarks/scripts/capture_baseline_round.py face --capability face.recognition --scenario-id idle_empty_'"$s"' --expected unknown --kind idle --distance 1.0 --window 12 --run-id hitl-0604-face --out artifacts/baseline/baseline_result.jsonl"'
+done
+
+# --- #82 GESTURE idle ×3（Roy 入鏡 ~1.5m，手放鬆，不刻意比手勢；60s 窗）---
+for s in 01 02 03; do
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 benchmarks/scripts/capture_baseline_round.py percep --capability gesture.wave --scenario-id wave_idle_'"$s"' --expected none --kind idle --window 60 --run-id hitl-0604-percep --out artifacts/baseline/baseline_result.jsonl"'
+done
+
+# --- #82 OBJECT idle ×2（畫面無杯子；60s 窗）---
+for s in 01 02; do
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 benchmarks/scripts/capture_baseline_round.py percep --capability object.cup --scenario-id cup_idle_'"$s"' --expected none --kind idle --window 60 --run-id hitl-0604-percep --out artifacts/baseline/baseline_result.jsonl"'
+done
+```
+> 要記的 caveat：face idle 是**空畫面**（無陌生人在場）→ 陌生人拒絕 **未驗證**。合 spec（face 是 evidence_only，無 guardian/stranger-alert 宣稱 — North Star §5），但 snapshot 要帶這個 caveat。若有第二人在場，可額外跑 `stranger_1m_01`（仍 `--expected unknown --kind idle`）作真實 false-accept 驗證。
+> **若失敗記這個：** idle 輪預測出 roy → false_accept，加長離框時間重做（不改模型）。gesture idle 閘是 `unknown_false_accept_rate`（RATE），spec §4 是 count gate（≤1/10min）— 標「rate-based proxy，非字面 count gate」，grade 別過度解讀。
+
+---
+
+## SCENE 3 — Roy 站 ~1.5-2m 揮手（gesture-positive）~6 min
+**Grade lane：gesture.wave success_rate ≥0.90 pass / 0.80-0.90 degraded / <0.80 fail。** wave confidence 硬寫死 1.0（`vision_perception_node.py:414`）→ recall 是 **100% 人工 ground-truth**；Roy 須目視確認每個窗都是真揮手。
+
+```bash
+# smoke：確認 recognizer backend 有發 wave（Roy 在 ~1.5m 揮手）：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && timeout 20 ros2 topic echo /event/gesture_detected --once"'   # 期望 "gesture":"wave"
+# wave 近 ~1m ×10（手舉著、連續揮）：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && for i in 01 02 03 04 05 06 07 08 09 10; do echo wave_1m_\$i; python3 benchmarks/scripts/capture_baseline_round.py percep --capability gesture.wave --scenario-id wave_1m_\$i --expected wave --kind positive --distance 1.0 --window 8 --run-id hitl-0604-percep --out artifacts/baseline/baseline_result.jsonl 2>&1 | tail -2; sleep 3; done"'
+# wave 遠 ~2m ×10：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && for i in 01 02 03 04 05 06 07 08 09 10; do echo wave_2m_\$i; python3 benchmarks/scripts/capture_baseline_round.py percep --capability gesture.wave --scenario-id wave_2m_\$i --expected wave --kind positive --distance 2.0 --window 8 --run-id hitl-0604-percep --out artifacts/baseline/baseline_result.jsonl 2>&1 | tail -2; sleep 3; done"'
+```
+> **若失敗記這個：** confidence 寫死 1.0 → recall/誤觸 是 100% 人工判讀；Roy 目視標每個窗 hit/miss。某窗在 recognizer 未出 wave → 記 MISS（誠實拉低 recall）。在 snapshot grade pass 前，Studio 只「顯示」手勢、**不觸發動作**（§4/§9）。
+
+---
+
+## SCENE 4 — 桌上放杯子 + 雜物（object-positive）~4 min
+**Grade lane：object.cup success_rate ≥0.80 pass / 0.60-0.80 degraded / <0.60 fail。**
+
+```bash
+# 先 SMOKE GATE — object_perception TRT 首建 3-10 分鐘。TRT 編譯中發 cup 窗 = 假 miss。
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && timeout 15 ros2 topic hz /perception/object/debug_image"'   # 期望 ~6-8 Hz；若 0 Hz，等、再測
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && timeout 20 ros2 topic echo /event/object_detected --once"'   # 杯子在桌上 → class_name==cup
+# cup 近 ~1m ×5（杯子放桌上 + 背景雜物；不在地上、不在手上）：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && for i in 01 02 03 04 05; do echo cup_1m_\$i; python3 benchmarks/scripts/capture_baseline_round.py percep --capability object.cup --scenario-id cup_1m_\$i --expected cup --kind positive --distance 1.0 --window 8 --run-id hitl-0604-percep --out artifacts/baseline/baseline_result.jsonl 2>&1 | tail -2; sleep 3; done"'
+# cup 遠 ~2m ×5：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && for i in 01 02 03 04 05; do echo cup_2m_\$i; python3 benchmarks/scripts/capture_baseline_round.py percep --capability object.cup --scenario-id cup_2m_\$i --expected cup --kind positive --distance 2.0 --window 8 --run-id hitl-0604-percep --out artifacts/baseline/baseline_result.jsonl 2>&1 | tail -2; sleep 3; done"'
+# 確認記錄都落地：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && grep -c gesture.wave artifacts/baseline/baseline_result.jsonl; grep -c object.cup artifacts/baseline/baseline_result.jsonl; grep -c face.recognition artifacts/baseline/baseline_result.jsonl"'
+```
+> **若失敗記這個：** cup 窗在 TRT 未暖前發 → 丟掉該輪（假 miss，別讓它污染 cup_recall）。debug_image 0 Hz = TRT 還在編，等。
+
+---
+
+## SCENE 5 — Go2 區域，nav DRY-RUN（不可走）~8 min
+**Grade lane：4 個 nav 能力全 = insufficient_data（設計如此）。無 baseline record、無 motion_sign_off（無動作）。**
+nav 要 **nav_capability lane**，不是 perception demo。voice/perception 採集已落 disk，現在停 demo 沒問題。
+
+```bash
+# （可選）停 perception demo 釋放 stack：
+# ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && bash scripts/clean_full_demo.sh"'
+# 起 nav lane（Go2 通電；Phase 10 stack）。等 ~50s：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && ROBOT_IP=192.168.123.161 MAP=/home/jetson/maps/home_living_room_v8.yaml bash scripts/start_nav_capability_demo_tmux.sh"'
+# 確認 action server + 站立 topics（無動作）：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && ros2 action list | grep nav && ros2 topic hz /state/nav/heartbeat"'
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && timeout 4 ros2 topic echo /state/nav/safety --once"'
+# *** DRY-RUN：不要設 /initialpose。AMCL 未定位下，goal 被 accept 後立即 abort → Go2 不動。 ***
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && source /opt/ros/humble/setup.zsh && source install/setup.zsh && python3 scripts/send_relative_goal.py --distance 0.3"'
+# 期望誠實 dry-run：success=False message='amcl_lost'（或 odom_lost_driver_disconnected / nav2_unavailable）。Go2 不動。
+# 這證明 client->server->AMCL-gate 鏈路端到端接通且零動作。
+# 不要 echo /event/nav/mission（不存在）。不要跑 --distance 0.5/1.0（那會走 Go2）。
+```
+> **若失敗記這個：** result success=True 或 Go2 動了 → 立刻 `clean_full_demo.sh`，記「/initialpose 殘留致 AMCL 已定位」。其餘照常記 insufficient_data。
+
+---
+
+## STEP 6 — BUILD SNAPSHOT + READINESS + FREEZE（全 WSL，Roy 在鍵盤前）~10 min
+```bash
+cd /home/roy422/newLife/elder_and_dog
+# 6a. 轉 voice CSV → JSONL（tag voice.command / voice.stop）。先找最新 CSV：
+NEWEST=$(ssh jetson-nano 'ls -t ~/elder_and_dog/test_results/*.csv | head -1')
+scp "jetson-nano:$NEWEST" /tmp/voice.csv
+python3 benchmarks/scripts/voice_csv_to_jsonl.py --csv /tmp/voice.csv --out /tmp/voice_baseline.jsonl --run-id hitl-0604-voice --stop-intent stop
+# voice.stop FN 檢查（6 stop 輪要 ZERO 'fail'）：
+grep '"capability_id": "voice.stop"' /tmp/voice_baseline.jsonl | grep '"pass_fail": "fail"'   # 期望「無輸出」= FN=0
+# 6b. 拉 perception+face JSONL、manifest、preflight 下來：
+scp jetson-nano:'~/elder_and_dog/artifacts/baseline/baseline_result.jsonl' /tmp/baseline_result.jsonl
+scp jetson-nano:'~/elder_and_dog/artifacts/baseline/preflight_result.json' /tmp/preflight_result.json
+scp jetson-nano:'~/elder_and_dog/.pawai-last-deploy' /tmp/jetson_manifest.json
+# 6c. 把 voice JSONL 併進同一個 baseline（aggregator 按 capability_id+scenario_kind 分組，非時間）：
+cat /tmp/voice_baseline.jsonl >> /tmp/baseline_result.jsonl
+# 6d. 在 WSL build snapshot（--preflight 強制）：
+python3 -m benchmarks.core.build_scoreboard /tmp/baseline_result.jsonl --manifest /tmp/jetson_manifest.json --preflight /tmp/preflight_result.json --out /tmp/baseline_snapshot.json
+# 6e. 看你關心的 graded rows：
+python3 -c "import json;c=json.load(open('/tmp/baseline_snapshot.json'))['capabilities'];print(json.dumps({k:c[k] for k in ['face.recognition','voice.command','voice.stop','gesture.wave','object.cup']},ensure_ascii=False,indent=2))"
+# 6f. readiness verdict（需 SSH up — 經 SSH 讀 live deploy SHA）：
+PAWAI_SCOREBOARD_PATH=/tmp/baseline_snapshot.json /home/roy422/.venv/bin/pawai readiness --json
+# 6g. freeze 給 demo day（複製 artifacts/baseline/baseline_snapshot.json → frozen/2026-06-18/）：
+cp /tmp/baseline_snapshot.json artifacts/baseline/baseline_snapshot.json
+/home/roy422/.venv/bin/pawai readiness freeze --date 2026-06-18
+# 6h. 把 evidence 凍進 git-tracked 資料夾（artifacts/baseline 在 gitignore）：
+mkdir -p docs/runbook/baseline-evidence/2026-06-04-hitl && cp /tmp/baseline_result.jsonl /tmp/baseline_snapshot.json /tmp/preflight_result.json /tmp/jetson_manifest.json docs/runbook/baseline-evidence/2026-06-04-hitl/
+```
+**verdict 數學：** `ready` 只在 run_trusted=True AND preflight pass AND snapshot SHA == Jetson `.pawai-last-deploy`（WSL HEAD `885728f` 對得上）AND 15 caps 全在 AND 每個 mainline cap pass、非 pass 者帶 failure_reason。**本輪預期 NOT-ready**（face 可能轉 pass，但 nav/pose 仍 insufficient_data）— 這是正確的、誠實的 fail-closed 結果，不是失敗。
+
+**清掉 schema_validator_unavailable：** 已驗證**本輪非 blocker** — jsonschema 4.26.0 可在 `/home/roy422/.venv` import；對 stale snapshot 跑 readiness 第一個 reason 是 `sha_mismatch` 不是 schema_validator。**在 WSL 用該 venv 跑 build+readiness 就不會觸發。** 永久鎖法（Codex follow-up，非本輪）：把 jsonschema 釘進 pawai/benchmarks runtime deps + 加 ImportError 測試。若真看到 `schema_validator_unavailable:ModuleNotFoundError`：`/home/roy422/.venv/bin/pip install jsonschema`。
+
+---
+
+## STEP 7 — 關 issue + 清環境（~5 min，WSL）
+```bash
+# 讀 issue body 用 --json（純 gh issue view 在此環境回空）：gh issue view <n> --repo roy4222/PawAI --json number,title,body,state,labels
+# #83 pose — 關 insufficient_data（無 observer、studio_only/P2）：
+gh issue comment 83 --repo roy4222/PawAI --body 'pose.basic = insufficient_data (no_samples). 觀測管線未接：perception_baseline_observer 只訂 gesture+object；capture_baseline_round.py 只有 face/percep mode，無 pose mode。studio_only/P2（North Star §5/§8），scope-guard 不換模型。pose.fall 維持 insufficient_data（幻覺未解，§5 禁宣稱）。本輪不收 record、不擋 6/18 freeze。'
+gh issue close 83 --repo roy4222/PawAI --reason completed
+# #84 nav — 4 caps 全 insufficient_data（dry-run 完成，無動作）：
+gh issue comment 84 --repo roy4222/PawAI --body 'nav 四能力全 insufficient_data。safe_stop=recorder BD-7 未接；no_auto_resume=BD-8 行為衝突待重設計；short_move=僅 dry-run（/nav/goto_relative --distance 0.3 未設 /initialpose 被 AMCL gate 以 amcl_lost abort，證明 action 鏈路通且 Go2 全程不動，安全先於移動鐵律 §7 未滿足前不跑真實 motion）；dynamic_avoidance=stop-only/future。修正：/event/nav/mission 不存在於 source，實際觀測是 action result(success/message/actual_distance)。本輪無真實 motion，無 motion_sign_off record。'
+gh issue close 84 --repo roy4222/PawAI --reason completed
+# 用 snapshot rows 的真實 grade + reason 關 #80、#82（face #81 視 grade 決定）；#88 tracking 最後關。
+# 不要據 6/3 handoff prose 宣稱 face PASS — 只有本輪乾淨重採重 build 的 snapshot 能改 grade。
+# 停一切：
+ssh jetson-nano 'zsh -lic "cd ~/elder_and_dog && bash scripts/clean_full_demo.sh"'   # 若 perception demo 還在
+# mic_stop 接線（Codex，4 檔）延到 demo stop 後的另一場 session — 動到語音主線，不可中途部署。本輪 voice 量 AS-IS-WITH-VAD。
+```
+
+---
+
+## 本輪預期誠實 grade
+| Cap | Lane | 備註 |
+|---|---|---|
+| voice.command | pass-eligible（≥80%） | VAD 時代 e2e，非 metric-v2 |
+| voice.stop | pass-eligible iff FN=0 | 任一 stop miss → fail |
+| face.recognition | degraded floor（每類 n≥3） | committed=FAIL；可信重測；idle=空畫面 → 陌生人拒絕未驗證 |
+| gesture.wave | pass-eligible（≥90%） | recall 是人工 ground-truth；idle 閘是 rate-proxy |
+| object.cup | pass-eligible（≥80%） | cup 輪前先 smoke-gate TRT |
+| pose.basic / pose.fall | insufficient_data | 無 observer；從 WSL 關閉 |
+| nav.*（4） | insufficient_data | dry-run、無動作、無 sign-off |
+
+> **若 HITL 整條被 SSH 卡死**（fallback，無 Jetson）：#118 Studio evidence UI + #120 capability health gate 接線可在 WSL 純軟體做（`cd pawai-studio/frontend && npm ci && npm run lint && npm run build` 綠；`pytest pawai_brain/test/ -q` 338 + `interaction_executive/test/ -q` 221 在 gate 預設 OFF 下綠）。**#120 ENABLE（`capability_gate_enabled=True`）是 motion-safety**：保持預設 OFF，未經 Roy 明確授權不得在任何 launch script 翻開。

--- a/pawai-studio/backend/mock_server.py
+++ b/pawai-studio/backend/mock_server.py
@@ -396,6 +396,10 @@ async def ws_text(ws: WebSocket):
 
 # ── REST: Gateway 端點 ──────────────────────────────────────────────
 
+@app.get("/api/scoreboard")
+async def get_scoreboard():
+    return {"provenance": "mock", "backend": "mock", "capabilities": []}
+
 @app.post("/api/command")
 async def post_command(cmd: SkillCommand):
     event = PawAIEvent(

--- a/pawai-studio/backend/mock_server.py
+++ b/pawai-studio/backend/mock_server.py
@@ -398,7 +398,9 @@ async def ws_text(ws: WebSocket):
 
 @app.get("/api/scoreboard")
 async def get_scoreboard():
-    return {"provenance": "mock", "backend": "mock", "capabilities": []}
+    # provenance = file identity (frozen|missing); mock has no snapshot file -> missing.
+    # mock-ness is carried by backend, not provenance (keeps the TS contract honest).
+    return {"provenance": "missing", "backend": "mock", "capabilities": []}
 
 @app.post("/api/command")
 async def post_command(cmd: SkillCommand):

--- a/pawai-studio/frontend/app/(studio)/studio/dev/page.tsx
+++ b/pawai-studio/frontend/app/(studio)/studio/dev/page.tsx
@@ -3,6 +3,7 @@
 import { useEventStream } from "@/hooks/use-event-stream";
 import { SkillButtons } from "@/components/chat/brain/skill-buttons";
 import { SkillTraceContent } from "@/components/chat/brain/skill-trace-content";
+import { ScoreboardChip } from "@/components/shared/scoreboard-chip";
 
 /**
  * /studio/dev — full-page dev panel for direct URL access.
@@ -25,6 +26,12 @@ export default function DevPage() {
         <SkillButtons />
         <div className="border-t border-[var(--sheet-border)]">
           <SkillTraceContent />
+        </div>
+        <div className="border-t border-[var(--sheet-border)] p-4">
+          <h2 className="mb-2 text-xs font-semibold text-muted-foreground">
+            能力 Scoreboard（誠實層 · 唯讀 frozen snapshot）
+          </h2>
+          <ScoreboardChip />
         </div>
       </div>
     </div>

--- a/pawai-studio/frontend/components/chat/brain/skill-trace-content.tsx
+++ b/pawai-studio/frontend/components/chat/brain/skill-trace-content.tsx
@@ -15,6 +15,7 @@ function statusToClass(status: string): string {
     case "proposed":
       return "bg-slate-500/20 text-slate-300 border-slate-500/40";
     case "blocked":
+    case "insufficient_data":
     case "fallback":
     case "retry":
       return "bg-amber-500/20 text-amber-300 border-amber-500/40";
@@ -128,10 +129,15 @@ export function SkillTraceContent() {
               <span className="font-medium">{t.stage}</span>
               <span className="opacity-60"> · </span>
               <span className="font-semibold">{t.status}</span>
-              {t.detail ? (
+              {t.detail?.trim() ? (
                 <>
                   <span className="opacity-60"> · </span>
                   <span className="truncate">{t.detail}</span>
+                </>
+              ) : (t.status === "blocked" || String(t.status) === "insufficient_data") ? (
+                <>
+                  <span className="opacity-60"> · </span>
+                  <span className="text-amber-300">⚠ no reason provided</span>
                 </>
               ) : null}
               <span className="ml-2 text-[10px] opacity-50">{t.engine}</span>

--- a/pawai-studio/frontend/components/shared/provenance-badge.tsx
+++ b/pawai-studio/frontend/components/shared/provenance-badge.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import type {
+  ProvenanceState,
+  ScoreboardBackend,
+  ScoreboardProvenance,
+} from "@/contracts/types";
+
+interface ProvenanceBadgeProps {
+  provenance?: ScoreboardProvenance;
+  backend?: ScoreboardBackend;
+  missing?: boolean;
+}
+
+const provenanceClasses: Record<ProvenanceState, string> = {
+  live: "bg-emerald-500/20 text-emerald-300 border-emerald-500/40",
+  frozen: "bg-sky-500/20 text-sky-300 border-sky-500/40",
+  mock: "bg-amber-500/20 text-amber-300 border-amber-500/40",
+  missing: "bg-red-500/20 text-red-300 border-red-500/40",
+};
+
+const provenanceLabels: Record<ProvenanceState, string> = {
+  live: "live",
+  frozen: "frozen",
+  mock: "mock",
+  missing: "missing",
+};
+
+export function ProvenanceBadge({
+  provenance,
+  backend,
+  missing,
+}: ProvenanceBadgeProps) {
+  const state: ProvenanceState =
+    missing === true || provenance === "missing"
+      ? "missing"
+      : backend === "mock"
+        ? "mock"
+        : backend === "live"
+          ? "live"
+          : provenance ?? "frozen";
+
+  return (
+    <Badge
+      className={provenanceClasses[state]}
+      title={`scoreboard provenance: ${provenanceLabels[state]}`}
+    >
+      {provenanceLabels[state]}
+    </Badge>
+  );
+}

--- a/pawai-studio/frontend/components/shared/scoreboard-chip.tsx
+++ b/pawai-studio/frontend/components/shared/scoreboard-chip.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { ProvenanceBadge } from "@/components/shared/provenance-badge";
+import type { ScoreboardGrade } from "@/contracts/types";
+import { useScoreboard } from "@/hooks/use-scoreboard";
+
+const gradeClasses: Record<ScoreboardGrade, string> = {
+  pass: "text-emerald-300",
+  degraded: "text-amber-300",
+  fail: "text-red-300",
+  insufficient_data: "text-zinc-300",
+};
+
+export function ScoreboardChip() {
+  const { data, loading } = useScoreboard();
+
+  if (loading) {
+    return <div className="text-xs text-zinc-400">loading</div>;
+  }
+
+  const capabilities = data?.capabilities ?? [];
+  const hasCapabilities = capabilities.length > 0;
+
+  return (
+    <div className="space-y-2 text-xs text-zinc-300">
+      <ProvenanceBadge
+        provenance={data?.provenance}
+        backend={data?.backend}
+        missing={!data}
+      />
+      <div className="space-y-1">
+        {hasCapabilities ? (
+          capabilities.map((capability) => (
+            <div
+              key={capability.capability_id}
+              className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_minmax(0,1fr)] gap-2 rounded border border-zinc-700/60 bg-zinc-900/40 px-2 py-1"
+            >
+              <span className="truncate">{capability.capability_id}</span>
+              <span className={gradeClasses[capability.grade]}>{capability.grade}</span>
+              <span className="truncate text-zinc-400">
+                {capability.failure_reason ?? "—"}
+              </span>
+              <span className="truncate text-zinc-500">
+                {capability.last_tested_at ?? "—"}
+              </span>
+            </div>
+          ))
+        ) : (
+          <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_minmax(0,1fr)] gap-2 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-red-300">
+            <span>missing</span>
+            <span className="text-red-300">insufficient_data</span>
+            <span>—</span>
+            <span>—</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/pawai-studio/frontend/components/shared/scoreboard-chip.tsx
+++ b/pawai-studio/frontend/components/shared/scoreboard-chip.tsx
@@ -30,21 +30,28 @@ export function ScoreboardChip() {
       />
       <div className="space-y-1">
         {hasCapabilities ? (
-          capabilities.map((capability) => (
-            <div
-              key={capability.capability_id}
-              className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_minmax(0,1fr)] gap-2 rounded border border-zinc-700/60 bg-zinc-900/40 px-2 py-1"
-            >
-              <span className="truncate">{capability.capability_id}</span>
-              <span className={gradeClasses[capability.grade]}>{capability.grade}</span>
-              <span className="truncate text-zinc-400">
-                {capability.failure_reason ?? "—"}
-              </span>
-              <span className="truncate text-zinc-500">
-                {capability.last_tested_at ?? "—"}
-              </span>
-            </div>
-          ))
+          capabilities.map((capability) => {
+            const reason = capability.failure_reason?.trim();
+            const reasonText = reason || (capability.grade === "pass" ? "—" : "⚠ 缺 reason");
+            const reasonClass = reason
+              ? "text-zinc-400"
+              : capability.grade === "pass"
+                ? "text-zinc-600"
+                : "text-amber-300";
+            return (
+              <div
+                key={capability.capability_id}
+                className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_minmax(0,1fr)] gap-2 rounded border border-zinc-700/60 bg-zinc-900/40 px-2 py-1"
+              >
+                <span className="truncate">{capability.capability_id}</span>
+                <span className={gradeClasses[capability.grade]}>{capability.grade}</span>
+                <span className={`truncate ${reasonClass}`}>{reasonText}</span>
+                <span className="truncate text-zinc-500">
+                  {capability.last_tested_at ?? "—"}
+                </span>
+              </div>
+            );
+          })
         ) : (
           <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_minmax(0,1fr)] gap-2 rounded border border-red-500/40 bg-red-500/10 px-2 py-1 text-red-300">
             <span>missing</span>

--- a/pawai-studio/frontend/contracts/types.ts
+++ b/pawai-studio/frontend/contracts/types.ts
@@ -462,3 +462,25 @@ export interface ConversationTracePayload {
   detail: string;
   ts: number;
 }
+export type ScoreboardGrade = 'pass' | 'degraded' | 'fail' | 'insufficient_data';
+export type ScoreboardProvenance = 'frozen' | 'missing';
+export type ScoreboardBackend = 'live' | 'mock';
+export type ProvenanceState = 'live' | 'mock' | 'frozen' | 'missing';
+export interface ScoreboardCapability {
+  capability_id: string;
+  grade: ScoreboardGrade;
+  failure_reason: string | null;
+  brain_allowed: boolean;
+  last_tested_at: string | null;
+}
+export interface ScoreboardResponse {
+  provenance: ScoreboardProvenance;
+  backend?: ScoreboardBackend;
+  source_path?: string;
+  schema_version?: string;
+  run_trusted?: boolean;
+  version_mismatch?: boolean;
+  git_commit?: string;
+  generated_at?: string;
+  capabilities: ScoreboardCapability[];
+}

--- a/pawai-studio/frontend/hooks/use-scoreboard.ts
+++ b/pawai-studio/frontend/hooks/use-scoreboard.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { ScoreboardResponse } from "@/contracts/types";
+import { getGatewayHttpUrl } from "@/lib/gateway-url";
+
+interface UseScoreboardResult {
+  data: ScoreboardResponse | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function useScoreboard(): UseScoreboardResult {
+  const [data, setData] = useState<ScoreboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function fetchScoreboard() {
+      try {
+        const response = await fetch(`${getGatewayHttpUrl()}/api/scoreboard`);
+
+        if (!response.ok) {
+          throw new Error(`Scoreboard request failed: ${response.status}`);
+        }
+
+        const scoreboard = (await response.json()) as ScoreboardResponse;
+
+        if (!cancelled) {
+          setData(scoreboard);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setData(null);
+          setError(err instanceof Error ? err.message : "Failed to load scoreboard");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void fetchScoreboard();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -568,11 +568,21 @@ def _read_scoreboard(path: Path) -> dict:
     last_tested_at is the snapshot-level timestamp (no per-capability time exists).
     """
     if not path.exists():
-        return {"provenance": "missing", "source_path": str(path), "capabilities": []}
+        return {
+            "provenance": "missing",
+            "backend": "live",
+            "source_path": str(path),
+            "capabilities": [],
+        }
     try:
         snap = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
-        return {"provenance": "missing", "source_path": str(path), "capabilities": []}
+        return {
+            "provenance": "missing",
+            "backend": "live",
+            "source_path": str(path),
+            "capabilities": [],
+        }
 
     timestamp = snap.get("timestamp")
     caps_in = snap.get("capabilities", {})
@@ -587,6 +597,7 @@ def _read_scoreboard(path: Path) -> dict:
         })
     return {
         "provenance": "frozen",
+        "backend": "live",
         "source_path": str(path),
         "schema_version": snap.get("schema_version"),
         "run_trusted": snap.get("run_trusted"),


### PR DESCRIPTION
## 來由
6/4 路線打通 session（Roy 授權 ultracode；Claude plan/review + Codex 寫 code + Tournament）。本 PR 兩部分：

### 1. #118 Studio 證據 UI（軟體，WSL 已驗）
收 #76 的 frontend 渲染半，把已存在的後端 `GET /api/scoreboard`（frozen snapshot）顯示出來。
- **scoreboard-chip**：4 欄 capability_id / grade / failure_reason / last_tested_at；fail+insufficient_data 視覺區分、空→'missing' 列**永不空白**。掛在 `/studio/dev`。
- **provenance-badge**：live / mock / frozen / missing（後端身分 vs 檔案身分兩軸）。
- **gateway + mock_server**：`/api/scoreboard` 回傳新增 `backend` tag → mock 不能假裝 live。
- **skill-trace-content**：blocked / insufficient_data 若 detail 空，顯 '⚠ no reason provided' 而非空白。
- **誠實護欄**：display-only、無 live recompute、無 motion/nav 觸發；face committed=FAIL 顯示為 fail 不是 pass。

**驗收（WSL 全綠）**：`npm ci` ✅ / `npm run lint` ✅ (0 errors) / `npm run build` ✅ (12 routes, TS pass)。

### 2. route-paving 文件
- `docs/runbook/2026-06-18-hitl-oneshot-runbook.md`：一次坐定 HITL runbook（#80-84 → build_scoreboard → readiness → freeze，指令 source-verified）。
- `docs/pawai-brain/plans/2026-06-04-codex-workorders.md`：4 工單（#118 本 PR、#120/#80-mic_stop/schema-fix 待 Roy 授權）。
- 順帶記錄 3 個既有文件 bug（不存在的 `/event/nav/mission` topic、gesture idle gate count-vs-rate、readiness 真 blocker=sha_mismatch）。

## 測試
- frontend：npm ci + lint + build 全綠（lint 僅 2 個既有 warning，非本 PR 檔案）。
- gateway/backend：py_compile 過。
- 無偷刪既有測試/邏輯（diff 46+/3-，3 個 deletion 皆預期）。

## Scope guard（未做）
- 未碰 Brain/IE/gate enforcement（#120 另案、需授權）。
- 未重寫 trace drawer、未動 `/api/scoreboard` frozen/missing 解析（只加 backend tag）。
- 未啟用任何 gate。

## 給 Roy 的視覺確認
`cd pawai-studio/frontend && npm run dev` → http://localhost:3000/studio/dev 看 chip（起 live gateway 標 live、起 mock 標 mock）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)