### PR TITLE
ci: run Studio gateway pytest in ROS container job (Tier 1, Plan A4)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -174,6 +174,18 @@ jobs:
             speech_processor
             face_perception
             vision_perception
+      - name: Studio gateway tests (needs rclpy — Plan A4, Tier 1)
+        run: |
+          # ffmpeg: asr_client.resample_to_wav16k shells out to it; the
+          # rostooling image doesn't bundle it (TestResampleAudio needs it).
+          (sudo apt update && sudo apt install --no-install-recommends ffmpeg -y) || \
+          (apt update && apt install --no-install-recommends ffmpeg -y) || true
+          pip3 install -r pawai-studio/gateway/requirements.txt 'pytest>=7' \
+            opencv-python-headless numpy pydub || \
+          pip3 install --break-system-packages -r pawai-studio/gateway/requirements.txt \
+            'pytest>=7' opencv-python-headless numpy pydub
+          bash -c "source /opt/ros/humble/setup.bash && \
+            cd pawai-studio/gateway && python3 -m pytest -q --tb=short"
       - name: Python syntax check
         run: |
           find . -name '*.py' \


### PR DESCRIPTION
## Plan A — Task A4（CI/CD Guardrails）

Per `docs/superpowers/plans/2026-06-10-plan-a-ci-guardrails.md` Task A4: gateway imports rclpy at module level（`studio_gateway.py:32`）→ its pytest suite runs as a new step in the **test_environment ROS container job**, not the plain fast gate.

### Container gotchas（review + 首次 CI run 抓到，已修）
1. **ffmpeg**：`asr_client.resample_to_wav16k` shell out 到 ffmpeg，rostooling image 不帶 → 4 條 `TestResampleAudio` 會 `FileNotFoundError`（本機過是因 WSL 有 ffmpeg）。Step 開頭比照 libunwind 模式 apt install。
2. **`'pytest>=7'` 強制升級**：image 帶 apt pytest 6.x，裸 `pytest` pip requirement 視為 already-satisfied；但 pip 裝進來的 anyio（fastapi 依賴）的 pytest plugin 在 collection 時 `from _pytest.scope import Scope`（pytest≥7 才有）→ 首次 run 在此紅掉。

### Evidence（紅綠驗證）
- ✅ **Green run** — gateway step: **65 passed in 0.96s**（本機 64+1 skip；container 裝了 opencc 連 skip 都轉 pass）: https://github.com/roy4222/PawAI/actions/runs/27317343929
- 🔴 **Red run** — deliberate broken assert in `test_gateway.py`（commit `1de88e8`）→ **test_environment failure**（Fast Gate unaffected: success — 失敗面正確隔離）: https://github.com/roy4222/PawAI/actions/runs/27317546771
- ✅ **Green again** — break commit dropped via force-push; head back to `a987c0e`（same sha as green run）.

Zero runtime code changes — workflow file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
