### PR TITLE
ci: fill pawai_brain fast-gate invocation 2 to 17 files (Tier 1, Plan A3)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
-        run: pip install pytest pytest-cov flake8 numpy opencv-python-headless jsonschema pyyaml
+        run: pip install pytest pytest-cov flake8 numpy opencv-python-headless jsonschema pyyaml requests langgraph
       - name: Flake8 lint (report-only)
         run: |
           flake8 speech_processor/ go2_robot_sdk/ face_perception/ \
@@ -75,11 +75,20 @@ jobs:
             --cov=vision_perception/vision_perception \
             --cov=benchmarks \
             --cov-report=term --cov-report=xml:coverage.xml
-          # Invocation 2: pawai_brain pure-Python tests in an isolated PYTHONPATH to avoid
-          # the duplicate top-level 'test' package collision with speech_processor/test
+          # Invocation 2: pawai_brain pure-Python tests (17 files, Tier 1) in an isolated
+          # PYTHONPATH to avoid the duplicate top-level 'test' package collision with
+          # speech_processor/test. Excluded (local-only, rclpy via conversation_graph_node):
+          # test_conversation_graph_node.py, test_user_message_builder.py.
           PYTHONPATH=pawai_brain pytest \
-            pawai_brain/test/test_effective_status.py \
+            pawai_brain/test/test_capability_builder_node.py \
             pawai_brain/test/test_capability_health_gate.py \
+            pawai_brain/test/test_capability_registry.py \
+            pawai_brain/test/test_demo_guides_loader.py \
+            pawai_brain/test/test_demo_policy_loader.py \
+            pawai_brain/test/test_effective_status.py \
+            pawai_brain/test/test_graph_smoke.py \
+            pawai_brain/test/test_health_loader.py \
+            pawai_brain/test/test_llm_client_offline.py \
             pawai_brain/test/test_mode_classifier.py \
             pawai_brain/test/test_response_repair.py \
             pawai_brain/test/test_skill_policy_gate.py \


### PR DESCRIPTION
## Plan A — Task A3（CI/CD Guardrails）

Per `docs/superpowers/plans/2026-06-10-plan-a-ci-guardrails.md` Task A3: expand fast-gate **Invocation 2**（pawai_brain）from 10 → 17 files (+59 tests), add pip deps `requests langgraph`.

Excluded per plan: `test_conversation_graph_node.py` / `test_user_message_builder.py`（import rclpy via `conversation_graph_node.py:26`，runner 無 rclpy，留本機 L1）。

### Evidence（紅綠驗證）
- ✅ **Green run** — invocation 2 executes with **278 passed**（was 219；log: `355 passed`/`278 passed`/`111 passed`）: https://github.com/roy4222/PawAI/actions/runs/27316302573
- 🔴 **Red run** — deliberate broken assert in `test_health_loader.py`（one of the 7 NEW files，commit `230bd35`）→ Fast Gate **failure**: https://github.com/roy4222/PawAI/actions/runs/27316423926
- ✅ **Green again** — break commit dropped via force-push; branch head back to `174eac3`（same sha as the green run above）.

Local CI-equivalent verification: 278 passed in 1.99s. Zero runtime code changes — workflow file only.

Note: executed out of plan order（A3 before A2）— A2 的 pawai_cli suite 發現 plan 預期落差（本機 300s + 1 env-dependent fail，另行處理），A3 與 A2 無內容依賴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
