### PR TITLE
ci: pre-commit smart-scope — per-package pytest isolation, 3→7 packages (Plan A6)

### DIFF
--- a/scripts/hooks/git-pre-commit.sh
+++ b/scripts/hooks/git-pre-commit.sh
@@ -60,31 +60,48 @@ fi
 # ════════════════════════════════════════
 # 3. Smart-scope package tests
 # ════════════════════════════════════════
-TEST_ARGS=""
-PYTHONPATH_EXTRA=""
+# One isolated invocation per affected package.  Several test/ dirs contain
+# __init__.py; a combined run collides on the top-level 'test' package and
+# produces "ModuleNotFoundError: No module named 'test.test_validator'".
+# Per-package isolation mirrors CI fast-gate behaviour.
+#
+# Format: "<staged-path-prefix>|<pythonpath-entry>|<pytest args>"
+#
+# Excluded by design:
+#   tools/pawai_cli     — ~300s real network timeouts on dev machines;
+#                         CI fast-gate invocation 4 covers it.
+#   go2_robot_sdk       — CI invocation 6 covers it; keeps hook <10s budget.
+#   nav_capability/test/integration — NEVER automate: test_mux_priority drives
+#                         a real 0.30 m/s cmd_vel through the mux
+#                         (2026-04-26 runaway incident).
+#
+# interaction_executive uses an explicit 6-file list: the remaining test files
+# import rclpy/std_msgs transitively and fail without ROS on PATH (mirrors CI
+# invocation 3).
+SUITES=(
+  "speech_processor/|speech_processor|speech_processor/test/"
+  "vision_perception/|vision_perception|vision_perception/test/"
+  "face_perception/|face_perception|face_perception/test/"
+  "interaction_executive/|interaction_executive|interaction_executive/test/test_attention_machine.py interaction_executive/test/test_pending_confirm.py interaction_executive/test/test_skill_contract.py interaction_executive/test/test_skill_contract_demo_fields.py interaction_executive/test/test_skill_queue.py interaction_executive/test/test_state_machine.py"
+  "pawai_brain/|pawai_brain|pawai_brain/test/"
+  "nav_capability/|nav_capability|nav_capability/test/ --ignore=nav_capability/test/integration"
+  "object_perception/|object_perception|object_perception/test/"
+)
 
-if echo "$STAGED" | grep -q '^speech_processor/'; then
-  TEST_ARGS="$TEST_ARGS speech_processor/test/"
-  PYTHONPATH_EXTRA="speech_processor"
-fi
-
-if echo "$STAGED" | grep -q '^vision_perception/'; then
-  TEST_ARGS="$TEST_ARGS vision_perception/test/"
-  PYTHONPATH_EXTRA="${PYTHONPATH_EXTRA:+$PYTHONPATH_EXTRA:}vision_perception"
-fi
-
-if echo "$STAGED" | grep -q '^face_perception/'; then
-  TEST_ARGS="$TEST_ARGS face_perception/test/"
-  PYTHONPATH_EXTRA="${PYTHONPATH_EXTRA:+$PYTHONPATH_EXTRA:}face_perception"
-fi
-
-if [[ -n "$TEST_ARGS" ]]; then
-  echo "[pre-commit] Running tests for affected packages..."
-  if ! PYTHONPATH="${PYTHONPATH_EXTRA}:${PYTHONPATH:-}" python3 -m pytest $TEST_ARGS -q --tb=line 2>&1; then
-    echo "[pre-commit] BLOCKED: tests failed." >&2
-    exit 1
+for spec in "${SUITES[@]}"; do
+  prefix="${spec%%|*}"
+  rest="${spec#*|}"
+  pp="${rest%%|*}"
+  args="${rest#*|}"
+  if echo "$STAGED" | grep -q "^${prefix}"; then
+    echo "[pre-commit] Running ${pp} tests..."
+    # shellcheck disable=SC2086
+    if ! PYTHONPATH="${pp}${PYTHONPATH:+:$PYTHONPATH}" python3 -m pytest $args -q --tb=line 2>&1; then
+      echo "[pre-commit] BLOCKED: tests failed (${pp})." >&2
+      exit 1
+    fi
   fi
-fi
+done
 
 echo "[pre-commit] All checks passed."
 exit 0


### PR DESCRIPTION
## Plan A — Task A6（CI/CD Guardrails）

Per `docs/superpowers/plans/2026-06-10-plan-a-ci-guardrails.md` Task A6: pre-commit hook smart-scope 3→7 套件。

### 結構改動（plan 的 TEST_ARGS 累加式不可行）
plan 原 snippet 沿用「累加 TEST_ARGS、一次 pytest」— 但 `speech_processor/test`、`pawai_brain/test`、`nav_capability/test`、`object_perception/test` 都有 `__init__.py` → 同一 invocation 撞 top-level `test` package（已實證 `ModuleNotFoundError: No module named 'test.test_validator'`）。改為 **SUITES array + per-package 隔離 invocation**（鏡像 CI 模式）；對既有 3 套件行為嚴格更安全（舊合併式在跨套件 commit 本來就會炸）。

### Deviations（已查證）
- **interaction_executive 用 6 檔 CI-safe 清單**（非 plan 的 9 檔）— 3 檔 transitive import rclpy/std_msgs（同 PR #143）。
- **tools/pawai_cli 不進 hook**（plan 原本要加）— 本機實測 ~300s 真實網路 timeout；CI invocation 4 已蓋（PR #146）。
- go2_robot_sdk 維持 CI-only（plan 原文如此，保 <10s 預算）。
- Review catch 順手修 pre-existing bug：`PYTHONPATH` 尾冒號會把 cwd 注入 sys.path → `${PYTHONPATH:+:$PYTHONPATH}`。

### Evidence
- **時間預算**：4 套件 worst-case（IE 111 + brain 348 + nav 67 + object 41 = 567 tests）實測 **8.6s** < 10s 目標。
- **BLOCKED 行為**：failing pytest → `[pre-commit] BLOCKED: tests failed (<pkg>).` + exit 1（驗證過）。
- **nav integration 隔離**：staged nav_capability dummy → hook 只跑 67 tests，output 無 integration（reviewer 實證）。

Zero runtime code changes — hook script only。CI 紅綠驗證不適用（hook 不在 CI 跑），以上為本機等價驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)