### PR TITLE
ci: add interaction_executive rclpy-free tests to fast gate (Tier 1, Plan A1)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -89,6 +89,23 @@ jobs:
             pawai_brain/test/test_world_snapshot.py \
             pawai_brain/test/test_world_state_builder.py \
             -v --tb=short
+          # Invocation 3 (2026-06-10 Plan A, Tier 1): interaction_executive —
+          # CI-safe subset only. Excluded from CI, run locally instead: 4 files
+          # importing rclpy directly (attention_integration / brain_rules /
+          # mini_e2e / nav_executor) + 3 files needing ROS modules anyway
+          # (idle_mvp: rclpy via brain_node; safety_layer: rclpy via
+          # world_state; world_state: std_msgs direct + rclpy via
+          # world_state module). See docs/superpowers/plans/
+          # 2026-06-10-plan-a-ci-guardrails.md. Isolated PYTHONPATH avoids the
+          # top-level 'test' package collision.
+          PYTHONPATH=interaction_executive pytest \
+            interaction_executive/test/test_attention_machine.py \
+            interaction_executive/test/test_pending_confirm.py \
+            interaction_executive/test/test_skill_contract.py \
+            interaction_executive/test/test_skill_contract_demo_fields.py \
+            interaction_executive/test/test_skill_queue.py \
+            interaction_executive/test/test_state_machine.py \
+            -v --tb=short
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Plan A — Task A1（CI/CD Guardrails）

Per `docs/superpowers/plans/2026-06-10-plan-a-ci-guardrails.md` Task A1: add fast-gate **Invocation 3** running interaction_executive's CI-safe pure-Python tests (111 tests, isolated `PYTHONPATH=interaction_executive`).

### Deviation from plan (recorded per plan's own exclusion convention)

Plan listed 9 files via `grep -L "import rclpy"`; verification under the CI-equivalent invocation found 3 of them cannot run on a plain ubuntu runner:

- `test_idle_mvp.py` — rclpy transitively via `brain_node.py`
- `test_safety_layer.py` — rclpy transitively via `world_state.py`
- `test_world_state.py` — `std_msgs` direct + rclpy via `world_state` module

→ Invocation 3 ships the **6 CI-safe files (111 tests)**; the 3 excluded files join the 4 direct-rclpy files in the local L1 tier.（plan 的 grep -L 啟發式抓不到間接 import — A6 pre-commit 清單需同步用 6 檔版。）

### Evidence（紅綠驗證）

- ✅ **Green run** — invocation 3 executes with **111 passed** (log: `355 passed`/`219 passed`/`111 passed` for invocations 1/2/3): https://github.com/roy4222/PawAI/actions/runs/27315354107
- 🔴 **Red run** — deliberate broken assert in `test_state_machine.py` (commit `05a87ca`) → Fast Gate **failure**: https://github.com/roy4222/PawAI/actions/runs/27315437533
- ✅ **Green again** — break commit dropped via force-push; branch head back to `86729bd` (same sha as the green run above).

Zero runtime code changes — workflow file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
