### PR TITLE
ci: add pawai_cli tests to fast gate as invocation 4 (Tier 1, Plan A2)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install dependencies
-        run: pip install pytest pytest-cov flake8 numpy opencv-python-headless jsonschema pyyaml requests langgraph
+        run: pip install pytest pytest-cov flake8 numpy opencv-python-headless jsonschema pyyaml requests langgraph click python-dotenv
       - name: Flake8 lint (report-only)
         run: |
           flake8 speech_processor/ go2_robot_sdk/ face_perception/ \
@@ -115,6 +115,10 @@ jobs:
             interaction_executive/test/test_skill_queue.py \
             interaction_executive/test/test_state_machine.py \
             -v --tb=short
+          # Invocation 4 (Plan A2, Tier 1): pawai_cli — mock-based CLI tests.
+          # PYTHONPATH needed: the package is not pip-installed on the runner.
+          # tests/ dir name avoids the top-level 'test' package collision.
+          PYTHONPATH=tools/pawai_cli pytest tools/pawai_cli/tests -v --tb=short
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Plan A — Task A2（CI/CD Guardrails）

Per `docs/superpowers/plans/2026-06-10-plan-a-ci-guardrails.md` Task A2: fast-gate **Invocation 4** runs `tools/pawai_cli/tests`（144 tests）, pip deps `click python-dotenv` added.

### Deviations from plan（已查證）

1. **`PYTHONPATH=tools/pawai_cli` 是必要的**（plan 說不用）— plan 作者環境有 pip-installed pawai_cli，runner 沒有。
2. **本機 1 fail + 300s 是環境污染，非 suite 問題**（deep review 實證 + CI 實跑證實）：
   - `test_health_brain_passes_jetson_host_env` 本機紅 = CLI callback 每次 invoke 都把開發者 `.env.local` 以 `override=True` 灌回 env，蓋掉 monkeypatch 的假 IP。runner 沒有 `.env.local` → CI 上 **PASS**（預測命中）。
   - 本機 300s = WSL 解析得到 `jetson-nano` → doctor/status 殘留的真實 ssh probe 等滿 5-28s timeout；runner DNS NXDOMAIN 毫秒級 → CI 實測 **144 passed in 1.41s**。
   - 無真實外連（openrouter 等全 mock）。

### Evidence（紅綠驗證）
- ✅ **Green run** — invocation 4 executes: **144 passed in 1.41s**（invocations 1-4: 355/278/111/144）: https://github.com/roy4222/PawAI/actions/runs/27317357843
- 🔴 **Red run** — deliberate broken assert in `tests/test_cache.py`（commit `db31aa4`）→ **Fast Gate failure**（container job unaffected: success — 失敗面正確隔離）: https://github.com/roy4222/PawAI/actions/runs/27317547155
- ✅ **Green again** — break commit dropped via force-push; head back to `9b808f8`（same sha as green run）.

### Follow-up（merge 後另開 issue，不在本 PR scope）
- `tests/conftest.py` autouse fixture 把 `PAWAI_REPO_ROOT` 指到 tmp_path → 根治本機紅 + 300s 開發摩擦。

Zero runtime code changes — workflow file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
