### PR TITLE
Brain Trace v1 — decision-chain /brain/trace, additive-only (Plan E)

### DIFF
--- a/docs/contracts/interaction_contract.md
+++ b/docs/contracts/interaction_contract.md
@@ -91,6 +91,7 @@
 | `/brain/conversation_trace` | Event | 觸發式 | Brain → Debug/Studio LLM proposal gate trace（skill_gate stage 完整 enum 見 §`/brain/conversation_trace` 章節，5/8 加 `needs_confirm` / `demo_guide`） | **v2.8** active |
 | `/brain/reset_context` | Command | 觸發式 | Studio → Brain context 重置（std_msgs/Empty）— `conversation_graph_node` 清 `_memory + _seen_sessions`；`brain_node` cancel `_pending_confirm` + 清 object_remark dedup + 結束上一段 active plan（v2.11）；**不清** `_state.attention` | **v2.10** active |
 | `/brain/gesture_enabled` | Command | 觸發式 | Studio → Brain 手勢總開關（std_msgs/Bool）— demo 錄影分段控制，關閉時 cancel in-flight PendingConfirm | **v2.11** active |
+| `/brain/trace` | Event | 觸發式 | Brain/Executive → Studio 決策鏈 trace（String JSON，schema = `pawai_contracts/pawai_contracts/trace_schema.py`）— `decision_id` 串 perception event → gate verdict（suppressed/blocked）→ plan_emitted → skill_result，回答「為什麼做/不做」。與 `/brain/conversation_trace`（LLM 對話 trace）用途不同。發布者 `brain_node` + `interaction_executive_node`，QoS RELIABLE depth 10；落盤/呈現屬 Studio Evidence Center（後續 plan） | **v2.12** active |
 | `/tts` | Command | 觸發式 | TTS 輸入文字（v2.10：envelope 加 `source` 欄位 — chat_reply / say_canned / skill_say；純文字 backward compat） | active |
 | `/webrtc_req` | Command | 觸發式 | Go2 WebRTC 命令 | active |
 

--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -200,6 +200,7 @@ class BrainNode(Node):
         self._pub_trace = self.create_publisher(String, "/brain/trace", _RELIABLE_10)
         self._plan_decision: dict[str, str] = {}   # plan_id → decision_id (GC in _gc_dedup)
         self._current_decision_id: str = ""
+        self._trace_throttle: dict[str, float] = {}   # hot-gate trace rate limit
         self._pub_brain_state = self.create_publisher(
             String, "/state/pawai_brain", _TRANSIENT_LOCAL_1
         )
@@ -315,6 +316,8 @@ class BrainNode(Node):
             f"[phase] {kind} proposal suppressed (demo_phase={self.demo_phase})",
             throttle_duration_sec=5.0,
         )
+        self._suppressed(gate="demo_phase", reason=f"phase:{self.demo_phase}:{kind}",
+                         throttle_key=f"phase:{kind}")
         return False
 
     def _set_gesture_enabled(self, enabled: bool, via: str) -> None:
@@ -518,12 +521,18 @@ class BrainNode(Node):
             self.get_logger().debug(f"trace publish failed: {exc}")
 
     def _suppressed(self, *, gate: str, reason: str, source_summary: str = "",
-                    cooldown_remaining_s: float | None = None) -> None:
+                    cooldown_remaining_s: float | None = None,
+                    throttle_key: str | None = None, throttle_s: float = 5.0) -> None:
         """Emit a suppressed-verdict trace for a gate early-return (Plan E3).
 
         Reads shared state for the Roy-required context fields; never raises
         (the underlying _trace swallows publish errors, and the state reads are
         guarded here)."""
+        if throttle_key is not None:
+            now = time.time()
+            if now - self._trace_throttle.get(throttle_key, 0.0) < throttle_s:
+                return
+            self._trace_throttle[throttle_key] = now
         try:
             with self._lock:
                 active = self._state.active_plan or {}
@@ -595,10 +604,14 @@ class BrainNode(Node):
         bucket = int(now / max(self.dedup_window_s, 0.001))
         cache_key = (source, key, bucket)
         with self._lock:
-            if cache_key in self._state.dedup_cache:
-                return True
-            self._state.dedup_cache[cache_key] = now
-            return False
+            hit = cache_key in self._state.dedup_cache
+            if not hit:
+                self._state.dedup_cache[cache_key] = now
+        if hit:
+            self._suppressed(gate="dedup", reason=f"dedup:{source}:{key}",
+                             throttle_key=f"dedup:{source}:{key}")
+            return True
+        return False
 
     def _gc_dedup(self) -> None:
         cutoff = time.time() - 5.0
@@ -774,6 +787,8 @@ class BrainNode(Node):
             proposed_args = {}
 
         if proposed_skill not in self.LLM_PROPOSABLE_SKILLS:
