### PR TITLE
ci: Tier 2 suites — nav_capability + go2_sdk fast-gate, object in container (Plan A5)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -55,6 +55,8 @@ jobs:
             vision_perception/test/test_event_action_bridge.py \
             vision_perception/test/test_mediapipe_pose_mapping.py \
             vision_perception/test/test_gesture_recognizer_backend.py \
+            vision_perception/test/test_lidar_obstacle_detector.py \
+            vision_perception/test/test_obstacle_detector.py \
             benchmarks/test/test_criteria.py \
             benchmarks/test/test_base_adapter.py \
             benchmarks/test/test_reporter.py \
@@ -119,6 +121,22 @@ jobs:
           # PYTHONPATH needed: the package is not pip-installed on the runner.
           # tests/ dir name avoids the top-level 'test' package collision.
           PYTHONPATH=tools/pawai_cli pytest tools/pawai_cli/tests -v --tb=short
+          # Invocation 5 (Plan A5, Tier 2): nav_capability pure-lib tests.
+          # NEVER add test/integration/ — test_mux_priority drives a real
+          # 0.30 m/s through the mux (2026-04-26 runaway incident).
+          # Dir-based collection: any NEW test file added here that imports
+          # rclpy will be auto-collected and fail on this runner — keep rclpy
+          # tests in integration/ (never automated) or switch to a file list.
+          PYTHONPATH=nav_capability pytest nav_capability/test/ \
+            --ignore=nav_capability/test/integration -v --tb=short
+          # Invocation 6 (Plan A5, Tier 2): go2_robot_sdk safety-critical pure tests.
+          # test_import.py excluded (aioice guard SystemExit on non-colcon env);
+          # test_reactive_stop_node.py excluded (rclpy — local L1 tier).
+          PYTHONPATH=go2_robot_sdk pytest \
+            go2_robot_sdk/test/test_robot_control_service.py \
+            go2_robot_sdk/test/test_reactive_stop_release_gate.py \
+            go2_robot_sdk/test/test_depth_geometry.py \
+            -v --tb=short
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4
@@ -190,6 +208,18 @@ jobs:
             'pytest>=7' opencv-python-headless numpy pydub
           bash -c "source /opt/ros/humble/setup.bash && \
             cd pawai-studio/gateway && python3 -m pytest -q --tb=short"
+      - name: object_perception tests (needs ROS msgs — Plan A5, Tier 2)
+        run: |
+          # Plan's fast-gate placement was unimplementable: the test module
+          # imports std_msgs + ObjectPerceptionNode (rclpy) at module level.
+          # onnxruntime / cv_bridge are lazy imports — not needed for tests.
+          # No rclpy.init() needed: tests use @staticmethod calls and a
+          # __new__ bypass, so importable ROS modules suffice (no DDS daemon).
+          pip3 install 'pytest>=7' opencv-python-headless numpy || \
+          pip3 install --break-system-packages 'pytest>=7' opencv-python-headless numpy
+          bash -c "source /opt/ros/humble/setup.bash && \
+            PYTHONPATH=\"object_perception:\$PYTHONPATH\" \
+            python3 -m pytest object_perception/test/ -q --tb=short"
       - name: Python syntax check
         run: |
           find . -name '*.py' \


### PR DESCRIPTION
## Plan A — Task A5（CI/CD Guardrails）

Per `docs/superpowers/plans/2026-06-10-plan-a-ci-guardrails.md` Task A5（Tier 2）：
- **Invocation 5**: nav_capability pure-lib（**67 tests**，plan 估 ~49）。`test/integration/` 永不自動化（test_mux_priority 會經 mux 灌真實 0.30 m/s — 2026-04-26 撞機）。
- **Invocation 6**: go2_robot_sdk 安全關鍵純測試 3 檔（**63 tests**）。test_import.py（known-red aioice guard）與 test_reactive_stop_node.py（rclpy）排除。
- **Invocation 1** 補 2 個 vision obstacle 檔（**+20 tests** → 375）。
- **object_perception（41 tests）→ ROS container job step**。

### Deviation from plan（已查證）
plan 把 object 放 fast-gate invocation 7 — **不可實作**：`test_object_perception.py` module-level `from std_msgs.msg import Empty` + `ObjectPerceptionNode`（rclpy），plain runner 沒有。onnxruntime/cv_bridge 是 lazy import、測試不需 rclpy.init()（@staticmethod + __new__ bypass）→ 走 A4 同款 container step（自帶 pip 依賴）。object 測試正是這輪重構的動機案例（COLOR_ZH 過期 = 「object 不在 CI」活證據），如今進 CI。

### Evidence（紅綠驗證）
- ✅ **Green run** — fast gate `375 / 278 / 111 / 144 / 67 / 63 passed`、container gateway 65 + **object 41 passed**: https://github.com/roy4222/PawAI/actions/runs/27318583800（amended sha；初版 eff608e 同綠 27318358412）
- 🔴 **Red run** — break commit `56fc5fc` 把 invocation 5 與 object step 指向不存在路徑 → **兩個 job 同一 run 各自變紅**（Fast Gate failure + test_environment failure）: https://github.com/roy4222/PawAI/actions/runs/27318766284
- ✅ **Green again** — break dropped via force-push，head 回 `a4ba1e8`（同上方綠 run sha）。

**紅驗證方式註記**：原計畫 break test assert，但 A6 的 pre-commit hook（本日稍早 merge）當場 BLOCKED 含壞測試的 commit，且本機 harness 政策禁止任何形式的 hook 跳過（skip 旗標與 hooksPath 覆寫都會被攔）— 護欄上線當天就工作了。改用 workflow 路徑級 break，走同一條 bash -e exit-code 傳播路徑，job 級紅證據等價。

Zero runtime code changes — workflow file only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
