### PR TITLE
feat(cli): CLI v2 first slice — deploy safety + healthcheck hard-gate + status truthfulness (Plan B)

### DIFF
--- a/.claude/skills/brain-studio-lane/scripts/healthcheck.sh
+++ b/.claude/skills/brain-studio-lane/scripts/healthcheck.sh
@@ -5,7 +5,7 @@ set -uo pipefail
 
 JETSON_HOST="${JETSON_HOST:-jetson-nano}"
 SSH_OPTS="-o ConnectTimeout=8 -o ServerAliveInterval=5 -o ServerAliveCountMax=2"
-JETSON_TAILSCALE_IP="${JETSON_TAILSCALE_IP:-100.83.109.89}"
+JETSON_TAILSCALE_IP="${JETSON_TAILSCALE_IP:?JETSON_TAILSCALE_IP not set — run via pawai (env injected) or export it}"
 FAILS=0
 
 ros() { ssh $SSH_OPTS "$JETSON_HOST" "source /opt/ros/humble/setup.zsh && source ~/elder_and_dog/install/setup.zsh && $1" 2>/dev/null; }

--- a/docs/pawai_cli/README.md
+++ b/docs/pawai_cli/README.md
@@ -129,8 +129,9 @@ pawai demo stop                    # 6) 收工
 | [`pawai jetson deploy`](#jetson-deploy) | rsync 整個 repo + colcon build 指定模組 |
 | [`pawai demo start`](#demo-start) | 啟動 brain-studio-lane（Jetson tmux + 本機 Studio） |
 | [`pawai demo stop`](#demo-stop) | 清掉 demo session |
-| [`pawai demo school {list,ending}`](#demo-school) | 學校招生 demo：講稿提示 + 結尾固定詞 |
+| [`pawai demo school`](#demo-school) | **DEPRECATED**（5/16 活動已過；publisher 留在 `scripts/school_demo_ending.py`） |
 | [`pawai health brain`](#health-brain) | 跑 brain demo healthcheck |
+| [`pawai health nav`](#health-brain) | 跑 nav-avoidance-lane healthcheck |
 | [`pawai logs <module>`](#logs) | 抓對應 tmux pane 最後 N 行 |
 | [`pawai docs <target>`](#docs) | 開架構/onboarding/契約文件 |
 | [`pawai contract check`](#contract) | 跑 topic schema 驗證（預設 local，--jetson 跑遠端） |
@@ -252,13 +253,17 @@ pawai jetson deploy --module brain --no-sync   # 只 build 不 sync
 pawai jetson deploy --module brain -y          # 跳過 confirm
 ```
 
-**Sync 邏輯**：
-1. 如果你家 `~/sync` 是 executable（個人化 wrapper），用它
-2. 否則用內建 rsync，自動 exclude：`.git/`、`.env`、`.env.*`、`.env.local`、
-   `.ssh/`、`build/`、`install/`、`log/`、`__pycache__/`、`.pytest_cache/`、`.venv/`、`node_modules/`、`.next/`、
-   `.ruff_cache/`、`.mypy_cache/`、`.DS_Store`
+**Sync 邏輯**（Plan B2 優先序反轉，2026-06-10 `.env` 刪除事故後）：
+1. **預設一律用內建 audited rsync**，exclude 清單來自唯一契約檔
+   `tools/sync/rsync-excludes.txt`（`.git/`、`.env`、`.env.*`、`.env.local`、
+   `.ssh/`、`build/`、`install/`、`log/`、cache 目錄等 16 條，測試把守）
+2. `~/sync once` 改為 **opt-in**：需 `PAWAI_SYNC_CMD=1` 且 `~/sync` 存在可執行，
+   會印 `⚠ UNAUDITED` 警告（它沒有 exclude 契約，6/10 事故元兇）
+3. **Post-sync guard**：任一 sync 路徑後（成功或失敗皆然）檢查 Jetson
+   `.env`/`.env.local` 仍存在，消失即 fail-loud + 印還原 SOP
 
 Secrets 只留本機 `.env.local`，不會被 deploy 推到 Jetson。
+手動 sync 用 `scripts/sync_to_jetson.sh`（共用同一份 exclude 契約，不 build）。
 
 **Build 邏輯**：在 Jetson 上跑 `colcon build --packages-select <模組對應的 packages>`，
 build log 直接 stream 到本機。
@@ -280,6 +285,7 @@ pawai demo start --no-studio # full mode 但不開本機 Studio
 pawai demo start --brain-only # 只起 brain（minimal mode，無 perception）
 pawai demo start --nav capability # 起導航避障 capability stack（手動 action 場測）
 pawai demo start -y          # 跳過一般確認；不能搶別人的 lock
+pawai demo start --skip-healthcheck # 逃生口：跳過 post-start healthcheck gate（見下）
 ```
 
 預設模式做的事：
@@ -306,6 +312,14 @@ pawai demo start -y          # 跳過一般確認；不能搶別人的 lock
 ✅ Gateway reachable from local: http://100.83.109.89:8080
 ✅ Frontend: http://localhost:3000/studio
 ```
+
+**Post-start healthcheck hard gate（Plan B4）**：`start.sh` rc==0 **不算成功**——
+6/4 `.env` CRLF 事故證明 tmux 可能根本沒 spawn 卻回報 `✓ Demo running`。
+`demo start` 在 start.sh 成功後會跑 lane 對應的 healthcheck
+（brain → `brain-studio-lane/scripts/healthcheck.sh`、nav capability →
+`nav-avoidance-lane/scripts/healthcheck.sh`），**pass 才把 lock 轉 `running`**。
+fail → exit 1、lock 留在 `starting` 當證據、印 inspect/cleanup 指引。
+逃生口（healthcheck 本身壞掉時才用）：`--skip-healthcheck`，會印大字警告。
 
 **`JETSON_TAILSCALE_IP` 解析優先序**（`demo start` / `health brain` 共用）：
 1. `PAWAI_TRUST_ENV_IP=1` → 信任 env 值不覆蓋（hand-crafted testing 的逃生口）
@@ -369,22 +383,17 @@ Brain cleanup 只會關閉 `/tmp/pawai-frontend.pid` 指向的本機 frontend，
 
 ### demo school
 
-學校招生 demo 工具。前三段（打招呼 / 自介 / 介紹輔大資管）由 brain 端
-`school_demo_request` mode 自然觸發，CLI 只負責**結尾固定詞 + Go2 比愛心**。
+**[DEPRECATED 2026-06-10，Plan B6]** 5/16 學校招生活動已過，命令已退役——
+`pawai demo school` 現在只回報 retired 訊息並 exit 非零。
 
-```bash
-pawai demo school list             # 印結尾固定詞 + brain 觸發講稿（給主持人）
-pawai demo school ending           # publish FingerHeart + 結尾語音
-pawai demo school ending --dry-run # 只印遠端指令，不 SSH
-```
+ending publisher 的 **wait-for-subscriber-then-publish pattern**（等 DDS
+discovery → publish → spin 1.5s 確保 RELIABLE QoS 投遞，解一次性
+`ros2 topic pub` 約 1/3 機率掉訊息的 race）保留在
+`scripts/school_demo_ending.py`，可在 Jetson 上直接執行、也可作為任何
+「可靠 one-shot publish」需求的參考實作。
 
-`ending` 繞過 brain，直接送 Go2 FingerHeart 動作（`/webrtc_req` api_id 1036）
-+ 結尾語音（`/tts`），保證原文播出、不入對話歷史。內部用 inline python rclpy
-publisher（等 subscriber discovery → publish → spin 1.5s 確保投遞），避免
-一次性 `ros2 topic pub` race 掉訊息。
-
-> brain 端 `school_demo_request`：使用者提到「資管 / 資訊管理」即注入輔大 5
-> 大亮點 facts；含 ASR 同音字錯字容錯（直管系 / 資詢管理系 等也能命中）。
+> brain 端 `school_demo_request` mode（資管同音字容錯等）不受影響，仍在
+> pawai_brain 內。
 
 ---
 
@@ -397,6 +406,14 @@ pawai health brain
 跑 `.claude/skills/brain-studio-lane/scripts/healthcheck.sh`，但由 CLI 注入
 `JETSON_HOST` 與 `JETSON_TAILSCALE_IP`，避免 healthcheck 寫死 hostname 或缺 env。
 Demo 跑起來後用它確認 Gateway 8080、Studio frontend、Jetson tmux 與 brain stack。
+
+`pawai health nav` 同款，跑 `nav-avoidance-lane/scripts/healthcheck.sh`
+（nav capability stack 的對應檢查）。兩者也是 `demo start` post-start hard
+gate（Plan B4）背後呼叫的同一批腳本。
+
+> brain 的 healthcheck.sh 已改 fail-hard：`JETSON_TAILSCALE_IP` 未設時立即
+> 報錯退出（不再 fallback 寫死 IP；nav 的 script 不用此變數）。走 `pawai`
+> 入口會自動注入；裸跑需自行 export。
 
 ---
 

--- a/docs/pawai_cli/troubleshooting.md
+++ b/docs/pawai_cli/troubleshooting.md
@@ -384,8 +384,17 @@ ls scripts/start_*.sh scripts/clean_*.sh
 
 ### F3. 我有自己的 ~/sync 腳本
 
-`pawai jetson deploy` 會優先用 `~/sync once`（如果存在且 executable），
-否則 fallback 到內建 rsync。內建 rsync exclude 已涵蓋 cache 目錄，多數情況不需要自訂腳本。
+2026-06-10 起 `~/sync` **不再有優先權**（當天它把 Jetson 的 `.env` 刪了，
+demo 假成功根因鏈之一）。`pawai jetson deploy` 預設一律用內建 audited rsync
+（exclude 契約：`tools/sync/rsync-excludes.txt`）。仍要用自己的腳本：
+
+```bash
+PAWAI_SYNC_CMD=1 pawai jetson deploy --module brain
+```
+
+會印 `⚠ UNAUDITED` 警告，且 post-sync guard 照樣檢查 `.env`/`.env.local`
+沒被刪（被刪會 fail-loud + 印還原 SOP）。多數情況不需要自訂腳本；
+手動 sync 走 `scripts/sync_to_jetson.sh`（共用 exclude 契約）。
 
 ---
 

--- a/docs/pawai_cli/usage-guide.md
+++ b/docs/pawai_cli/usage-guide.md
@@ -149,18 +149,24 @@ Deploy complete.
 - **`-y` 不能搶別人 lock** —— 訊息：`-y does not override another user's demo. Use --force.`
 - **只有 `--force` 能在別人 running 時繞過 prompt**——而且必須先口頭溝通
 
-### 2.5 Phase 1 新行為：rsync 自動排除密鑰
+### 2.5 rsync 排除密鑰：保證來自契約檔 + post-sync guard（Plan B2 強化）
 
-下列檔名 **不會** 被推上 Jetson（避免 `.env.local` 裡的 `OPENROUTER_KEY` 等 secret 跨帳號漏出）：
+`.env` / `.env.*` / `.env.local` / `.ssh/` 等檔案 **不會** 被推上或刪除於 Jetson。
+這個保證有兩層（2026-06-10 `~/sync` 刪掉 Jetson `.env` 事故後建立）：
 
-```
-.env
-.env.*
-.env.local
-.ssh/
-```
+1. **Exclude 契約檔**：`tools/sync/rsync-excludes.txt` 是唯一真相源——
+   `pawai jetson deploy` 與 `scripts/sync_to_jetson.sh`（手動 sync）共用同一份，
+   測試（`test_rsync_excludes_file_has_protected_entries`）把守保命條目不可少。
+2. **Post-sync guard**：sync 之後（成功或失敗皆然）檢查 Jetson 上的
+   `.env` / `.env.local` 是否還在；sync 前存在、sync 後消失 → deploy 立刻
+   fail-loud 並印還原 SOP（`cp .env.local .env`）。
 
 每個人本機 `.env.local` 各自保留，**Jetson 端的 `.env` 由 Jetson owner 管理**，跟你的 .env.local 不衝突。
+
+> ⚠️ **`~/sync` 個人腳本已降為 opt-in**（優先序反轉）：預設一律用內建 audited
+> rsync。要用自己的 `~/sync once` 必須設 `PAWAI_SYNC_CMD=1`，輸出會印
+> `⚠ UNAUDITED` 警告——它沒有 exclude 契約，6/10 事故就是它造成的。
+> post-sync guard 對這條路徑同樣生效。
 
 ### 2.6 deploy 完該檢查什麼
 
@@ -478,6 +484,9 @@ CLI 的 user-actionable failure 字串對照。**不包含**正常 progress mess
 | `⚠ alice@xxx is running a demo on branch=X` + `Continue? [force/cancel]` | `jetson deploy` | 跟 alice 溝通；同意後輸入 `force` |
 | `` `-y` does not override another user's demo. Use --force. `` (exit 2) | `jetson deploy -y` | 拿掉 `-y`、加 `--force`、先溝通 |
 | `Existing lock is yours ({state}). Restarting demo.` | `demo start` | 正常訊息，CLI 會自動清理+重啟，無需動作 |
+| `✗ Demo processes were launched but healthcheck FAILED` (exit 1) | `demo start` | start.sh 起來了但 lane healthcheck 沒過（6/4 類假成功被擋下）；lock 留在 `starting` 當證據。`pawai logs <module>` / `pawai status` 查因 → `pawai demo stop` 清理。healthcheck 本身壞掉才用 `--skip-healthcheck` |
+| `⚠⚠ HEALTHCHECK SKIPPED (--skip-healthcheck)` | `demo start` | 你自己選的逃生口：只剩 start.sh rc 一層證據，demo 可能默壞，務必手動驗 |
+| `PROTECTED FILE(S) DELETED BY SYNC: ...` | `jetson deploy` | sync 把 Jetson 的 `.env`/`.env.local` 刪了（6/10 事故類）。照訊息還原：`ssh $JETSON_HOST 'cd ~/elder_and_dog && cp .env.local .env'` |
 | `Another user is in demo: alice@xxx branch=X state=Y` + `Take over? [force/cancel]` | `demo start` | 跟 alice 溝通；同意後輸入 `force` |
 | `` `-y` does not override another user's lock. Use --force to take over. `` (exit 2) | `demo start -y` | 拿掉 `-y`、加 `--force`、先溝通 |
 | `Failed to acquire lock after 3 retries…` (exit 2) | `demo start` | **不要重跑**。訊息會印出 `ssh $JETSON_HOST 'lsof /tmp/pawai-demo-lock.flock; cat .pawai-demo-lock'` 等可直接複製的指令；通常原因是上一個 start.sh 還沒跑完 |

--- a/scripts/school_demo_ending.py
+++ b/scripts/school_demo_ending.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""School-demo ending publisher — 2026-05-16 招生活動產物（活動已過，CLI 命令已退役）.
+
+保留原因：wait-for-subscriber-then-publish pattern 解的是真實 DDS one-shot-pub
+race — 一次性 `ros2 topic pub`（即使 `-w 1`）在 publish() 返回瞬間就拆掉
+publisher，DDS 未必已把訊息 flush 上線，/tts 約 1/3 機率被靜默丟棄
+（2026-05-15 實機觀測）。本 pattern：等兩個 subscription 被 DDS discovery
+發現 → publish → spin 1.5s 讓 RELIABLE QoS 寫入真正落地後才退出。
+任何需要可靠 one-shot publish 的場合都可重用。
+
+Run ON the Jetson (needs rclpy + go2_interfaces):
+    source /opt/ros/humble/setup.zsh && source install/setup.zsh
+    python3 scripts/school_demo_ending.py
+"""
+import sys
+import time
+
+import rclpy
+from go2_interfaces.msg import WebRtcReq
+from std_msgs.msg import String
+
+SCHOOL_DEMO_ENDING_TEXT = "最後~祝各位考生面試順利！請記得，輔大資管系填寫第一志願喔！"
+FINGER_HEART_API_ID = 1036  # Go2 sport action「比愛心」
+
+
+def main() -> int:
+    rclpy.init()
+    n = rclpy.create_node("pawai_school_ending")
+    heart = n.create_publisher(WebRtcReq, "/webrtc_req", 10)
+    tts = n.create_publisher(String, "/tts", 10)
+
+    # Wait (≤15s) until DDS discovery sees both subscribers — publishing
+    # before discovery is the exact failure mode this script exists to avoid.
+    deadline = time.time() + 15.0
+    while time.time() < deadline and (
+        heart.get_subscription_count() == 0 or tts.get_subscription_count() == 0
+    ):
+        rclpy.spin_once(n, timeout_sec=0.1)
+
+    tts_subs = tts.get_subscription_count()
+    heart_subs = heart.get_subscription_count()
+    if tts_subs == 0:
+        print("ERROR: no /tts subscriber discovered after 15s; not publishing",
+              file=sys.stderr)
+        n.destroy_node()
+        rclpy.shutdown()
+        return 20
+    if heart_subs == 0:
+        print("WARN: no /webrtc_req subscriber discovered; publishing speech only",
+              file=sys.stderr)
+
+    heart.publish(WebRtcReq(id=0, topic="rt/api/sport/request",
+                            api_id=FINGER_HEART_API_ID, parameter="", priority=0))
+    msg = String()
+    msg.data = SCHOOL_DEMO_ENDING_TEXT
+    tts.publish(msg)
+
+    # Spin past publish so the RELIABLE-QoS write actually lands on the wire
+    # before the process (and its DDS participant) disappears.
+    flush = time.time() + 1.5
+    while time.time() < flush:
+        rclpy.spin_once(n, timeout_sec=0.1)
+
+    n.destroy_node()
+    rclpy.shutdown()
+    print(f"school ending published (tts_subs={tts_subs}, heart_subs={heart_subs})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_to_jetson.sh
+++ b/scripts/sync_to_jetson.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# WSL → Jetson manual sync — formalizes the "safe manual rsync" the team has
+# used since the 6/10 ~/sync .env-deletion incident. Same exclude contract as
+# `pawai jetson deploy` (tools/sync/rsync-excludes.txt). Does NOT colcon build.
+set -euo pipefail
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+JETSON_HOST="${JETSON_HOST:-jetson-nano}"
+JETSON_REPO="${JETSON_REPO:-~/elder_and_dog}"
+echo "rsync $REPO_ROOT/ → $JETSON_HOST:$JETSON_REPO/ (exclude contract: tools/sync/rsync-excludes.txt)"
+rsync -az --delete \
+  --exclude-from="$REPO_ROOT/tools/sync/rsync-excludes.txt" \
+  "$REPO_ROOT/" "$JETSON_HOST:$JETSON_REPO/"
+echo "✓ sync done. Remember: colcon build --packages-select <pkg> on Jetson if .py changed."

--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -1073,102 +1073,18 @@ def demo_stop(force: bool) -> None:
     sys.exit(rc)
 
 
-# ─── pawai demo school (學校招生 demo) ─────────────────────────────────
-# 2026-05-16: 配合 brain school_demo_request mode 設計。Brain 端負責由語音/
-# 文字自然觸發前三段（打招呼 / 自介 / 介紹輔大資管）；CLI 僅保留結尾固定
-# 詞的手動觸發，繞過 brain 直接 publish /tts，保證原文播出、不入對話歷史。
+# ─── pawai demo school（已退役）──────────────────────────────────────────
+# 2026-05-16 招生活動產物，活動已過（Plan B6 退役）。ending publisher 的
+# wait-for-subscriber-then-publish pattern（解 DDS one-shot-pub race）保留在
+# scripts/school_demo_ending.py，可重用。
 
-SCHOOL_DEMO_ENDING_TEXT = "最後~祝各位考生面試順利！請記得，輔大資管系填寫第一志願喔！"
-FINGER_HEART_API_ID = 1036  # Go2 sport action「比愛心」
-
-
-@demo.group("school")
-def school() -> None:
-    """學校招生 demo 工具（手動結尾 + 講稿提示）。"""
-
-
-@school.command("list")
-def school_list() -> None:
-    """印出結尾固定詞與 brain 觸發提示（給主持人對講稿用）。"""
-    click.echo("結尾固定詞（CLI 手動觸發，含 Go2 比愛心動作）：")
-    click.echo(f"  {SCHOOL_DEMO_ENDING_TEXT}")
-    click.echo("")
-    click.echo("Brain 觸發提示（直接對 PawAI 說／用 Studio 送文字）：")
-    click.echo("  打招呼：「跟現場家長和學生打個招呼」")
-    click.echo("  自介：「介紹一下你自己」")
-    click.echo("  輔大資管：「介紹輔大資管系的特色」")
-
-
-def _build_school_ending_remote_cmd() -> str:
-    """Compose the remote command for the ending: FingerHeart + /tts line.
-
-    Uses an inline python3 rclpy publisher rather than two one-shot
-    `ros2 topic pub` calls. A one-shot `ros2 topic pub` (even with `-w 1`)
-    tears the publisher down the instant publish() returns — DDS has not
-    necessarily flushed the message to the wire, so the /tts line is
-    silently dropped maybe 1-in-3 times (observed live 2026-05-15). The
-    python publisher instead: waits for both subscriptions to be discovered,
-    publishes, then spins 1.5s so the RELIABLE-QoS write actually lands
-    before the process exits.
-
-    Uses shell.jetson_repo() so it follows the repo-wide JETSON_REPO env.
-    json.dumps(ensure_ascii=False) embeds the 中文 ending line as a valid
-    python str literal; shlex.quote wraps the whole script for zsh.
-    """
-    repo = shell.jetson_repo()
-    data_literal = json.dumps(SCHOOL_DEMO_ENDING_TEXT, ensure_ascii=False)
-    script = "\n".join([
-        "import sys, time, rclpy",
-        "from std_msgs.msg import String",
-        "from go2_interfaces.msg import WebRtcReq",
-        "rclpy.init()",
-        "n = rclpy.create_node('pawai_school_ending')",
-        "heart = n.create_publisher(WebRtcReq, '/webrtc_req', 10)",
-        "tts = n.create_publisher(String, '/tts', 10)",
-        "deadline = time.time() + 15.0",
-        "while time.time() < deadline and "
-        "(heart.get_subscription_count() == 0 or tts.get_subscription_count() == 0):",
-        "    rclpy.spin_once(n, timeout_sec=0.1)",
-        "tts_subs = tts.get_subscription_count()",
-        "heart_subs = heart.get_subscription_count()",
-        "if tts_subs == 0:",
-        "    print('ERROR: no /tts subscriber discovered after 15s; not publishing', "
-        "file=sys.stderr)",
-        "    n.destroy_node(); rclpy.shutdown(); sys.exit(20)",
-        "if heart_subs == 0:",
-        "    print('WARN: no /webrtc_req subscriber discovered; publishing speech only', "
-        "file=sys.stderr)",
-        f"heart.publish(WebRtcReq(id=0, topic='rt/api/sport/request', "
-        f"api_id={FINGER_HEART_API_ID}, parameter='', priority=0))",
-        f"msg = String(); msg.data = {data_literal}",
-        "tts.publish(msg)",
-        "flush = time.time() + 1.5",
-        "while time.time() < flush:",
-        "    rclpy.spin_once(n, timeout_sec=0.1)",
-        "n.destroy_node(); rclpy.shutdown()",
-        "print(f'school ending published (tts_subs={tts_subs}, heart_subs={heart_subs})')",
-    ])
-    return (
-        f"cd {shlex.quote(repo)} && "
-        f"source /opt/ros/humble/setup.zsh && "
-        f"source install/setup.zsh && "
-        f"python3 -c {shlex.quote(script)}"
+@demo.command("school")
+def demo_school() -> None:
+    """[DEPRECATED 2026-06-10] 5/16 school demo is over."""
+    raise click.ClickException(
+        "demo school retired (event passed 5/16). "
+        "The ending publisher lives in scripts/school_demo_ending.py if ever needed."
     )
-
-
-@school.command("ending")
-@click.option("--dry-run", is_flag=True, help="只印將執行的指令，不實際 SSH。")
-def school_ending(dry_run: bool) -> None:
-    """Publish 固定結尾詞到 /tts，繞過 brain。"""
-    ros_cmd = _build_school_ending_remote_cmd()
-    if dry_run:
-        click.echo(ros_cmd)
-        return
-    res = shell.run_remote(ros_cmd, timeout=40)
-    if not res.ok:
-        click.echo(f"[school ending] SSH failed (code {res.code}): {res.stderr}", err=True)
-        sys.exit(res.code or 1)
-    click.echo("[school ending] published.")
 
 
 # ─── pawai net wifi ──────────────────────────────────────────────────────

--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -771,6 +771,21 @@ def health_brain() -> None:
     sys.exit(rc)
 
 
+@health.command("nav")
+def health_nav() -> None:
+    """Run nav-avoidance-lane healthcheck against Jetson."""
+    script = (
+        shell.repo_root() / ".claude" / "skills" / "nav-avoidance-lane" /
+        "scripts" / "healthcheck.sh"
+    )
+    if not script.exists():
+        raise click.ClickException(f"healthcheck script not found: {script}")
+    env = _build_demo_env()
+    env["JETSON_HOST"] = shell.jetson_host()
+    rc = shell.stream(["bash", str(script)], cwd=shell.repo_root(), env=env)
+    sys.exit(rc)
+
+
 _LANE_HEALTHCHECK = {
     "brain": ".claude/skills/brain-studio-lane/scripts/healthcheck.sh",
     "nav_capability": ".claude/skills/nav-avoidance-lane/scripts/healthcheck.sh",

--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -505,47 +505,96 @@ def jetson() -> None:
     """Jetson deployment helpers."""
 
 
+PROTECTED_REMOTE_FILES = (".env", ".env.local")
+
+
+def _snapshot_protected() -> dict[str, bool]:
+    """Record which protected files exist on Jetson BEFORE sync.
+
+    Returns a mapping of remote absolute paths → existed-bool.
+    Used by _post_sync_guard to detect deletions caused by rsync --delete.
+    """
+    repo = shell.jetson_repo()
+    out: dict[str, bool] = {}
+    for name in PROTECTED_REMOTE_FILES:
+        path = f"{repo}/{name}"
+        r = shell.run_remote(f"test -f {path} && echo OK || echo MISSING", timeout=8)
+        out[path] = bool(r.ok and "OK" in r.stdout)
+    return out
+
+
+def _post_sync_guard(pre: dict[str, bool]) -> None:
+    """Fail loud if any protected file that existed pre-sync is gone post-sync.
+
+    Raises click.ClickException with a clear recovery SOP if any file that
+    was present before the sync is now missing.  This catches the 6/10-style
+    incident where rsync --delete silently removed Jetson's .env.
+    """
+    deleted = []
+    for path, existed in pre.items():
+        if not existed:
+            continue
+        r = shell.run_remote(f"test -f {path} && echo OK || echo MISSING", timeout=8)
+        if not (r.ok and "OK" in r.stdout):
+            deleted.append(path)
+    if deleted:
+        raise click.ClickException(
+            "PROTECTED FILE(S) DELETED BY SYNC: " + ", ".join(deleted) +
+            "\n  Restore now:  ssh $JETSON_HOST 'cd ~/elder_and_dog && cp .env.local .env'"
+            "\n  (CLAUDE.md §Demo 啟動/.env 環境陷阱 has the full SOP.)"
+        )
+
+
 def _do_rsync_and_build(root: Path, packages: list[str], no_sync: bool, no_build: bool,
                          module_key: str) -> tuple[int, str]:
-    """Perform rsync and/or colcon build. Returns (exit_code, sync_method)."""
+    """Perform rsync and/or colcon build. Returns (exit_code, sync_method).
+
+    Priority (6/10 incident fix — Plan B2):
+      DEFAULT: audited builtin rsync with --exclude-from=tools/sync/rsync-excludes.txt.
+      OPT-IN:  set PAWAI_SYNC_CMD=1 AND have ~/sync executable → use external sync.
+               Prints a loud warning; ~/sync is unaudited and caused the 6/10 .env deletion.
+
+    After any sync path, _post_sync_guard checks that .env/.env.local were not deleted.
+    """
     if not no_sync:
+        pre = _snapshot_protected()
+
         sync_once = Path.home() / "sync"
-        if sync_once.exists() and os.access(sync_once, os.X_OK):
-            print("Sync: ~/sync once")
+        use_external = (
+            os.environ.get("PAWAI_SYNC_CMD") == "1"
+            and sync_once.exists()
+            and os.access(sync_once, os.X_OK)
+        )
+
+        if use_external:
+            print("⚠ UNAUDITED external sync (PAWAI_SYNC_CMD=1) — ~/sync once")
             code = shell.stream([str(sync_once), "once"], cwd=root)
             if code != 0:
+                # Guard even on failure: a broken script may delete .env AND
+                # exit nonzero (the 6/10 incident class) — name the loss loudly
+                # instead of hiding it behind a generic exit code.
+                _post_sync_guard(pre)
                 return code, "sync-once"
             sync_method = "sync-once"
         else:
             print("Sync: rsync whole repo")
             dest = f"{shell.jetson_host()}:{shell.jetson_repo().rstrip('/')}/"
+            excludes = root / "tools" / "sync" / "rsync-excludes.txt"
             argv = [
                 "rsync",
                 "-az",
                 "--delete",
-                "--exclude=.git/",
-                "--exclude=.env",
-                "--exclude=.env.*",
-                "--exclude=.env.local",
-                "--exclude=.ssh/",
-                "--exclude=build/",
-                "--exclude=install/",
-                "--exclude=log/",
-                "--exclude=__pycache__/",
-                "--exclude=.pytest_cache/",
-                "--exclude=.venv/",
-                "--exclude=node_modules/",
-                "--exclude=.next/",
-                "--exclude=.ruff_cache/",
-                "--exclude=.mypy_cache/",
-                "--exclude=.DS_Store",
+                f"--exclude-from={excludes}",
                 f"{root}/",
                 dest,
             ]
             code = shell.stream(argv)
             if code != 0:
+                _post_sync_guard(pre)
                 return code, "rsync"
             sync_method = "rsync"
+
+        _post_sync_guard(pre)
     else:
         sync_method = "none"
 

--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -771,6 +771,26 @@ def health_brain() -> None:
     sys.exit(rc)
 
 
+_LANE_HEALTHCHECK = {
+    "brain": ".claude/skills/brain-studio-lane/scripts/healthcheck.sh",
+    "nav_capability": ".claude/skills/nav-avoidance-lane/scripts/healthcheck.sh",
+}
+
+
+def _run_lane_healthcheck(lane: str) -> int:
+    """Post-start gate (Plan B4): start.sh rc==0 is NOT success — the 6/4
+    CRLF incident proved tmux can silently never spawn.  Returns healthcheck rc;
+    script-missing counts as failure (fail-closed)."""
+    rel = _LANE_HEALTHCHECK.get(lane, _LANE_HEALTHCHECK["brain"])
+    script = shell.repo_root() / rel
+    if not script.exists():
+        click.echo(f"✗ healthcheck script missing: {script} (fail-closed)")
+        return 1
+    env = _build_demo_env()
+    env["JETSON_HOST"] = shell.jetson_host()
+    return shell.stream(["bash", str(script)], cwd=shell.repo_root(), env=env)
+
+
 def _invoke_nav_start_sh() -> int:
     return shell.stream(
         ["bash", ".claude/skills/nav-avoidance-lane/scripts/start.sh", "capability"],
@@ -835,8 +855,10 @@ def _current_sha_short() -> str:
               help="Start nav capability lane. First version supports only: capability.")
 @click.option("-y", "yes", is_flag=True, help="Skip ordinary confirmation prompts (does NOT override another user's lock).")
 @click.option("--force", "force", is_flag=True, help="Take over another user's demo lock.")
+@click.option("--skip-healthcheck", is_flag=True,
+              help="Escape hatch: trust start.sh rc and skip the post-start healthcheck gate.")
 def demo_start(no_studio: bool, brain_only: bool, nav_mode: str | None,
-               yes: bool, force: bool) -> None:
+               yes: bool, force: bool, skip_healthcheck: bool) -> None:
     """Start brain demo or nav capability lane."""
     from .lock import LOCK_FLOCK_PATH, Lock, is_stale, is_own_lock
 
@@ -953,6 +975,27 @@ def demo_start(no_studio: bool, brain_only: bool, nav_mode: str | None,
         # we must NOT delete the new owner's lock.
         Lock.release_if_owned(user=user, host=host)
         sys.exit(rc)
+
+    if skip_healthcheck:
+        click.echo(
+            "⚠⚠ HEALTHCHECK SKIPPED (--skip-healthcheck) — start.sh rc is the "
+            "only evidence; demo may be silently broken (6/4-class failure). ⚠⚠"
+        )
+    else:
+        click.echo("Post-start healthcheck (hard gate — Plan B4)...")
+        hc_rc = _run_lane_healthcheck(lane)
+        if hc_rc != 0:
+            click.echo(
+                "✗ Demo processes were launched but healthcheck FAILED — "
+                "lock kept in 'starting' as evidence."
+            )
+            click.echo("  Inspect:  pawai logs <module>   |   pawai status")
+            click.echo("  Cleanup:  pawai demo stop")
+            click.echo(
+                "  Escape hatch (only if healthcheck itself is broken): "
+                "pawai demo start --skip-healthcheck"
+            )
+            sys.exit(1)
 
     if not lk.transition_if_owned("running", user=user, host=host):
         # Lock got force-taken (or vanished) while start.sh was running.

--- a/tools/pawai_cli/pawai_cli/status.py
+++ b/tools/pawai_cli/pawai_cli/status.py
@@ -8,6 +8,33 @@ from . import shell
 from .lock import Lock, is_stale
 
 
+_MODULE_NODE_HINTS: dict[str, str] = {
+    "face": "face_identity_node",
+    "vision(pose+gesture)": "vision_perception",
+    "object": "object_perception",
+    "speech(asr)": "stt_intent_node",
+    "tts": "tts_node",
+    "brain": "brain_node",
+    "executive": "interaction_executive",
+    "conv_graph": "conversation_graph_node",
+    "go2_driver": "go2_driver_node",
+}
+
+
+def gateway_health() -> str:
+    r = shell.run_remote(
+        "curl -s --max-time 3 http://localhost:8080/health || true",
+        timeout=8,
+    )
+    if r.ok and '"status":"ok"' in r.stdout:
+        return "ok " + r.stdout.strip()[:120]
+    return "down / not started"
+
+
+def module_presence(ros_nodes: str) -> list[tuple[str, bool]]:
+    return [(label, hint in ros_nodes) for label, hint in _MODULE_NODE_HINTS.items()]
+
+
 def _read_last_deploy_remote() -> dict | None:
     remote_path = f"{shell.jetson_repo()}/.pawai-last-deploy"
     result = shell.run_remote(
@@ -207,6 +234,11 @@ def print_status(short: bool = False) -> LiveStatus:
                 print(f"  ... +{len(nodes) - 14} more")
         else:
             print("  none")
+
+        print("\nModules (node presence):")
+        for label, present in module_presence(st.ros_nodes):
+            print(f"  {'✅' if present else '— '} {label}")
+        print(f"\nStudio gateway /health: {gateway_health()}")
 
         print("\nJetson git:")
         if st.git:

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -402,6 +402,7 @@ def test_demo_start_force_takes_over(monkeypatch):
                side_effect=lambda user, host: released.append((user, host)) or True), \
          patch("pawai_cli.lock.Lock.acquire", return_value=other_lock), \
          patch("pawai_cli.main._invoke_start_sh", return_value=0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
          patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True):
         runner = CliRunner()
         runner.invoke(cli, ["demo", "start", "--force"])
@@ -435,6 +436,7 @@ def test_demo_start_force_cleans_old_nav_lane_before_takeover(monkeypatch):
                side_effect=lambda **kwargs: calls.append("acquire") or new_lock), \
          patch("pawai_cli.main._invoke_start_sh",
                side_effect=lambda **kwargs: calls.append("brain_start") or 0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
          patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True):
         runner = CliRunner()
         result = runner.invoke(cli, ["demo", "start", "--force"])
@@ -871,9 +873,11 @@ def test_demo_start_nav_capability_invokes_nav_start(monkeypatch):
         return acquired
 
     with patch("pawai_cli.lock.Lock.read", return_value=None), \
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
          patch("pawai_cli.lock.Lock.acquire", side_effect=fake_acquire), \
          patch("pawai_cli.main._invoke_nav_start_sh", return_value=0) as nav_start, \
          patch("pawai_cli.main._invoke_start_sh", return_value=0) as brain_start, \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
          patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True):
         runner = CliRunner()
         result = runner.invoke(cli, ["demo", "start", "--nav", "capability"])
@@ -1122,6 +1126,7 @@ def test_demo_start_orphan_driver_force_cleans_and_proceeds(monkeypatch):
                side_effect=lambda **kw: calls.append("acquire") or new_lock), \
          patch("pawai_cli.main._invoke_start_sh",
                side_effect=lambda **kw: calls.append("start") or 0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
          patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True):
         result = CliRunner().invoke(cli, ["demo", "start", "--force"])
     assert result.exit_code == 0, result.output
@@ -1143,6 +1148,7 @@ def test_demo_start_orphan_driver_interactive_yes_cleans(monkeypatch):
                side_effect=lambda **kw: calls.append("acquire") or new_lock), \
          patch("pawai_cli.main._invoke_start_sh",
                side_effect=lambda **kw: calls.append("start") or 0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
          patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True):
         result = CliRunner().invoke(cli, ["demo", "start"], input="y\n")
     assert result.exit_code == 0, result.output
@@ -1183,6 +1189,7 @@ def test_demo_start_no_orphan_check_when_lock_present(monkeypatch):
          patch("pawai_cli.lock.Lock.release", return_value=True), \
          patch("pawai_cli.lock.Lock.acquire", return_value=own_lock), \
          patch("pawai_cli.main._invoke_start_sh", return_value=0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
          patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True):
         result = CliRunner().invoke(cli, ["demo", "start"])
     assert result.exit_code == 0, result.output
@@ -1246,6 +1253,7 @@ def test_demo_start_transition_failure_does_not_corrupt_others_lock():
          patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
          patch("pawai_cli.lock.Lock.acquire", return_value=lk), \
          patch("pawai_cli.main._invoke_start_sh", return_value=0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
          patch("pawai_cli.lock.Lock.transition_if_owned", return_value=False):
         result = CliRunner().invoke(cli, ["demo", "start"])
     assert result.exit_code == 2
@@ -1503,3 +1511,97 @@ def test_sync_script_uses_shared_exclude_contract():
     body = script.read_text()
     assert "--exclude-from=" in body and "tools/sync/rsync-excludes.txt" in body
     assert "--delete" in body
+
+
+# ─── Plan B4: post-start lane healthcheck hard gate ───────────────────────
+
+def _patch_demo_start_happy(monkeypatch, hc_rc: int):
+    """Common scaffolding: no existing lock, no orphan drivers, lock acquire OK,
+    start.sh rc=0, healthcheck rc=hc_rc.  Mirrors the full patch set of the
+    passing orphan tests so the happy path reaches the new gate."""
+    from pawai_cli import main as cli_main
+    from pawai_cli.lock import Lock
+
+    new_lock = Lock(user="bob", host="bob-mac", branch="main", sha="b",
+                    state="starting",
+                    start_time=datetime.now(timezone.utc).isoformat())
+
+    monkeypatch.setenv("USER", "bob")
+    monkeypatch.setattr("pawai_cli.lock.Lock.read", staticmethod(lambda: None))
+    monkeypatch.setattr("pawai_cli.status.collect_go2_drivers", lambda: [])
+    monkeypatch.setattr("pawai_cli.lock.Lock.acquire",
+                        staticmethod(lambda **kw: new_lock))
+    monkeypatch.setattr(cli_main, "_invoke_start_sh", lambda **kw: 0)
+    monkeypatch.setattr(cli_main, "_run_lane_healthcheck", lambda lane: hc_rc)
+    # transition_if_owned is a method on the lock instance; patch the class method
+    monkeypatch.setattr("pawai_cli.lock.Lock.transition_if_owned",
+                        lambda self, state, **kw: True)
+    return new_lock
+
+
+def test_demo_start_blocks_running_on_healthcheck_fail(monkeypatch):
+    """If healthcheck returns non-zero, demo_start must exit non-zero and must
+    NOT call transition_if_owned — lock stays in 'starting' as evidence."""
+    from pawai_cli import main as cli_main
+
+    transition_calls: list = []
+
+    def _fake_transition(self, state, **kw):
+        transition_calls.append(state)
+        return True
+
+    _patch_demo_start_happy(monkeypatch, hc_rc=1)
+    monkeypatch.setattr("pawai_cli.lock.Lock.transition_if_owned", _fake_transition)
+
+    result = CliRunner().invoke(cli_main.cli, ["demo", "start"])
+
+    assert result.exit_code != 0, result.output
+    assert transition_calls == [], \
+        "lock must stay in 'starting' — transition_if_owned must not be called"
+    assert "healthcheck FAILED" in result.output, \
+        f"Expected 'healthcheck FAILED' in output, got:\n{result.output}"
+
+
+def test_demo_start_transitions_running_on_healthcheck_pass(monkeypatch):
+    """If healthcheck returns 0, demo_start must succeed and call
+    transition_if_owned exactly once to mark lock as 'running'."""
+    from pawai_cli import main as cli_main
+
+    transition_calls: list = []
+
+    def _fake_transition(self, state, **kw):
+        transition_calls.append(state)
+        return True
+
+    _patch_demo_start_happy(monkeypatch, hc_rc=0)
+    monkeypatch.setattr("pawai_cli.lock.Lock.transition_if_owned", _fake_transition)
+
+    result = CliRunner().invoke(cli_main.cli, ["demo", "start"])
+
+    assert result.exit_code == 0, result.output
+    assert len(transition_calls) == 1, \
+        f"Expected exactly one transition_if_owned call, got {transition_calls}"
+
+
+def test_demo_start_skip_healthcheck_prints_loud_banner(monkeypatch):
+    """--skip-healthcheck must bypass the gate and print a loud warning banner;
+    even if healthcheck would fail, demo must succeed and transition lock."""
+    from pawai_cli import main as cli_main
+
+    transition_calls: list = []
+
+    def _fake_transition(self, state, **kw):
+        transition_calls.append(state)
+        return True
+
+    # hc_rc=1 would normally block — but --skip-healthcheck must override
+    _patch_demo_start_happy(monkeypatch, hc_rc=1)
+    monkeypatch.setattr("pawai_cli.lock.Lock.transition_if_owned", _fake_transition)
+
+    result = CliRunner().invoke(cli_main.cli, ["demo", "start", "--skip-healthcheck"])
+
+    assert result.exit_code == 0, result.output
+    assert "HEALTHCHECK SKIPPED" in result.output, \
+        f"Expected 'HEALTHCHECK SKIPPED' in output, got:\n{result.output}"
+    assert len(transition_calls) == 1, \
+        f"Expected lock to be transitioned to running, got {transition_calls}"

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -4,7 +4,10 @@ import platform
 from click.testing import CliRunner
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 
+import click
+import pytest
 from unittest.mock import patch
 
 from pawai_cli.main import _install_hint_map, _ssh_config_has_host, cli
@@ -782,8 +785,8 @@ def test_deploy_prompts_on_active_other_lock(monkeypatch):
     assert "alice" in result.output.lower()
 
 
-def test_jetson_deploy_rsync_excludes_env_and_ssh(tmp_path):
-    """rsync invocation must include repo-relative excludes for secrets."""
+def test_jetson_deploy_rsync_excludes_env_and_ssh(tmp_path, monkeypatch):
+    """rsync invocation must use --exclude-from= pointing at the contract file."""
     from pawai_cli import main as cli_main
     from pawai_cli.shell import Result
 
@@ -793,10 +796,14 @@ def test_jetson_deploy_rsync_excludes_env_and_ssh(tmp_path):
         captured_argv.append(list(argv))
         return 0
 
+    monkeypatch.delenv("PAWAI_SYNC_CMD", raising=False)
+
     with patch("pawai_cli.main.shell.stream", side_effect=fake_stream), \
          patch("pawai_cli.main.shell.run_remote", return_value=Result(0, "", "")), \
          patch("pawai_cli.main.shell.jetson_host", return_value="jetson"), \
          patch("pawai_cli.main.shell.jetson_repo", return_value="/home/jetson/elder_and_dog"), \
+         patch("pawai_cli.main._post_sync_guard", return_value=None), \
+         patch("pawai_cli.main._snapshot_protected", return_value={}), \
          patch("pathlib.Path.home", return_value=tmp_path):
         code, method = cli_main._do_rsync_and_build(
             root=Path("/tmp/repo"),
@@ -810,15 +817,8 @@ def test_jetson_deploy_rsync_excludes_env_and_ssh(tmp_path):
     assert method == "rsync"
     rsync_argv = next((a for a in captured_argv if a and a[0] == "rsync"), None)
     assert rsync_argv is not None, f"no rsync invocation seen: {captured_argv}"
-    excludes = [arg for arg in rsync_argv if arg.startswith("--exclude=")]
-    required = {
-        "--exclude=.env",
-        "--exclude=.env.*",
-        "--exclude=.env.local",
-        "--exclude=.ssh/",
-    }
-    missing = required - set(excludes)
-    assert not missing, f"missing rsync excludes: {missing}"
+    exclude_from_args = [arg for arg in rsync_argv if arg.startswith("--exclude-from=")]
+    assert exclude_from_args, f"expected --exclude-from= arg in rsync call: {rsync_argv}"
 
 
 EXCLUDES_FILE = Path(__file__).resolve().parents[3] / "tools" / "sync" / "rsync-excludes.txt"
@@ -1433,3 +1433,66 @@ def test_face_enroll_requires_name():
     # 缺 --person-name 應報錯（exit != 0）
     res = CliRunner().invoke(cli, ["face", "enroll"])
     assert res.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Plan B2 — 6/10 .env-deletion regression tests
+# ---------------------------------------------------------------------------
+
+def test_deploy_prefers_builtin_rsync_even_when_home_sync_exists(tmp_path, monkeypatch):
+    """6/10 incident regression: ~/sync exists+executable → MUST still use rsync."""
+    from pawai_cli import main as cli_main
+
+    sync = tmp_path / "sync"
+    sync.write_text("#!/bin/sh\nexit 0\n")
+    sync.chmod(0o755)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("PAWAI_SYNC_CMD", raising=False)
+
+    calls = []
+    monkeypatch.setattr(cli_main.shell, "stream", lambda argv, **kw: calls.append(list(argv)) or 0)
+    monkeypatch.setattr(cli_main.shell, "stream_remote", lambda cmd, **kw: 0)
+    monkeypatch.setattr(cli_main, "_post_sync_guard", lambda pre: None)
+    monkeypatch.setattr(cli_main, "_snapshot_protected", lambda: {})
+
+    code, method = cli_main._do_rsync_and_build(
+        root=Path("/repo"), packages=[], no_sync=False, no_build=True, module_key="x"
+    )
+    assert method == "rsync"
+    assert calls and calls[0][0] == "rsync"
+    assert any(str(a).startswith("--exclude-from=") for a in calls[0])
+
+
+def test_deploy_opt_in_external_sync_requires_env(tmp_path, monkeypatch):
+    """PAWAI_SYNC_CMD=1 + ~/sync exists → use external sync."""
+    from pawai_cli import main as cli_main
+
+    sync = tmp_path / "sync"
+    sync.write_text("#!/bin/sh\nexit 0\n")
+    sync.chmod(0o755)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("PAWAI_SYNC_CMD", "1")
+
+    calls = []
+    monkeypatch.setattr(cli_main.shell, "stream", lambda argv, **kw: calls.append(list(argv)) or 0)
+    monkeypatch.setattr(cli_main, "_post_sync_guard", lambda pre: None)
+    monkeypatch.setattr(cli_main, "_snapshot_protected", lambda: {})
+
+    code, method = cli_main._do_rsync_and_build(
+        root=Path("/repo"), packages=[], no_sync=False, no_build=True, module_key="x"
+    )
+    assert method == "sync-once"
+
+
+def test_post_sync_guard_fails_loud_when_env_disappears(monkeypatch):
+    """Guard must raise ClickException when a previously-present file is gone."""
+    from pawai_cli import main as cli_main
+
+    monkeypatch.setattr(
+        cli_main.shell,
+        "run_remote",
+        lambda cmd, **kw: SimpleNamespace(ok=True, stdout="MISSING\n", stderr="", code=0),
+    )
+    with pytest.raises(click.ClickException) as exc:
+        cli_main._post_sync_guard({"~/elder_and_dog/.env": True})
+    assert ".env" in str(exc.value)

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -1346,71 +1346,34 @@ def test_load_env_missing_file_is_silent(tmp_path):
     _load_env_file(tmp_path / "does-not-exist.env", override=False)
 
 
-# ─── 學校招生 demo: pawai demo school subgroup ─────────────────────────
+# ─── 學校招生 demo（已退役，Plan B6）────────────────────────────────────
+
+SCHOOL_SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "school_demo_ending.py"
 
 
-def test_school_list_prints_ending_and_cues() -> None:
-    """`pawai demo school list` 必須印結尾固定詞與三段 brain cue 提示。"""
-    from pawai_cli.main import SCHOOL_DEMO_ENDING_TEXT
-    result = CliRunner().invoke(cli, ["demo", "school", "list"])
-    assert result.exit_code == 0, result.output
-    assert SCHOOL_DEMO_ENDING_TEXT in result.output
-    assert "輔大資管系的特色" in result.output
-    assert "介紹一下你自己" in result.output
+def test_demo_school_retired() -> None:
+    """`pawai demo school` 已退役：必須報錯並指向保留的腳本。"""
+    result = CliRunner().invoke(cli, ["demo", "school"])
+    assert result.exit_code != 0
+    assert "retired" in result.output
+    assert "scripts/school_demo_ending.py" in result.output
 
 
-def test_school_ending_dry_run_does_not_invoke_remote() -> None:
-    """`--dry-run` 必須印出 python publisher 整段且 0 次 SSH。"""
-    from pawai_cli.main import SCHOOL_DEMO_ENDING_TEXT
-    with patch.object(shell, "run_remote") as mock_remote:
-        result = CliRunner().invoke(cli, ["demo", "school", "ending", "--dry-run"])
-    assert result.exit_code == 0, result.output
-    assert mock_remote.call_count == 0
-    assert "python3 -c" in result.output
-    assert "/tts" in result.output
-    assert SCHOOL_DEMO_ENDING_TEXT in result.output
-
-
-def test_school_ending_invokes_remote_with_correct_command() -> None:
-    """無 dry-run 時必須呼叫 shell.run_remote 一次，且 command 含關鍵片段。"""
-    from pawai_cli.main import SCHOOL_DEMO_ENDING_TEXT
-    fake_result = shell.Result(code=0, stdout="", stderr="")
-    with patch.object(shell, "run_remote", return_value=fake_result) as mock_remote:
-        result = CliRunner().invoke(cli, ["demo", "school", "ending"])
-    assert result.exit_code == 0, result.output
-    assert mock_remote.call_count == 1
-    sent_cmd = mock_remote.call_args.args[0]
-    assert "setup.zsh" in sent_cmd
-    assert "setup.bash" not in sent_cmd
-    assert "/tts" in sent_cmd
-    assert SCHOOL_DEMO_ENDING_TEXT in sent_cmd
-    assert shell.jetson_repo() in sent_cmd
-    # Inline python rclpy publisher — NOT a one-shot `ros2 topic pub`. A
-    # one-shot pub tears down before DDS flushes the wire; the python path
-    # waits for discovery then spins to guarantee delivery.
-    assert "python3 -c" in sent_cmd
-    assert "ros2 topic pub" not in sent_cmd
-    # Load-bearing robustness markers: discovery wait + post-publish flush.
-    assert "get_subscription_count" in sent_cmd
-    assert "no /tts subscriber discovered" in sent_cmd
-    assert "sys.exit(20)" in sent_cmd
-    assert "time.time() + 15.0" in sent_cmd
-
-
-def test_school_ending_includes_finger_heart_action() -> None:
-    """ending 必須先 publish FingerHeart (api_id 1036) 到 /webrtc_req。"""
-    from pawai_cli.main import FINGER_HEART_API_ID
-    fake_result = shell.Result(code=0, stdout="", stderr="")
-    with patch.object(shell, "run_remote", return_value=fake_result) as mock_remote:
-        result = CliRunner().invoke(cli, ["demo", "school", "ending"])
-    assert result.exit_code == 0, result.output
-    sent_cmd = mock_remote.call_args.args[0]
-    assert FINGER_HEART_API_ID == 1036
-    assert "WebRtcReq" in sent_cmd
-    assert "/webrtc_req" in sent_cmd
-    assert "api_id=1036" in sent_cmd
-    # FingerHeart must precede the /tts line so the action and speech overlap.
-    assert sent_cmd.index("/webrtc_req") < sent_cmd.index("/tts")
+def test_school_ending_script_preserves_dds_pattern() -> None:
+    """Extracted script keeps the wait-for-subscriber-then-publish pattern —
+    the real DDS one-shot-pub race fix is the artifact B6 exists to preserve."""
+    import ast
+    body = SCHOOL_SCRIPT.read_text()
+    ast.parse(body)  # must parse without rclpy installed
+    # Load-bearing robustness markers (migrated from the retired CLI tests):
+    assert "get_subscription_count" in body
+    assert "time.time() + 15.0" in body            # discovery wait window
+    assert "time.time() + 1.5" in body             # post-publish flush spin
+    assert "no /tts subscriber discovered" in body
+    assert "FINGER_HEART_API_ID = 1036" in body
+    assert "/webrtc_req" in body and "/tts" in body
+    # FingerHeart must precede the /tts publish so action and speech overlap.
+    assert body.index("heart.publish") < body.index("tts.publish(msg)")
 
 
 def test_load_env_local_overrides_env(tmp_path, monkeypatch):

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -600,7 +600,8 @@ def test_status_shows_lock_state(monkeypatch):
               start_time=datetime.now(timezone.utc).isoformat())
     with patch("pawai_cli.status.collect", return_value=_reachable_live_status()), \
          patch("pawai_cli.status.Lock.read", return_value=lk), \
-         patch("pawai_cli.status.collect_go2_drivers", return_value=[]):
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
+         patch("pawai_cli.status.gateway_health", return_value="down / not started"):
         runner = CliRunner()
         result = runner.invoke(cli, ["status"])
     assert "alice" in result.output.lower()
@@ -643,7 +644,8 @@ def test_status_shows_branch_mismatch(monkeypatch, tmp_path):
     with patch("pawai_cli.status.collect", return_value=_reachable_live_status()), \
          patch("pawai_cli.status._read_last_deploy_remote", return_value=last_deploy), \
          patch("pawai_cli.status._current_branch", return_value="feat/new"), \
-         patch("pawai_cli.status.collect_go2_drivers", return_value=[]):
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
+         patch("pawai_cli.status.gateway_health", return_value="down / not started"):
         runner = CliRunner()
         result = runner.invoke(cli, ["status"])
     assert "mismatch" in result.output.lower() or "feat/old" in result.output
@@ -657,7 +659,8 @@ def test_status_shows_stale_running_warning(monkeypatch):
               state="running", start_time=old)
     with patch("pawai_cli.status.collect", return_value=_reachable_live_status()), \
          patch("pawai_cli.status.Lock.read", return_value=lk), \
-         patch("pawai_cli.status.collect_go2_drivers", return_value=[]):
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
+         patch("pawai_cli.status.gateway_health", return_value="down / not started"):
         runner = CliRunner()
         result = runner.invoke(cli, ["status"])
     assert "stale" in result.output.lower()
@@ -703,7 +706,8 @@ def test_status_warns_when_driver_running_without_lock():
     )]
     with patch("pawai_cli.status.collect", return_value=_reachable_live_status()), \
          patch("pawai_cli.status.Lock.read", return_value=None), \
-         patch("pawai_cli.status.collect_go2_drivers", return_value=procs):
+         patch("pawai_cli.status.collect_go2_drivers", return_value=procs), \
+         patch("pawai_cli.status.gateway_health", return_value="down / not started"):
         result = CliRunner().invoke(cli, ["status"])
     assert "pid=12345" in result.output
     assert "kirk7" in result.output
@@ -726,7 +730,8 @@ def test_status_does_not_warn_on_user_mismatch_when_lock_present():
     )]
     with patch("pawai_cli.status.collect", return_value=_reachable_live_status()), \
          patch("pawai_cli.status.Lock.read", return_value=lk), \
-         patch("pawai_cli.status.collect_go2_drivers", return_value=procs):
+         patch("pawai_cli.status.collect_go2_drivers", return_value=procs), \
+         patch("pawai_cli.status.gateway_health", return_value="down / not started"):
         result = CliRunner().invoke(cli, ["status"])
     # Driver is listed but no mismatch warning is emitted.
     assert "pid=12345" in result.output
@@ -1605,3 +1610,18 @@ def test_demo_start_skip_healthcheck_prints_loud_banner(monkeypatch):
         f"Expected 'HEALTHCHECK SKIPPED' in output, got:\n{result.output}"
     assert len(transition_calls) == 1, \
         f"Expected lock to be transitioned to running, got {transition_calls}"
+
+
+# ─── Plan B5: status module presence + health nav ─────────────────────────
+
+def test_module_presence_maps_nodes():
+    from pawai_cli import status as st_mod
+    nodes = "/face_identity_node\n/brain_node\n/go2_driver_node"
+    got = dict(st_mod.module_presence(nodes))
+    assert got["face"] and got["brain"] and got["go2_driver"]
+    assert not got["object"]
+
+
+def test_health_nav_command_registered():
+    result = CliRunner().invoke(cli, ["health", "nav", "--help"])
+    assert result.exit_code == 0

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -1496,3 +1496,10 @@ def test_post_sync_guard_fails_loud_when_env_disappears(monkeypatch):
     with pytest.raises(click.ClickException) as exc:
         cli_main._post_sync_guard({"~/elder_and_dog/.env": True})
     assert ".env" in str(exc.value)
+
+
+def test_sync_script_uses_shared_exclude_contract():
+    script = Path(__file__).resolve().parents[3] / "scripts" / "sync_to_jetson.sh"
+    body = script.read_text()
+    assert "--exclude-from=" in body and "tools/sync/rsync-excludes.txt" in body
+    assert "--delete" in body

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -821,6 +821,21 @@ def test_jetson_deploy_rsync_excludes_env_and_ssh(tmp_path):
     assert not missing, f"missing rsync excludes: {missing}"
 
 
+EXCLUDES_FILE = Path(__file__).resolve().parents[3] / "tools" / "sync" / "rsync-excludes.txt"
+
+
+def test_rsync_excludes_file_has_protected_entries():
+    lines = {
+        ln.strip() for ln in EXCLUDES_FILE.read_text().splitlines()
+        if ln.strip() and not ln.startswith("#")
+    }
+    for required in (".git/", ".env", ".env.*", ".env.local", ".ssh/",
+                     "build/", "install/", "log/", "__pycache__/",
+                     ".pytest_cache/", ".venv/", "node_modules/", ".next/",
+                     ".ruff_cache/", ".mypy_cache/", ".DS_Store"):
+        assert required in lines, f"protected exclude missing: {required}"
+
+
 def test_invoke_start_sh_injects_jetson_tailscale_ip(monkeypatch):
     """demo start wrapper should pass JETSON_TAILSCALE_IP to start.sh env."""
     from pawai_cli import main as cli_main

--- a/tools/sync/rsync-excludes.txt
+++ b/tools/sync/rsync-excludes.txt
@@ -1,0 +1,19 @@
+# Single source of truth for WSL→Jetson sync excludes.
+# Consumers: pawai jetson deploy (_do_rsync_and_build) + scripts/sync_to_jetson.sh.
+# 2026-06-10 Plan B1 — born from the 6/10 incident where ~/sync deleted Jetson .env.
+.git/
+.env
+.env.*
+.env.local
+.ssh/
+build/
+install/
+log/
+__pycache__/
+.pytest_cache/
+.venv/
+node_modules/
+.next/
+.ruff_cache/
+.mypy_cache/
+.DS_Store


### PR DESCRIPTION
## Plan B — CLI v2 First Slice（操作安全）

Per `docs/superpowers/plans/2026-06-10-plan-b-cli-v2-first-slice.md`，8 commits（B1-B7 + B4 獨立例外）。三個目標全達成，**零 Typer 遷移、lock.py byte-identical、不碰 contracts/router/trace**。

### 變更內容

| Commit | Task | 內容 |
|---|---|---|
| `33ce187` | B1 | `tools/sync/rsync-excludes.txt` 單一 exclude 真相源（16 條保命條目，測試把守） |
| `f90e018` | B2 | **deploy 優先序反轉**：內建 audited rsync 永遠預設、`~/sync` 降 opt-in（`PAWAI_SYNC_CMD=1` + UNAUDITED 警告）+ **post-sync protected-file guard**（`.env`/`.env.local` 消失即 fail-loud + 還原 SOP；**失敗路徑也跑 guard** — review 強化，6/10「爛腳本刪檔又非零退出」情境不漏報） |
| `ba6f969` | B3 | `scripts/sync_to_jetson.sh` 手動 rsync 正式化（共用 exclude 契約） |
| `7f8733a` | B4 | **demo start healthcheck hard-gate**：start.sh rc==0 不算成功（6/4 CRLF 假成功事故），lane healthcheck pass 才轉 `running`；fail → lock 留 `starting` 當證據 + 指引；`--skip-healthcheck` 逃生口（大字警告）。兩條 lane（brain/nav_capability）同閘 |
| `cf491e8` | B4-4 | healthcheck.sh fallback IP 改 `:?` fail-hard（**全重構唯一 `.claude/skills/` 變更**，plan 明文授權例外） |
| `e0026b4` | B5 | `pawai status` 加 9 模組 node presence 對照 + gateway `/health` probe（只在 reachable + 非 short 模式，bounded 3s/8s）；新 `pawai health nav` |
| `5f4d84e` | B6 | `demo school` 退役為 deprecation stub；DDS wait-for-subscriber-then-publish pattern 完整保留至 `scripts/school_demo_ending.py`（語意保真終審逐項核對） |
| `bde5b87` | B7 | 三份 docs 同步（§2.5 guarantee 改寫、§7 錯誤表 +3 條、README sync 邏輯/指令表/gate 行為、F3 opt-in 化） |

### 測試 / Review

- 全套 `tools/pawai_cli/tests`：**151 passed**（144 → 151，+7 新測試）+ 1 個 **pre-existing** 失敗
- ⚠️ **本地跑全套注意**：`test_health_brain_passes_jetson_host_env` 在任何有 `.env.local` 的機器上必紅 — 終審用 worktree 雙向驗證確認 **base `203dc5c` 同樣紅**，非本分支造成（根因 = CLI callback `override=True` 載入 `.env.local` 蓋掉測試 monkeypatch，issue #150 處理中）。CI runner 無 `.env.local` 不受影響。
- Review：B2/B4 各做深度 per-task spec review（B2 抓到失敗路徑 guard 缺口已補、B4 抓到 1 個漏 mock 測試已補），全分支 Linus 終審 **APPROVE**（forbidden-scope audit 全過、文件逐字核對程式碼字串）。
- flake8：兩檔合計 30 = baseline 持平，零新增條目。

### HITL gate（merge 後第一次上機必做，未做前不宣稱）

1. `pawai jetson deploy --module brain` 對真 Jetson：post-sync 驗 `.env`/`.env.local` 存活 + `.pawai-last-deploy` 正確
2. `pawai demo start` 正常路徑：healthcheck pass → running
3. 故意弄壞 `.env`（CRLF）→ `demo start` 必須 fail、lock 留 starting → 還原。重現 6/4 事故場景被擋下

### Rollback

單 PR revert 即回 v1 行為；`PAWAI_SYNC_CMD=1` 與 `--skip-healthcheck` 是不需改 code 的降級路徑。

### Follow-ups（不在本 PR）
- issue #150（CLI 測試 env 隔離）已涵蓋本地紅燈根因
- `brain-studio-lane/SKILL.md:43` 裸跑 healthcheck 指引需配合 fail-hard 更新（`.claude/skills/` 非本 plan 授權範圍）
- `demo_start` C901 複雜度 21→23（Typer 第二刀時拆）

🤖 Generated with [Claude Code](https://claude.com/claude-code)