### PR TITLE
feat(brain): #120 capability health gate → IE runtime (default-OFF)

### DIFF
--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -23,6 +23,7 @@ from .pending_confirm import (
 )
 from .safety_layer import SafetyLayer
 from .skill_contract import (
+    ExecutorKind,
     SKILL_REGISTRY,
     PriorityClass,
     SkillPlan,
@@ -264,6 +265,8 @@ class BrainNode(Node):
         # 預設 False 維持現有 object_remark + sit_along 獨立行為
         self.declare_parameter("demo_video_cup_compound", False)
         self.declare_parameter("demo_video_silent_sit_along", False)
+        self.declare_parameter("capability_gate_enabled", False)
+        self.declare_parameter("baseline_snapshot_path", "")
         self.chat_wait_ms = int(self.get_parameter("chat_wait_ms").value)
         self.dedup_window_s = float(self.get_parameter("dedup_window_s").value)
         self.unknown_face_accumulate_s = float(
@@ -278,6 +281,13 @@ class BrainNode(Node):
         self.peace_direct_stretch = bool(self.get_parameter("peace_direct_stretch").value)
         self.demo_video_cup_compound = bool(self.get_parameter("demo_video_cup_compound").value)
         self.demo_video_silent_sit_along = bool(self.get_parameter("demo_video_silent_sit_along").value)
+        self._capability_gate_enabled = bool(
+            self.get_parameter("capability_gate_enabled").value
+        )
+        self._baseline_snapshot_path = str(
+            self.get_parameter("baseline_snapshot_path").value or ""
+        )
+        self._capability_health_cache: dict[str, Any] | None = None
         if self.gesture_direct_disabled:
             # Instance shadow class attribute — 不影響其他 BrainNode instances 或 test fixtures
             self._GESTURE_DIRECT = {}
@@ -330,6 +340,41 @@ class BrainNode(Node):
 
     def _mark_cooldown(self, key: str) -> None:
         self._state.last_alert_ts[key] = time.time()
+
+    def _capability_health_block(self, skill: str) -> str | None:
+        if not self._capability_gate_enabled:
+            return None
+
+        # Lazy import: keep brain_node importable (IE standalone tests) without
+        # pawai_brain on the path; only the gate-ON runtime path needs it.
+        from pawai_brain.capability.health_loader import (
+            load_capability_health,
+            skill_capability,
+        )
+
+        capability_id = skill_capability(skill)
+        if capability_id == "content":
+            return None
+        if capability_id is None:
+            if self._skill_has_motion_or_nav(skill):
+                return f"{skill}:unmapped_motion_capability"
+            return None
+
+        if self._capability_health_cache is None:
+            self._capability_health_cache = load_capability_health(self._baseline_snapshot_path)
+
+        health = self._capability_health_cache.get(capability_id)
+        grade = str(health.grade)
+        if grade in {"fail", "degraded", "insufficient_data"} or not health.brain_allowed:
+            return f"{skill}:{capability_id}:{grade}"
+        return None
+
+    def _skill_has_motion_or_nav(self, skill: str) -> bool:
+        contract = SKILL_REGISTRY.get(skill)
+        if contract is None:
+            return True
+        motion_executors = {ExecutorKind.MOTION, ExecutorKind.NAV}
+        return any(step.executor in motion_executors for step in (contract.steps or []))
 
     def _check_dedup(self, source: str, key: str) -> bool:
         if not key:
@@ -509,6 +554,17 @@ class BrainNode(Node):
                 stage="skill_gate",
                 status="rejected_not_allowed",
                 detail=proposed_skill,
+            )
+            return
+
+        reason = self._capability_health_block(proposed_skill)
+        if reason:
+            self._emit_trace(
+                session_id=session_id,
+                engine=engine,
+                stage="skill_gate",
+                status="blocked",
+                detail=reason,
             )
             return
 

--- a/pawai_brain/pawai_brain/capability/health_loader.py
+++ b/pawai_brain/pawai_brain/capability/health_loader.py
@@ -1,0 +1,91 @@
+"""Load frozen capability health snapshots for capability gate enforcement."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from pawai_brain.capability.effective_status import CapabilityHealth
+
+
+SKILL_TO_CAPABILITY: dict[str, str] = {
+    "wave_hello": "gesture.wave",
+    "sit_along": "nav.short_move",
+    "stand": "nav.short_move",
+    "wiggle": "nav.short_move",
+    "stretch": "nav.short_move",
+    "show_status": "content",
+    "self_introduce": "content",
+    "careful_remind": "content",
+}
+
+
+def _insufficient_data_health() -> CapabilityHealth:
+    return CapabilityHealth(
+        grade="insufficient_data",
+        claim_level="untrusted",
+        dependency_role="unknown",
+        risk_role="blocked",
+        brain_allowed=False,
+    )
+
+
+class FailClosedCapabilityHealth(dict[str, CapabilityHealth]):
+    """Capability health mapping that fails closed for unknown capability ids."""
+
+    def __missing__(self, capability_id: str) -> CapabilityHealth:
+        health = _insufficient_data_health()
+        self[capability_id] = health
+        return health
+
+    def get(self, capability_id: str, default: CapabilityHealth | None = None) -> CapabilityHealth:
+        del default
+        return self[capability_id]
+
+
+def skill_capability(skill: str) -> str | None:
+    """Return the capability id associated with a skill, if one is known."""
+    return SKILL_TO_CAPABILITY.get(skill)
+
+
+def _fail_closed() -> FailClosedCapabilityHealth:
+    return FailClosedCapabilityHealth()
+
+
+def _build_health(raw: dict[str, Any]) -> CapabilityHealth:
+    return CapabilityHealth(
+        grade=str(raw.get("grade", "insufficient_data")),
+        claim_level=str(raw.get("claim_level", "untrusted")),
+        dependency_role=str(raw.get("dependency_role", "unknown")),
+        risk_role=str(raw.get("risk_role", "blocked")),
+        brain_allowed=bool(raw.get("brain_allowed", False)),
+    )
+
+
+def load_capability_health(snapshot_path: str) -> dict[str, CapabilityHealth]:
+    """Load a trusted baseline capability health snapshot.
+
+    Any loader error returns a mapping that fails closed for every requested capability id.
+    """
+    if not snapshot_path:
+        return _fail_closed()
+
+    try:
+        snapshot = json.loads(Path(snapshot_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return _fail_closed()
+
+    if not isinstance(snapshot, dict) or snapshot.get("run_trusted") is not True:
+        return _fail_closed()
+
+    capabilities = snapshot.get("capabilities")
+    if not isinstance(capabilities, dict):
+        return _fail_closed()
+
+    loaded: FailClosedCapabilityHealth = FailClosedCapabilityHealth()
+    for capability_id, capability in capabilities.items():
+        if isinstance(capability_id, str) and isinstance(capability, dict):
+            loaded[capability_id] = _build_health(capability)
+
+    return loaded

--- a/pawai_brain/pawai_brain/capability/registry.py
+++ b/pawai_brain/pawai_brain/capability/registry.py
@@ -1,11 +1,12 @@
 """CapabilityRegistry — merge SkillContract + DemoGuide → CapabilityEntry list."""
 from __future__ import annotations
 import time
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
 from .demo_guides_loader import DemoGuide
-from .effective_status import WorldFlags, compute_effective_status
+from .effective_status import CapabilityHealth, WorldFlags, compute_effective_status
 
 
 _AVAILABLE_STATUSES = frozenset({"available", "needs_confirm"})
@@ -52,11 +53,16 @@ class CapabilityRegistry:
         self._guides = list(guides)
 
     def build_entries(
-        self, world: WorldFlags, recent_results: list
+        self,
+        world: WorldFlags,
+        recent_results: list,
+        capability_health: Mapping[str, CapabilityHealth] | None = None,
     ) -> list:
         entries: list = []
         for name, contract in self._skills.items():
-            entries.append(self._skill_entry(name, contract, world, recent_results))
+            entries.append(
+                self._skill_entry(name, contract, world, recent_results, capability_health)
+            )
         for guide in self._guides:
             entries.append(self._guide_entry(guide))
         return entries
@@ -64,7 +70,12 @@ class CapabilityRegistry:
     # ── internals ──
 
     def _skill_entry(
-        self, name: str, contract, world: WorldFlags, recent_results: list
+        self,
+        name: str,
+        contract,
+        world: WorldFlags,
+        recent_results: list,
+        capability_health: Mapping[str, CapabilityHealth] | None = None,
     ) -> CapabilityEntry:
         # Adapter for compute_effective_status
         adapter = _SkillAdapter(
@@ -78,7 +89,11 @@ class CapabilityRegistry:
             has_nav_step=any(_is_nav(s) for s in (contract.steps or [])),
             kind="skill",
         )
-        status, reason = compute_effective_status(adapter, world)
+        health = capability_health.get(name) if capability_health is not None else None
+        if health is None:
+            status, reason = compute_effective_status(adapter, world)
+        else:
+            status, reason = compute_effective_status(adapter, world, health)
         return CapabilityEntry(
             name=name,
             kind="skill",

--- a/pawai_brain/test/test_health_loader.py
+++ b/pawai_brain/test/test_health_loader.py
@@ -1,0 +1,89 @@
+import json
+from pathlib import Path
+
+from pawai_brain.capability.health_loader import load_capability_health, skill_capability
+
+
+FIXTURE = Path(__file__).parent / "fixtures" / "baseline_snapshot.example.json"
+
+
+def test_load_capability_health_from_trusted_snapshot() -> None:
+    raw = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    capability_id = "gesture.wave"
+    expected = raw["capabilities"][capability_id]
+
+    health = load_capability_health(str(FIXTURE))[capability_id]
+
+    assert health.grade == expected["grade"]
+    assert health.claim_level == expected["claim_level"]
+    assert health.dependency_role == expected["dependency_role"]
+    assert health.risk_role == expected["risk_role"]
+    assert health.brain_allowed is expected["brain_allowed"]
+
+
+def test_load_capability_health_empty_path_fails_closed() -> None:
+    health_by_capability = load_capability_health("")
+
+    for capability_id in ("gesture.wave", "nav.short_move", "unknown.capability"):
+        assert health_by_capability[capability_id].grade == "insufficient_data"
+
+
+def test_load_capability_health_missing_path_fails_closed(tmp_path: Path) -> None:
+    health_by_capability = load_capability_health(str(tmp_path / "missing.json"))
+
+    for capability_id in ("gesture.wave", "nav.short_move", "unknown.capability"):
+        assert health_by_capability[capability_id].grade == "insufficient_data"
+
+
+def test_load_capability_health_unreadable_path_fails_closed(tmp_path: Path) -> None:
+    unreadable = tmp_path / "snapshot-dir"
+    unreadable.mkdir()
+
+    health_by_capability = load_capability_health(str(unreadable))
+
+    for capability_id in ("gesture.wave", "nav.short_move", "unknown.capability"):
+        assert health_by_capability[capability_id].grade == "insufficient_data"
+
+
+def test_load_capability_health_invalid_json_fails_closed(tmp_path: Path) -> None:
+    invalid = tmp_path / "baseline_snapshot.json"
+    invalid.write_text("{not-json", encoding="utf-8")
+
+    health_by_capability = load_capability_health(str(invalid))
+
+    for capability_id in ("gesture.wave", "nav.short_move", "unknown.capability"):
+        assert health_by_capability[capability_id].grade == "insufficient_data"
+
+
+def test_load_capability_health_untrusted_snapshot_fails_closed(tmp_path: Path) -> None:
+    untrusted = tmp_path / "baseline_snapshot.json"
+    untrusted.write_text(
+        json.dumps(
+            {
+                "run_trusted": False,
+                "capabilities": {
+                    "gesture.wave": {
+                        "capability_id": "gesture.wave",
+                        "grade": "pass",
+                        "claim_level": "trusted",
+                        "risk_role": "allowed",
+                        "dependency_role": "available",
+                        "brain_allowed": True,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    health_by_capability = load_capability_health(str(untrusted))
+
+    for capability_id in ("gesture.wave", "nav.short_move", "unknown.capability"):
+        assert health_by_capability[capability_id].grade == "insufficient_data"
+
+
+def test_skill_capability_mapping() -> None:
+    assert skill_capability("wave_hello") == "gesture.wave"
+    assert skill_capability("sit_along") == "nav.short_move"
+    assert skill_capability("show_status") == "content"
+    assert skill_capability("unknown_motion") is None


### PR DESCRIPTION
## 來由
#85 v0.2 的 grade gate 純邏輯接到 IE runtime。**Roy 6/4 明確授權**（HITL session 中）。**DEFAULT-OFF**：`capability_gate_enabled=False` 時 runtime 逐字不變。

## 範圍
- **NEW `health_loader.py`**：`load_capability_health()` 讀 frozen snapshot → **fail-closed**（缺檔/不可讀/JSON壞/run_trusted≠True → 每個 capability 回 insufficient_data，**絕不空 dict/passthrough**）。`SKILL_TO_CAPABILITY` map（wave_hello→gesture.wave、sit_along/stand/wiggle/stretch→nav.short_move、show_status/self_introduce/careful_remind→content）。
- **`brain_node.py`**：`_capability_health_block()` 第二道 gate 插在 cooldown 前（涵蓋 execute/confirm/trace_only 三分支）；gate ON 時 block『motion skill 對應 capability=fail/degraded/insufficient_data』或『unmapped motion skill』；content skill passthrough。ROS params `capability_gate_enabled`(False) + `baseline_snapshot_path`('')。**pawai_brain import 改 lazy**（IE 獨立測試可 collect；OFF path 根本不 import）。
- **`registry.py`**：optional `capability_health` 第三 arg threaded；**目前休眠**（無 caller 傳）、且若啟用是 fail-closed-safe。真正 enforcement 在 brain_node gate。
- **`test_health_loader.py`**：7 個 fail-closed 測試。

## 驗收（本地全綠）
- `interaction_executive/test/` **221 passed**（OFF-path **byte-identical**）
- `pawai_brain/test/` **345 passed**（338 原有 + 7 新）
- `test_capability_health_gate.py` 20 + `test_skill_policy_gate.py` parity 綠
- 新 core 檔 flake8 --max-line-length=100 乾淨

## ⚠️ Enforcement 未啟用
`capability_gate_enabled` 在**所有 launch/demo/tmux 腳本維持 False**。開啟是 motion-safety 變更、需另行明確授權。

## Review 修正（Claude）
- Codex 的 allowlist 單一來源收斂**打破 AST parity 測試 → 已還原**（duplicate 維持原狀、test 守著），列為 follow-up。
- pawai_brain 跨套件 import **改 lazy** 解 IE 測試 collection ERROR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)