+            self._suppressed(gate="llm_allowlist", reason=f"skill:{proposed_skill}",
+                             source_summary=f"session={session_id}")
             self._emit_trace(
                 session_id=session_id,
                 engine=engine,
@@ -785,6 +800,8 @@ class BrainNode(Node):
 
         reason = self._capability_health_block(proposed_skill)
         if reason:
+            self._suppressed(gate="capability_health", reason=str(reason),
+                             source_summary=f"skill:{proposed_skill}")
             self._emit_trace(
                 session_id=session_id,
                 engine=engine,
@@ -796,6 +813,10 @@ class BrainNode(Node):
 
         cd = SKILL_REGISTRY[proposed_skill].cooldown_s
         if self._in_cooldown(proposed_skill, cd):
+            self._suppressed(
+                gate="skill_cooldown", reason=f"{proposed_skill}:cooldown",
+                source_summary=f"skill:{proposed_skill}",
+                cooldown_remaining_s=self._cooldown_remaining(proposed_skill, cd))
             self._emit_trace(
                 session_id=session_id,
                 engine=engine,
@@ -904,8 +925,11 @@ class BrainNode(Node):
         if not gesture:
             return
 
-        # 2026-06-09 demo: runtime gate — 操作員關閉時手勢完全不發 plan（連 trace 也不發）。
+        # 2026-06-09 demo: runtime gate — 操作員關閉時手勢完全不發 plan。
+        # (Plan E: /brain/trace 的 suppressed 仍發 — 它就是回答「為什麼沒反應」的通道。)
         if not self.gesture_enabled:
+            self._suppressed(gate="gesture_enabled", reason="gesture_enabled=false",
+                             source_summary=f"gesture={gesture}")
             return
         # 2026-06-10 demo phase gate（all=不擋）
         if not self._phase_allows("gesture"):
@@ -922,9 +946,13 @@ class BrainNode(Node):
         # If a confirm is already in flight, gestures only feed the state machine
         # via the periodic tick — don't fire new skills.
         if self._pending_confirm.state == ConfirmState.PENDING:
+            self._suppressed(gate="pending_confirm", reason="confirm_in_flight",
+                             source_summary=f"gesture={gesture}")
             return
 
         if self._has_active_skill_or_sequence():
+            self._suppressed(gate="active_plan", reason="skill_or_sequence_active",
+                             source_summary=f"gesture={gesture}")
             return
         if self._check_dedup("gesture", gesture):
             return
@@ -954,6 +982,9 @@ class BrainNode(Node):
                 self.get_logger().info(
                     f"[gate] gesture={gesture} suppressed ({reason_str})"
                 )
+                self._suppressed(gate="conversation_gate",
+                                 reason=f"conversation_gate:{reason_str}",
+                                 source_summary=f"gesture={gesture}")
                 self._emit_trace(
                     session_id=f"gesture-{int(time.time())}",
                     engine="brain_node",
@@ -1160,6 +1191,11 @@ class BrainNode(Node):
         contract = SKILL_REGISTRY[skill]
         cd = contract.cooldown_s
         if cd > 0 and self._in_cooldown(skill, cd):
+            remaining = self._cooldown_remaining(skill, cd)
+            self._suppressed(
+                gate="skill_cooldown", reason=f"cooldown:{skill}:{remaining:.1f}s",
+                source_summary=f"skill:{skill}", cooldown_remaining_s=remaining,
+                throttle_key=f"skill_cd:{skill}")
             return False
         try:
             plan = build_plan(
@@ -1263,6 +1299,11 @@ class BrainNode(Node):
                 # 2026-06-10 demo: stranger_alert_enabled=False 時擋發射不擋累積
                 # （6/9 HITL：face 幻覺餵爆 unknown → active plan 霸佔 brain，
                 # cup/greet 全黑的根因）。runtime param set 開回時立即恢復。
+                if not self.stranger_alert_enabled:
+                    self._suppressed(gate="stranger_alert_enabled",
+                                     reason="stranger_alert_enabled=false",
+                                     source_summary=f"identity={identity}",
+                                     throttle_key="stranger_alert_enabled")
                 if (
                     self.stranger_alert_enabled
                     and not self._in_cooldown("stranger_alert", 30.0)
@@ -1291,6 +1332,18 @@ class BrainNode(Node):
                 or self._pending_confirm.state == ConfirmState.PENDING \
                 or self._world.snapshot().tts_playing:
             # 5/9 review: also block during TTS to avoid mid-sentence interrupt.
+            parts = []
+            if not stable:
+                parts.append("not_stable")
+            if self._has_active_skill_or_sequence():
+                parts.append("active_plan")
+            if self._pending_confirm.state == ConfirmState.PENDING:
+                parts.append("pending_confirm")
+            if self._world.snapshot().tts_playing:
+                parts.append("tts_playing")
+            self._suppressed(gate="greet_gate", reason=",".join(parts) or "greet_gate",
+                             source_summary=f"identity={identity}",
+                             throttle_key=f"greet_gate:{identity}")
             return
         # 2026-06-08 VIS-4 (Roy): drop the ENGAGED distance/dwell gate. D435 depth at
         # ~1.5-2m is too noisy — a distance threshold forced the user to hold an exact
@@ -1300,11 +1353,21 @@ class BrainNode(Node):
         if self.greet_require_sitting:
             last_sit = self._state.last_sitting_seen_ts
             if last_sit <= 0.0 or (time.time() - last_sit) > self.greet_sitting_window_s:
+                self._suppressed(gate="greet_sitting_window",
+                                 reason=f"sitting_window:{self.greet_sitting_window_s}s",
+                                 source_summary=f"identity={identity}",
+                                 throttle_key=f"greet_sitting:{identity}")
                 return  # not currently sitting → don't greet
         # known face stable (+ sitting) is real engagement → reset idle clock
         self._touch_user_interaction()
         cooldown_key = f"greet_known_person:{identity}"
         if self._in_cooldown(cooldown_key, self.greet_cooldown_s):
+            self._suppressed(
+                gate="greet_cooldown", reason=f"cooldown:greet:{identity}",
+                source_summary=f"identity={identity}",
+                cooldown_remaining_s=self._cooldown_remaining(
+                    cooldown_key, self.greet_cooldown_s),
+                throttle_key=f"greet_cooldown:{identity}")
             return
         self._mark_cooldown(cooldown_key)
         self._emit(
@@ -1458,12 +1521,24 @@ class BrainNode(Node):
         # 3rd race-condition hole alongside stranger_alert / greet_known_person
         # which already use _attention_state_snapshot(). Fix: same helper.
         if self._attention_state_snapshot() != AttentionState.ENGAGED:
+            self._suppressed(gate="attention_engaged",
+                             reason=f"attention:{self._attention_state_snapshot().name}",
+                             source_summary=f"class={class_name}",
+                             throttle_key=f"obj_engaged:{class_name}")
             return  # IDLE / NOTICED / INTERACTING — stay quiet
         if self._has_active_skill_or_sequence():
+            self._suppressed(gate="active_plan", reason="skill_or_sequence_active",
+                             source_summary=f"class={class_name}",
+                             throttle_key=f"obj_active:{class_name}")
             return
         if self._pending_confirm.state == ConfirmState.PENDING:
+            self._suppressed(gate="pending_confirm", reason="confirm_in_flight",
+                             source_summary=f"class={class_name}")
             return
         if snap.tts_playing:
+            self._suppressed(gate="tts_playing", reason="tts_playing",
+                             source_summary=f"class={class_name}",
+                             throttle_key=f"obj_tts:{class_name}")
             return  # Don't insert object remark while PAI is speaking
 
         # 2026-05-23 5/27 demo video mode: cup + Roy + recent sitting → 複合句
@@ -1510,6 +1585,12 @@ class BrainNode(Node):
         seen_key = (class_name,)
         last = self._object_remark_seen.get(seen_key, 0.0)
         if now - last < OBJECT_REMARK_DEDUP_S:
+            self._suppressed(
+                gate="object_remark_dedup",
+                reason=f"remark_dedup:{class_name}",
+                source_summary=f"class={class_name}",
+                cooldown_remaining_s=max(0.0, OBJECT_REMARK_DEDUP_S - (now - last)),
+                throttle_key=f"obj_dedup:{class_name}")
             return
         self._object_remark_seen[seen_key] = now
 
@@ -1654,21 +1735,28 @@ class BrainNode(Node):
                     break
 
         # Plan E: skill_result trace on terminal/blocked statuses (additive).
-        if status in (
-            SkillResultStatus.COMPLETED.value,
-            SkillResultStatus.ABORTED.value,
-            SkillResultStatus.BLOCKED_BY_SAFETY.value,
-            SkillResultStatus.STEP_FAILED.value,
-        ):
-            blocked = status == SkillResultStatus.BLOCKED_BY_SAFETY.value
-            self._trace(TraceEvent(
-                decision_id=self._plan_decision.get(str(plan_id), ""),
-                node="brain_node", kind=TraceKind.SKILL_RESULT,
-                verdict=Verdict.BLOCKED if blocked else Verdict.ACCEPTED,
-                gate="safety" if blocked else "",
-                reason=str(payload.get("reason") or status), plan_id=str(plan_id or ""),
-                detail={"status": status},
-            ))
+        self._trace_skill_result(status, plan_id, payload)
+
+    _TERMINAL_RESULT_STATUSES = frozenset({
+        SkillResultStatus.COMPLETED.value,
+        SkillResultStatus.ABORTED.value,
+        SkillResultStatus.BLOCKED_BY_SAFETY.value,
+        SkillResultStatus.STEP_FAILED.value,
+    })
+
+    def _trace_skill_result(self, status, plan_id, payload: dict[str, Any]) -> None:
+        """Plan E: emit a skill_result trace for terminal/blocked statuses."""
+        if status not in self._TERMINAL_RESULT_STATUSES:
+            return
+        blocked = status == SkillResultStatus.BLOCKED_BY_SAFETY.value
+        self._trace(TraceEvent(
+            decision_id=self._plan_decision.get(str(plan_id), ""),
+            node="brain_node", kind=TraceKind.SKILL_RESULT,
+            verdict=Verdict.BLOCKED if blocked else Verdict.ACCEPTED,
+            gate="safety" if blocked else "",
+            reason=str(payload.get("reason") or status), plan_id=str(plan_id or ""),
+            detail={"status": status},
+        ))
 
     def _on_reset_context(self, msg: Empty) -> None:  # noqa: ARG002
         """P1-2: Cancel PendingConfirm when browser requests a context reset.

--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -5,6 +5,7 @@ import json
 import random
 import threading
 import time
+import uuid
 from collections import deque
 from dataclasses import dataclass, field
 from typing import Any
@@ -51,6 +52,7 @@ from pawai_contracts.zh_tables import (
 )
 # LLM proposal policy single-sourced in pawai_contracts (Plan C4, 2026-06-10).
 from pawai_contracts import llm_policy as _llm_policy
+from pawai_contracts.trace_schema import TraceEvent, TraceKind, Verdict, make_suppressed
 
 # Per-class speaking dedup (D-4: key = class_name only, color dropped to prevent
 # color-jitter bypass).  SkillContract.cooldown_s=5 only stops the *skill* from
@@ -192,6 +194,12 @@ class BrainNode(Node):
         self._last_chat_input_ts: float = 0.0
 
         self._pub_proposal = self.create_publisher(String, "/brain/proposal", _RELIABLE_10)
+        # Plan E (2026-06-10): decision-chain trace. Distinct from
+        # /brain/conversation_trace (LLM dialogue stages) — this one answers
+        # 「為什麼沒反應」. Persistence belongs to the Studio gateway, NOT here.
+        self._pub_trace = self.create_publisher(String, "/brain/trace", _RELIABLE_10)
+        self._plan_decision: dict[str, str] = {}   # plan_id → decision_id (GC in _gc_dedup)
+        self._current_decision_id: str = ""
         self._pub_brain_state = self.create_publisher(
             String, "/state/pawai_brain", _TRANSIENT_LOCAL_1
         )
@@ -473,6 +481,15 @@ class BrainNode(Node):
         self.get_logger().info(
             f"PROPOSAL {plan.selected_skill} src={plan.source} reason={plan.reason}"
         )
+        # Plan E: decision-chain bookkeeping + plan_emitted trace (additive).
+        self._plan_decision[plan.plan_id] = self._current_decision_id
+        self._trace(TraceEvent(
+            decision_id=self._current_decision_id, node="brain_node",
+            kind=TraceKind.PLAN_EMITTED, verdict=Verdict.ACCEPTED,
+            gate="", reason=plan.reason, plan_id=plan.plan_id,
+            detail={"skill": plan.selected_skill, "source": plan.source,
+                    "priority": int(plan.priority_class)},
+        ))
 
     def _plan_to_dict(self, plan: SkillPlan) -> dict[str, Any]:
         return {
@@ -486,7 +503,48 @@ class BrainNode(Node):
             "priority_class": int(plan.priority_class),
             "session_id": plan.session_id,
             "created_at": plan.created_at,
+            # Plan E (additive): chains this proposal to its triggering
+            # perception event; IE tolerates unknown fields.
+            "decision_id": self._current_decision_id,
         }
+
+    def _trace(self, ev: TraceEvent) -> None:
+        """Publish a TraceEvent. NEVER raises — tracing must not break callbacks."""
+        try:
+            msg = String()
+            msg.data = ev.to_json()
+            self._pub_trace.publish(msg)
+        except Exception as exc:  # noqa: BLE001 — additive instrumentation only
+            self.get_logger().debug(f"trace publish failed: {exc}")
+
+    def _suppressed(self, *, gate: str, reason: str, source_summary: str = "",
+                    cooldown_remaining_s: float | None = None) -> None:
+        """Emit a suppressed-verdict trace for a gate early-return (Plan E3).
+
+        Reads shared state for the Roy-required context fields; never raises
+        (the underlying _trace swallows publish errors, and the state reads are
+        guarded here)."""
+        try:
+            with self._lock:
+                active = self._state.active_plan or {}
+            pending = f"{self._pending_confirm.state.name}:" \
+                      f"{getattr(self._pending_confirm, 'skill', '') or ''}"
+            self._trace(make_suppressed(
+                decision_id=self._current_decision_id, node="brain_node",
+                gate=gate, reason=reason, demo_phase=self.demo_phase,
+                active_plan=str(active.get("selected_skill") or ""),
+                pending_confirm=pending,
+                cooldown_remaining_s=cooldown_remaining_s,
+                source_summary=source_summary,
+            ))
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().debug(f"suppressed trace failed: {exc}")
+
+    def _cooldown_remaining(self, key: str, cooldown_s: float) -> float:
+        last = self._state.last_alert_ts.get(key)
+        if last is None:
+            return 0.0
+        return max(0.0, cooldown_s - (time.time() - last))
 
     def _in_cooldown(self, key: str, cooldown_s: float) -> bool:
         last = self._state.last_alert_ts.get(key)
@@ -548,6 +606,9 @@ class BrainNode(Node):
             self._state.dedup_cache = {
                 key: ts for key, ts in self._state.dedup_cache.items() if ts > cutoff
             }
+        # Plan E: bound the plan→decision map (insertion-ordered dict).
+        while len(self._plan_decision) > 200:
+            self._plan_decision.pop(next(iter(self._plan_decision)))
 
     def _has_active_skill_or_sequence(self) -> bool:
         """Return True when a SKILL or SEQUENCE priority plan is actively running.
@@ -567,6 +628,9 @@ class BrainNode(Node):
         payload = self._load_json(msg)
         if payload is None:
             return
+        # Plan E: one decision_id per inbound event — chains gate verdicts,
+        # plan and skill_result (single-threaded executor → serial-safe).
+        self._current_decision_id = f"speech-{uuid.uuid4().hex[:12]}"
         if self.perception_router_enabled:
             ev = parse_speech(payload)
             transcript, session_id = ev.transcript, ev.session_id
@@ -662,6 +726,9 @@ class BrainNode(Node):
         payload = self._load_json(msg)
         if payload is None:
             return
+        # Plan E: one decision_id per inbound event — chains gate verdicts,
+        # plan and skill_result (single-threaded executor → serial-safe).
+        self._current_decision_id = f"chat-{uuid.uuid4().hex[:12]}"
         session_id = str(payload.get("session_id") or "")
         reply_text = str(payload.get("reply_text") or "").strip()
         engine = str(payload.get("engine") or "legacy")
@@ -825,6 +892,9 @@ class BrainNode(Node):
         payload = self._load_json(msg)
         if payload is None:
             return
+        # Plan E: one decision_id per inbound event — chains gate verdicts,
+        # plan and skill_result (single-threaded executor → serial-safe).
+        self._current_decision_id = f"gesture-{uuid.uuid4().hex[:12]}"
         if self.perception_router_enabled:
             gesture = parse_gesture(payload).gesture
         else:  # legacy parse — Phase 0 fallback, byte-identical semantics
@@ -1134,6 +1204,9 @@ class BrainNode(Node):
         payload = self._load_json(msg)
         if payload is None:
             return
+        # Plan E: one decision_id per inbound event — chains gate verdicts,
+        # plan and skill_result (single-threaded executor → serial-safe).
+        self._current_decision_id = f"face-{uuid.uuid4().hex[:12]}"
         if self.perception_router_enabled:
             ev = parse_face(payload)
             identity, stable = ev.identity, ev.stable
@@ -1247,6 +1320,9 @@ class BrainNode(Node):
         payload = self._load_json(msg)
         if payload is None:
             return
+        # Plan E: one decision_id per inbound event — chains gate verdicts,
+        # plan and skill_result (single-threaded executor → serial-safe).
+        self._current_decision_id = f"pose-{uuid.uuid4().hex[:12]}"
         if self.perception_router_enabled:
             pose = parse_pose(payload).pose
         else:  # legacy parse — Phase 0 fallback, byte-identical semantics
@@ -1339,6 +1415,9 @@ class BrainNode(Node):
         payload = self._load_json(msg)
         if payload is None:
             return
+        # Plan E: one decision_id per inbound event — chains gate verdicts,
+        # plan and skill_result (single-threaded executor → serial-safe).
+        self._current_decision_id = f"object-{uuid.uuid4().hex[:12]}"
 
         if self.perception_router_enabled:
             ev = parse_object(payload)
@@ -1479,6 +1558,9 @@ class BrainNode(Node):
         payload = self._load_json(msg)
         if payload is None:
             return
+        # Plan E: one decision_id per inbound event — chains gate verdicts,
+        # plan and skill_result (single-threaded executor → serial-safe).
+        self._current_decision_id = f"skill_request-{uuid.uuid4().hex[:12]}"
         skill = str(payload.get("skill") or "").strip()
         args = payload.get("args") or {}
         if skill not in SKILL_REGISTRY:
@@ -1570,6 +1652,23 @@ class BrainNode(Node):
                     if status == SkillResultStatus.BLOCKED_BY_SAFETY.value:
                         plan["accepted"] = False
                     break
+
+        # Plan E: skill_result trace on terminal/blocked statuses (additive).
+        if status in (
+            SkillResultStatus.COMPLETED.value,
+            SkillResultStatus.ABORTED.value,
+            SkillResultStatus.BLOCKED_BY_SAFETY.value,
+            SkillResultStatus.STEP_FAILED.value,
+        ):
+            blocked = status == SkillResultStatus.BLOCKED_BY_SAFETY.value
+            self._trace(TraceEvent(
+                decision_id=self._plan_decision.get(str(plan_id), ""),
+                node="brain_node", kind=TraceKind.SKILL_RESULT,
+                verdict=Verdict.BLOCKED if blocked else Verdict.ACCEPTED,
+                gate="safety" if blocked else "",
+                reason=str(payload.get("reason") or status), plan_id=str(plan_id or ""),
+                detail={"status": status},
+            ))
 
     def _on_reset_context(self, msg: Empty) -> None:  # noqa: ARG002
         """P1-2: Cancel PendingConfirm when browser requests a context reset.

--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -622,6 +622,11 @@ class BrainNode(Node):
         # Plan E: bound the plan→decision map (insertion-ordered dict).
         while len(self._plan_decision) > 200:
             self._plan_decision.pop(next(iter(self._plan_decision)))
+        # Plan E: expire stale trace-throttle entries (same 5s horizon family).
+        tcut = time.time() - 60.0
+        self._trace_throttle = {
+            k: ts for k, ts in self._trace_throttle.items() if ts > tcut
+        }
 
     def _has_active_skill_or_sequence(self) -> bool:
         """Return True when a SKILL or SEQUENCE priority plan is actively running.
@@ -929,7 +934,8 @@ class BrainNode(Node):
         # (Plan E: /brain/trace 的 suppressed 仍發 — 它就是回答「為什麼沒反應」的通道。)
         if not self.gesture_enabled:
             self._suppressed(gate="gesture_enabled", reason="gesture_enabled=false",
-                             source_summary=f"gesture={gesture}")
+                             source_summary=f"gesture={gesture}",
+                             throttle_key=f"gesture_off:{gesture}")
             return
         # 2026-06-10 demo phase gate（all=不擋）
         if not self._phase_allows("gesture"):
@@ -1713,17 +1719,14 @@ class BrainNode(Node):
                         "executor": payload.get("detail"),
                         "args": payload.get("step_args", {}),
                     }
-            elif status in (
-                SkillResultStatus.COMPLETED.value,
-                SkillResultStatus.ABORTED.value,
-                SkillResultStatus.BLOCKED_BY_SAFETY.value,
-                # 2026-06-10 review blocker: STEP_FAILED 在 executive 端就是 plan 終結
-                # （兩條 STEP_FAILED 路徑都緊跟 self._queue.pop()，不會再有 terminal
-                # status）。若不在此清 active_plan，一次 NAV step 失敗（例如忘了開
-                # nav_executor_enabled / goal rejected / timeout）會讓 active_plan
-                # 永久卡住 → not-active gate 把 cup/greet/gesture/語音全黑（重演 6/9）。
-                SkillResultStatus.STEP_FAILED.value,
-            ):
+            # 2026-06-10 review blocker: STEP_FAILED 在 executive 端就是 plan 終結
+            # （兩條 STEP_FAILED 路徑都緊跟 self._queue.pop()，不會再有 terminal
+            # status）。若不在此清 active_plan，一次 NAV step 失敗（例如忘了開
+            # nav_executor_enabled / goal rejected / timeout）會讓 active_plan
+            # 永久卡住 → not-active gate 把 cup/greet/gesture/語音全黑（重演 6/9）。
+            # Status set shared with the Plan E skill_result trace
+            # (_TERMINAL_RESULT_STATUSES) so the two can never drift.
+            elif status in self._TERMINAL_RESULT_STATUSES:
                 if self._state.active_plan and self._state.active_plan["plan_id"] == plan_id:
                     self._state.active_plan = None
                     self._state.active_step = None

--- a/interaction_executive/interaction_executive/interaction_executive_node.py
+++ b/interaction_executive/interaction_executive/interaction_executive_node.py
@@ -24,6 +24,8 @@ try:
 except ImportError:  # pragma: no cover - local unit environments may lack generated actions
     GotoRelative = None
 
+from pawai_contracts.trace_schema import TraceEvent, TraceKind, Verdict
+
 from .safety_layer import SafetyLayer
 from .skill_contract import (
     BANNED_API_IDS,
@@ -89,6 +91,9 @@ class InteractionExecutiveNode(Node):
         self._pub_skill_result = self.create_publisher(
             String, "/brain/skill_result", _RELIABLE_20
         )
+        # Plan E: decision-chain trace mirror — IE reports safety BLOCKED
+        # verdicts on the same /brain/trace channel as brain_node.
+        self._pub_trace = self.create_publisher(String, "/brain/trace", _RELIABLE_20)
 
         # NAV action client lazy-created on first NAV step（避免無 nav stack 環境
         # 建 client 的 discovery 開銷）；_nav_state 是當前 in-flight goal 的狀態。
@@ -114,6 +119,25 @@ class InteractionExecutiveNode(Node):
                 self.get_logger().info(f"nav_step_timeout_s set to {self.nav_step_timeout_s}")
         return SetParametersResult(successful=True)
 
+    def _trace_safety_block(self, data: dict[str, Any], plan, reason) -> None:
+        """Plan E: mirror a safety BLOCKED verdict onto /brain/trace.
+
+        decision_id comes from the proposal payload (additive field, empty for
+        pre-Plan-E senders). NEVER raises — additive instrumentation only."""
+        try:
+            trace_msg = String()
+            trace_msg.data = TraceEvent(
+                decision_id=str(data.get("decision_id") or ""),
+                node="interaction_executive", kind=TraceKind.SKILL_RESULT,
+                verdict=Verdict.BLOCKED, gate="safety",
+                reason=str(reason or "blocked_by_safety"),
+                plan_id=str(plan.plan_id or ""),
+                detail={"skill": plan.selected_skill},
+            ).to_json()
+            self._pub_trace.publish(trace_msg)
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().debug(f"trace publish failed: {exc}")
+
     def _on_proposal(self, msg: String) -> None:
         data = self._load_json(msg)
         if data is None:
@@ -132,6 +156,7 @@ class InteractionExecutiveNode(Node):
                 SkillResultStatus.BLOCKED_BY_SAFETY,
                 detail=validation.reason,
             )
+            self._trace_safety_block(data, plan, validation.reason)
             return
 
         self._emit_result(plan, None, SkillResultStatus.ACCEPTED, detail=plan.selected_skill)

--- a/interaction_executive/test/test_router_golden.py
+++ b/interaction_executive/test/test_router_golden.py
@@ -156,7 +156,7 @@ def _normalize(published: list[str]) -> list[dict]:
     out = []
     for raw in published:
         d = json.loads(raw)
-        for vol in ("plan_id", "created_at", "session_id"):
+        for vol in ("plan_id", "created_at", "session_id", "decision_id"):
             d.pop(vol, None)
         for step in d.get("steps", []):
             step.pop("step_id", None)

--- a/interaction_executive/test/test_trace_emission.py
+++ b/interaction_executive/test/test_trace_emission.py
@@ -1,0 +1,99 @@
+"""Trace emission tests (Plan E4) — rclpy local tier (NOT in the CI fast gate).
+Pattern: capture /brain/trace publishes, fire one suppression scenario, assert
+gate/reason/decision-chain fields. Behavior itself is asserted unchanged by the
+untouched pre-Plan-E test suite."""
+import json
+
+import pytest
+
+rclpy = pytest.importorskip("rclpy")
+from std_msgs.msg import String  # noqa: E402
+
+from interaction_executive.brain_node import BrainNode  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def rclpy_ctx():
+    if not rclpy.ok():
+        rclpy.init()
+    yield
+    if rclpy.ok():
+        rclpy.shutdown()
+
+
+@pytest.fixture
+def node():
+    n = BrainNode()
+    n.traces = []
+    n._pub_trace.publish = (  # type: ignore[method-assign]
+        lambda m: n.traces.append(json.loads(m.data))
+    )
+    yield n
+    n.destroy_node()
+
+
+def _msg(payload: dict) -> String:
+    m = String()
+    m.data = json.dumps(payload, ensure_ascii=False)
+    return m
+
+
+def test_gesture_disabled_emits_suppressed(node):
+    node.gesture_enabled = False
+    node._on_gesture(_msg({"gesture": "thumbs_up", "confidence": 0.95}))
+    hits = [t for t in node.traces if t["gate"] == "gesture_enabled"]
+    assert hits and hits[0]["verdict"] == "suppressed"
+    assert hits[0]["detail"]["demo_phase"] == node.demo_phase
+    assert hits[0]["decision_id"].startswith("gesture-")
+
+
+def test_phase_gate_emits_suppressed_with_phase(node):
+    node.demo_phase = "s3_object"
+    node.gesture_enabled = True
+    node._on_gesture(_msg({"gesture": "wave", "confidence": 0.9}))
+    hits = [t for t in node.traces if t["gate"] == "demo_phase"]
+    assert hits and "s3_object" in hits[0]["reason"]
+    assert "gesture" in hits[0]["reason"]
+
+
+def test_plan_emitted_and_skill_result_share_decision_id(node):
+    node._on_speech_intent(_msg({"transcript": "停", "session_id": "t1"}))
+    emitted = [t for t in node.traces if t["kind"] == "plan_emitted"]
+    assert emitted, "stop keyword should emit a plan"
+    plan_id, decision_id = emitted[0]["plan_id"], emitted[0]["decision_id"]
+    assert decision_id.startswith("speech-")
+    node._on_skill_result(_msg({"plan_id": plan_id, "status": "completed"}))
+    results = [t for t in node.traces if t["kind"] == "skill_result"]
+    assert results and results[0]["decision_id"] == decision_id
+    assert results[0]["verdict"] == "accepted"
+
+
+def test_blocked_by_safety_result_verdict(node):
+    node._on_speech_intent(_msg({"transcript": "停", "session_id": "t2"}))
+    emitted = [t for t in node.traces if t["kind"] == "plan_emitted"]
+    plan_id = emitted[0]["plan_id"]
+    node._on_skill_result(_msg({"plan_id": plan_id, "status": "blocked_by_safety",
+                                "reason": "banned_api:1301"}))
+    blocked = [t for t in node.traces
+               if t["kind"] == "skill_result" and t["verdict"] == "blocked"]
+    assert blocked and blocked[0]["gate"] == "safety"
+    assert blocked[0]["reason"] == "banned_api:1301"
+
+
+def test_object_dedup_emits_suppressed_with_remaining(node):
+    from interaction_executive.attention_machine import AttentionState
+    node._attention._state = AttentionState.ENGAGED
+    payload = {"objects": [{"class_name": "cup", "confidence": 0.6, "color": "red"}]}
+    node._on_object(_msg(payload))          # first: emits remark, sets dedup
+    node._on_object(_msg(payload))          # second: 60s remark dedup hit
+    hits = [t for t in node.traces if t["gate"] == "object_remark_dedup"]
+    assert hits, [t["gate"] for t in node.traces]
+    assert hits[0]["detail"]["cooldown_remaining_s"] > 0
+    assert "cup" in hits[0]["detail"]["source_summary"]
+
+
+def test_trace_never_breaks_callback(node):
+    node._pub_trace.publish = lambda m: (_ for _ in ()).throw(RuntimeError("boom"))
+    node.gesture_enabled = False
+    # Must not raise even though every trace publish explodes.
+    node._on_gesture(_msg({"gesture": "thumbs_up"}))

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -104,6 +104,9 @@ TOPIC_MAP: dict[str, str] = {
     "/brain/skill_result":             "brain:skill_result",
     "/brain/conversation_trace":        "brain:conversation_trace",
     "/brain/conversation_trace_shadow": "brain:conversation_trace_shadow",
+    # Plan E: decision-chain trace (bridge ONLY — persistence/export/panel
+    # belong to the Studio Evidence Center plan, not here).
+    "/brain/trace":                     "brain:trace",
 }
 
 FACE_THROTTLE_S = 0.5  # 10Hz → 2Hz

--- a/pawai_contracts/pawai_contracts/trace_schema.py
+++ b/pawai_contracts/pawai_contracts/trace_schema.py
@@ -1,0 +1,73 @@
+"""/brain/trace event schema — single source (Plan E, Roy ruling 2026-06-10 D5):
+'Trace 的單一真相是 pawai_contracts schema + gateway JSONL。Brain 只負責說明自己
+為什麼做/不做；Studio 只負責記錄與呈現；CLI 只負責讀取與匯出。'
+
+decision_id chains one causal line: perception event → gate verdicts → plan →
+skill_result. Emission: brain_node / interaction_executive (this plan);
+conversation_graph joins later. Persistence: Studio gateway (separate plan).
+ADDITIVE-ONLY: schema changes must stay backward-compatible (add fields, never
+rename/remove)."""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class TraceKind(str, Enum):
+    PERCEPTION_EVENT = "perception_event"
+    CANDIDATE = "candidate"
+    POLICY_DECISION = "policy_decision"
+    PLAN_EMITTED = "plan_emitted"
+    SKILL_RESULT = "skill_result"
+    TTS_STATE = "tts_state"
+
+
+class Verdict(str, Enum):
+    ACCEPTED = "accepted"
+    SUPPRESSED = "suppressed"
+    BLOCKED = "blocked"
+
+
+@dataclass
+class TraceEvent:
+    decision_id: str
+    node: str                      # brain_node | interaction_executive | conversation_graph
+    kind: TraceKind
+    verdict: Verdict
+    gate: str = ""                 # e.g. demo_phase / gesture_enabled / active_plan / tts_playing
+    reason: str = ""               # e.g. phase:s3_object / cooldown:greet:Roy / banned_api:1301
+    detail: dict[str, Any] = field(default_factory=dict)
+    plan_id: str = ""
+    ts: float = field(default_factory=time.time)
+    v: int = 1
+
+    def to_json(self) -> str:
+        d = {
+            "v": self.v, "ts": self.ts, "decision_id": self.decision_id,
+            "node": self.node, "kind": self.kind.value, "verdict": self.verdict.value,
+            "gate": self.gate, "reason": self.reason, "detail": self.detail,
+        }
+        if self.plan_id:
+            d["plan_id"] = self.plan_id
+        return json.dumps(d, ensure_ascii=False)
+
+
+def make_suppressed(*, decision_id: str, node: str, gate: str, reason: str,
+                    demo_phase: str = "", active_plan: str = "",
+                    pending_confirm: str = "", cooldown_remaining_s: float | None = None,
+                    source_summary: str = "") -> TraceEvent:
+    """Roy-required suppressed payload: 被哪個 gate 擋 / 當時 demo_phase /
+    active_plan 是誰 / pending_confirm 是誰 / cooldown 還剩多久 / 來源摘要."""
+    return TraceEvent(
+        decision_id=decision_id, node=node, kind=TraceKind.POLICY_DECISION,
+        verdict=Verdict.SUPPRESSED, gate=gate, reason=reason,
+        detail={
+            "gate": gate, "reason": reason, "demo_phase": demo_phase,
+            "active_plan": active_plan, "pending_confirm": pending_confirm,
+            "cooldown_remaining_s": cooldown_remaining_s,
+            "source_summary": source_summary,
+        },
+    )

--- a/pawai_contracts/test/test_trace_schema.py
+++ b/pawai_contracts/test/test_trace_schema.py
@@ -1,0 +1,41 @@
+import json
+
+from pawai_contracts.trace_schema import TraceEvent, TraceKind, Verdict, make_suppressed
+
+
+def test_round_trip_json():
+    ev = TraceEvent(decision_id="d1", node="brain_node", kind=TraceKind.POLICY_DECISION,
+                    verdict=Verdict.SUPPRESSED, gate="demo_phase", reason="phase:s3_object")
+    d = json.loads(ev.to_json())
+    assert d["decision_id"] == "d1" and d["verdict"] == "suppressed" and d["ts"] > 0
+
+
+def test_make_suppressed_carries_roy_required_fields():
+    ev = make_suppressed(
+        decision_id="d2", node="brain_node", gate="gesture_enabled",
+        reason="gesture_enabled=false", demo_phase="all",
+        active_plan="stranger_alert", pending_confirm="PENDING:wiggle",
+        cooldown_remaining_s=12.5, source_summary="gesture=thumbs_up conf=0.95",
+    )
+    d = json.loads(ev.to_json())
+    for key in ("gate", "reason", "demo_phase", "active_plan", "pending_confirm",
+                "cooldown_remaining_s", "source_summary"):
+        assert key in d["detail"], key
+
+
+def test_verdict_and_kind_enums_frozen():
+    assert {v.value for v in Verdict} == {"accepted", "suppressed", "blocked"}
+    assert {k.value for k in TraceKind} == {
+        "perception_event", "candidate", "policy_decision",
+        "plan_emitted", "skill_result", "tts_state",
+    }
+
+
+def test_plan_id_only_when_set():
+    base = TraceEvent(decision_id="d3", node="brain_node",
+                      kind=TraceKind.PLAN_EMITTED, verdict=Verdict.ACCEPTED)
+    assert "plan_id" not in json.loads(base.to_json())
+    withid = TraceEvent(decision_id="d3", node="brain_node",
+                        kind=TraceKind.PLAN_EMITTED, verdict=Verdict.ACCEPTED,
+                        plan_id="p-1")
+    assert json.loads(withid.to_json())["plan_id"] == "p-1"


### PR DESCRIPTION
## Plan E — Brain Trace v1（單 PR、6 commits）

Per `docs/superpowers/plans/2026-06-10-plan-e-brain-trace-v1.md` + Roy 拍板 D5 邊界（schema=contracts、發射=Brain/IE、落盤=Studio 後續 plan、CLI 只讀 —「不再發明第三套 trace」）。

**回答「PawAI 為什麼沒反應」**：每個 gate 早退發 `suppressed` trace（gate 名/reason/demo_phase/active_plan/pending_confirm/cooldown 剩餘/來源摘要），`decision_id` 把 perception event → gate verdict → plan_emitted → skill_result 串成因果鏈，新 topic `/brain/trace`（contract v2.12）。

### Commits
| Commit | 內容 |
|---|---|
| `cd57058` | E1 — trace schema（pawai_contracts，10 tests） |
| `aaf1e5c` | E2 — TraceEmitter + decision_id 鏈（7 入口）+ proposal 增 additive `decision_id` 欄位 + **contract 同 commit 登記**（ghost-topic pre-commit gate 攔下第一次嘗試 — 護欄如設計運作） |
| `71999c0` | E3 — **15 個 suppression 點插樁** + IE safety BLOCKED 鏡像；熱路徑（10Hz face/object 流）用獨立 `_trace_throttle` 限流（刻意不用 `last_alert_ts` — 那會洩進 `/brain/state`）；`_suppressed` 全部呼叫點在鎖外（threading.Lock 不可重入，終審逐點死鎖審計通過） |
| `1d98f41` | E4 — 6 條 emission 測試（含「trace publish 爆炸不傷 callback」） |
| `b9d51d6` | E5 — gateway TOPIC_MAP 一行橋接（**零落盤**，全 diff grep 證實） |
| review | 終審 3 Minor：throttle GC / gesture_off throttle / terminal-status 常數共用防 drift |

### Additive-only 證明（終審六角度攻擊全守住）
- **既有測試零修改全綠**：IE 276（270+6 新）/ brain 348 / contracts 10 / gateway 64+1skip
- 逐 hunk 審計：18 純加行 + 2 個可證等價重構（`_check_dedup` 鎖外發 trace、skill_result trace 抽 helper）— runtime 對抗測試實證（50 連發無死鎖、cooldown 字典零洩漏、dedup 等價）
- **golden router referee 照常通過**（trace 不擾動 Plan D 的等價裁判）
- flake8 = baseline 持平（12→10，重構反而少 2 條 C901）
- 插樁覆蓋 = plan 表 **100%**；表外 gap（gesture confirm cooldown / stranger 內部 5 條件 / pose 路徑等 6 處）誠實列於終審報告，屬 v2 候選

### Jetson smoke（merge 後）
brain lane 起、`ros2 topic echo /brain/trace`：gesture off 時比手勢 + s3_object phase 時比手勢 → 兩條 suppressed 即時可見；Studio event drawer 出現 `brain:trace`。

### Rollback
Revert PR 即可（additive topic 無消費者依賴）。

### 交棒（明確不在本 PR）
Studio Evidence Center plan：gateway JSONL 落盤 + `GET /api/trace/*` + panel；CLI 只讀同一份。Timer 驅動 emission 的 decision_id 歸屬（沿用前一事件，近似值）留 ISM 處理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)