### PR TITLE
ci: sync ros2-test-suite skill PACKAGES 4→8 with Plan A CI coverage (Plan A7)

### DIFF
--- a/.claude/skills/ros2-test-suite/scripts/run_all_tests.py
+++ b/.claude/skills/ros2-test-suite/scripts/run_all_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""PawAI ROS2 Test Suite — run all package tests with summary."""
+"""PawAI ROS2 Test Suite — run all package tests with summary (8 packages)."""
 
 import argparse
 import os
@@ -28,11 +28,36 @@ PACKAGES = {
     "go2_robot_sdk": {
         "test_dir": "go2_robot_sdk/test",
         "quick": False,
+        # test_import.py: known-red on non-colcon envs (aioice guard SystemExit), POST_DEMO fix
+        "extra_args": ["--ignore=go2_robot_sdk/test/test_import.py"],
     },
+    "interaction_executive": {
+        "test_dir": "interaction_executive/test",
+        "quick": False,
+    },
+    "pawai_brain": {
+        "test_dir": "pawai_brain/test",
+        "quick": False,
+    },
+    "nav_capability": {
+        "test_dir": "nav_capability/test",
+        "quick": False,
+        # integration/ NEVER automated: test_mux_priority drives real
+        # 0.30 m/s through the mux (2026-04-26 incident)
+        "extra_args": ["--ignore=nav_capability/test/integration"],
+    },
+    "object_perception": {
+        "test_dir": "object_perception/test",
+        "quick": False,
+    },
+    # DELIBERATELY EXCLUDED:
+    # tools/pawai_cli — ~300s on dev machines (tests leave real ssh probes waiting out timeouts;
+    #   one test fails when .env.local exists). CI fast-gate invocation 4 covers it.
+    #   Re-add after the planned conftest env-isolation fix.
 }
 
 
-def run_tests(pkg_name: str, test_dir: str) -> dict:
+def run_tests(pkg_name: str, test_dir: str, extra_args: list | None = None) -> dict:
     """Run pytest for a package and return results."""
     full_path = os.path.join(REPO_ROOT, test_dir)
     if not os.path.isdir(full_path):
@@ -42,9 +67,12 @@ def run_tests(pkg_name: str, test_dir: str) -> dict:
     if not test_files:
         return {"status": "skipped", "reason": "no test files", "passed": 0, "failed": 0, "errors": []}
 
+    cmd = [sys.executable, "-m", "pytest", full_path, "-q", "--tb=line", "--no-header"]
+    if extra_args:
+        cmd.extend(extra_args)
     start = time.time()
     result = subprocess.run(
-        [sys.executable, "-m", "pytest", full_path, "-q", "--tb=line", "--no-header"],
+        cmd,
         capture_output=True, text=True, cwd=REPO_ROOT, timeout=60
     )
     elapsed = time.time() - start
@@ -82,6 +110,8 @@ def run_tests(pkg_name: str, test_dir: str) -> dict:
     status = "passed" if failed == 0 and passed > 0 else "failed" if failed > 0 else "skipped"
     return {
         "status": status,
+        "reason": ("0 tests collected (collection error or all skipped)"
+                   if status == "skipped" else ""),
         "passed": passed,
         "failed": failed,
         "elapsed": round(elapsed, 2),
@@ -113,7 +143,7 @@ def main():
 
     for pkg_name, pkg_info in targets.items():
         print(f"\n  Running {pkg_name}...", end="", flush=True)
-        r = run_tests(pkg_name, pkg_info["test_dir"])
+        r = run_tests(pkg_name, pkg_info["test_dir"], pkg_info.get("extra_args"))
         results[pkg_name] = r
         total_passed += r["passed"]
         total_failed += r["failed"]


### PR DESCRIPTION
## Plan A — Task A7（CI/CD Guardrails）

Per `docs/superpowers/plans/2026-06-10-plan-a-ci-guardrails.md` Task A7: `ros2-test-suite` skill 的 PACKAGES dict 4→**8** 套件，與 Plan A 新增的 CI 覆蓋同步。

### 內容
- 新增 interaction_executive（本機 ROS 全跑 258）/ pawai_brain（348）/ nav_capability（67，`integration/` 永不自動化 — mux 撞機 2026-04-26）/ object_perception（41）。
- go2_robot_sdk 加 `--ignore=test_import.py`（known-red aioice guard on non-colcon envs，POST_DEMO 修）→ 90 passed。
- 新 `extra_args` 機制（dict 條目可帶額外 pytest args）。
- 順手修一個此檔案的潛在 crash（review 證實為真）：suite 收到 0 tests 時 `r['reason']` KeyError。

### Deviations（已查證）
- **tools/pawai_cli 不收**（plan 原列）— 本機 ~300s 真實網路 timeout（同 PR #146 分析）；CI invocation 4 已蓋。conftest env 隔離修好後再加回。
- 所以是 4→**8** 不是 plan 寫的 9。

### 驗證
本機全套實跑：**1019 passed, 0 failed**（speech 202 / face 13 / go2 90 / IE 258 / brain 348 / nav 67 / object 41；vision 在本機因 stale colcon install 跳過 — pre-existing 環境問題，reviewer 在 main 版本重現確認非本 PR 造成）。

CI 紅綠驗證不適用（skill script 不在 CI 跑）；PR CI 為標準閘門。

🤖 Generated with [Claude Code](https://claude.com/claude-code)