### PR TITLE
fix(cli): module build lists 依賴閉包 — fresh deploy 必紅修復 (B-E smoke Gap 1)

### DIFF
--- a/docs/pawai_cli/modules.md
+++ b/docs/pawai_cli/modules.md
@@ -12,12 +12,12 @@ CLI 內建 8 個 module，跟 ROS2 package、log target、test 命令對應。
 | Module | 中文 | ROS Packages | Demo Log Targets | Go2 控制 |
 |--------|------|--------------|------------------|---------|
 | `face` | 人臉辨識 | `face_perception` | `demo:face` | 無 |
-| `speech` | 語音 | `speech_processor` | `demo:asr`、`demo:tts` | 透過 Megaphone TTS |
-| `gesture` | 手勢辨識 | `vision_perception` | `demo:vision` | 透過互動 skill 間接 |
-| `pose` | 姿勢辨識 | `vision_perception` | `demo:vision` | `fallen_alert` 可停 Go2 |
+| `speech` | 語音 | `go2_interfaces`、`speech_processor` | `demo:asr`、`demo:tts` | 透過 Megaphone TTS |
+| `gesture` | 手勢辨識 | `go2_interfaces`、`vision_perception` | `demo:vision` | 透過互動 skill 間接 |
+| `pose` | 姿勢辨識 | `go2_interfaces`、`vision_perception` | `demo:vision` | `fallen_alert` 可停 Go2 |
 | `object` | 物體辨識 | `object_perception` | `demo:object` | 無 |
-| `nav` | 導航避障 | `go2_robot_sdk` | `demo:go2`、`nav-cap-demo:nav_action`、`reactive-stop:reactive` | 直接動作 |
-| `brain` | PawAI Brain | `pawai_brain`、`interaction_executive` | `demo:llm`、`demo:executive`、`pawai_brain:conv_graph` | 透過 `interaction_executive` |
+| `nav` | 導航避障 | `go2_interfaces`、`go2_robot_sdk` | `demo:go2`、`nav-cap-demo:nav_action`、`reactive-stop:reactive` | 直接動作 |
+| `brain` | PawAI Brain | `go2_interfaces`、`pawai_contracts`、`pawai_brain`、`interaction_executive` | `demo:llm`、`demo:executive`、`pawai_brain:conv_graph` | 透過 `interaction_executive` |
 | `studio` | Studio 前端/Gateway | （無 ROS package） | `local:/tmp/studio_frontend.log`、`demo:gateway` | 無 |
 
 ### 別名
@@ -51,7 +51,7 @@ pawai logs face
 
 ### speech — 語音
 
-- **Package**：`speech_processor`
+- **Packages**：`go2_interfaces`、`speech_processor`（介面依賴，fresh deploy 需一起 build）
 - **Doc**：[`docs/pawai-brain/architecture/0511/speech.md`](../pawai-brain/architecture/0511/speech.md)
 - **Tests**：`python3 -m pytest speech_processor/test -v`
 - **Logs**：`demo:asr`、`demo:tts`
@@ -67,7 +67,7 @@ pawai logs speech --lines 300  # 抓 asr + tts pane
 
 ### gesture — 手勢辨識
 
-- **Package**：`vision_perception`（與 pose 共用）
+- **Packages**：`go2_interfaces`、`vision_perception`（與 pose 共用）
 - **Doc**：[`docs/pawai-brain/architecture/0511/gesture.md`](../pawai-brain/architecture/0511/gesture.md)
 - **Tests**：`python3 -m pytest vision_perception/test -v -k gesture`
 - **Log**：`demo:vision`
@@ -78,7 +78,7 @@ pawai logs speech --lines 300  # 抓 asr + tts pane
 
 ### pose — 姿勢辨識
 
-- **Package**：`vision_perception`（與 gesture 共用）
+- **Packages**：`go2_interfaces`、`vision_perception`（與 gesture 共用）
 - **Doc**：[`docs/pawai-brain/architecture/0511/pose.md`](../pawai-brain/architecture/0511/pose.md)
 - **Tests**：`python3 -m pytest vision_perception/test -v -k pose`
 - **Log**：`demo:vision`
@@ -100,7 +100,7 @@ pawai logs speech --lines 300  # 抓 asr + tts pane
 
 ### nav — 導航避障
 
-- **Package**：`go2_robot_sdk`（含 nav2/AMCL/cartographer launch）
+- **Packages**：`go2_interfaces`、`go2_robot_sdk`（含 nav2/AMCL/cartographer launch）
 - **Docs**：
   - [`.claude/skills/nav-avoidance-lane/SKILL.md`](../../.claude/skills/nav-avoidance-lane/SKILL.md)
   - [`docs/navigation/CLAUDE.md`](../navigation/CLAUDE.md)
@@ -117,7 +117,7 @@ pawai logs speech --lines 300  # 抓 asr + tts pane
 
 ### brain — PawAI Brain
 
-- **Packages**：`pawai_brain`、`interaction_executive`
+- **Packages**：`go2_interfaces`、`pawai_contracts`、`pawai_brain`、`interaction_executive`
 - **Doc**：[`docs/pawai-brain/architecture/0511/brain.md`](../pawai-brain/architecture/0511/brain.md)
 - **Tests**：
   - `python3 -m pytest pawai_brain/test -v`

--- a/tools/pawai_cli/pawai_cli/modules.py
+++ b/tools/pawai_cli/pawai_cli/modules.py
@@ -30,7 +30,7 @@ MODULES: dict[str, ModuleInfo] = {
     "speech": ModuleInfo(
         key="speech",
         title="語音功能",
-        packages=("speech_processor",),
+        packages=("go2_interfaces", "speech_processor"),
         docs=("docs/pawai-brain/architecture/0511/speech.md",),
         tests=("python3 -m pytest speech_processor/test -v",),
         logs=("demo:asr", "demo:tts"),
@@ -40,7 +40,7 @@ MODULES: dict[str, ModuleInfo] = {
     "gesture": ModuleInfo(
         key="gesture",
         title="手勢辨識",
-        packages=("vision_perception",),
+        packages=("go2_interfaces", "vision_perception"),
         docs=("docs/pawai-brain/architecture/0511/gesture.md",),
         tests=("python3 -m pytest vision_perception/test -v -k gesture",),
         logs=("demo:vision",),
@@ -50,7 +50,7 @@ MODULES: dict[str, ModuleInfo] = {
     "pose": ModuleInfo(
         key="pose",
         title="姿勢辨識",
-        packages=("vision_perception",),
+        packages=("go2_interfaces", "vision_perception"),
         docs=("docs/pawai-brain/architecture/0511/pose.md",),
         tests=("python3 -m pytest vision_perception/test -v -k pose",),
         logs=("demo:vision",),
@@ -70,7 +70,7 @@ MODULES: dict[str, ModuleInfo] = {
     "nav": ModuleInfo(
         key="nav",
         title="導航避障功能",
-        packages=("go2_robot_sdk",),
+        packages=("go2_interfaces", "go2_robot_sdk"),
         docs=(".claude/skills/nav-avoidance-lane/SKILL.md", "docs/navigation/CLAUDE.md"),
         tests=("python3 -m pytest go2_robot_sdk/test -v",),
         logs=("demo:go2", "nav-cap-demo:nav_action", "reactive-stop:reactive"),
@@ -80,7 +80,7 @@ MODULES: dict[str, ModuleInfo] = {
     "brain": ModuleInfo(
         key="brain",
         title="PawAI Brain",
-        packages=("pawai_brain", "interaction_executive"),
+        packages=("go2_interfaces", "pawai_contracts", "pawai_brain", "interaction_executive"),
         docs=("docs/pawai-brain/architecture/0511/brain.md",),
         tests=(
             "python3 -m pytest pawai_brain/test -v",

--- a/tools/pawai_cli/tests/test_modules_closure.py
+++ b/tools/pawai_cli/tests/test_modules_closure.py
@@ -1,0 +1,75 @@
+"""Module build-list dependency closure (2026-06-11 B-E smoke Gap 1).
+
+Root cause class: `pawai jetson deploy --module X` runs
+`colcon build --packages-select <module packages>`.  If a selected package's
+package.xml depends on another *repo-local* package that is NOT in the build
+list, a fresh machine (or a machine where that dependency was never built)
+fails with "Failed to find .../share/<dep>/package.sh".
+
+First hit: Plan C made interaction_executive depend on pawai_contracts, but
+the brain module build list didn't include it — every fresh
+`deploy --module brain` went red.  The same latent gap existed for
+go2_interfaces in speech/gesture/pose/nav/brain (masked only because Jetson
+had built it long ago).
+
+This test pins the closure so the next extraction can't reintroduce the class.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from pawai_cli.modules import MODULES
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Dependency tags that require the dep to be colcon-built/deployable.
+# test_depend intentionally excluded: not needed to build or run on Jetson.
+_DEP_TAGS = ("depend", "build_depend", "exec_depend")
+
+
+def _local_packages() -> dict[str, Path]:
+    pkgs: dict[str, Path] = {}
+    for px in REPO_ROOT.glob("*/package.xml"):
+        m = re.search(r"<name>([^<]+)</name>", px.read_text(encoding="utf-8"))
+        if m:
+            pkgs[m.group(1).strip()] = px
+    return pkgs
+
+
+def _declared_deps(package_xml: Path) -> set[str]:
+    txt = package_xml.read_text(encoding="utf-8")
+    deps: set[str] = set()
+    for tag in _DEP_TAGS:
+        deps |= {d.strip() for d in re.findall(rf"<{tag}>([^<]+)</{tag}>", txt)}
+    return deps
+
+
+def test_repo_local_packages_discovered() -> None:
+    """Sanity: discovery must see the packages this test exists to protect."""
+    local = _local_packages()
+    assert "pawai_contracts" in local
+    assert "go2_interfaces" in local
+
+
+@pytest.mark.parametrize("key", sorted(MODULES))
+def test_module_build_list_is_dependency_closed(key: str) -> None:
+    module = MODULES[key]
+    local = _local_packages()
+    selected = set(module.packages)
+    missing: set[str] = set()
+    for pkg in module.packages:
+        xml = local.get(pkg)
+        if xml is None:  # non-repo package (none today) — nothing to check
+            continue
+        for dep in _declared_deps(xml):
+            if dep in local and dep not in selected:
+                missing.add(dep)
+    assert not missing, (
+        f"module '{key}' build list {module.packages} is missing repo-local "
+        f"dependencies {sorted(missing)} — fresh `pawai jetson deploy "
+        f"--module {key}` will fail at colcon env setup. Add them to "
+        f"pawai_cli/modules.py."
+    )


### PR DESCRIPTION
## 問題（6/11 真機 smoke 抓到）

Plan C merge 後 `interaction_executive/package.xml` 依賴 `pawai_contracts`，但 CLI brain module 的 build 清單沒包含它 → **任何 fresh 機器跑 `pawai jetson deploy --module brain` 必紅**：

```
colcon.colcon_ros.task.ament_python.build ERROR Failed to find the following files:
- /home/jetson/elder_and_dog/install/pawai_contracts/share/pawai_contracts/package.sh
```

## 修法：修 class 不修單例

closure invariant test 掃出 **5/8 modules 同型 latent gap**（speech / gesture / pose / nav / brain 全缺 `go2_interfaces` — 只因 Jetson 早就 build 過才沒人撞到）：

- `modules.py`：5 個 module 的 `packages` 補齊 repo-local 依賴閉包
- `tests/test_modules_closure.py`（新）：parse 各 package.xml 的 `depend`/`build_depend`/`exec_depend`，斷言每個 module build list 依賴閉合 — 防止下次 package 抽取重蹈
- `docs/pawai_cli/modules.md`：文件同步

## 紅綠驗證

- Test 先行：**5 modules 紅**（brain/gesture/nav/pose/speech）→ 修後 **9 passed**
- 全套 pawai_cli：**160 passed**、1 紅為既有 #150 本機 `.env.local` 污染（stash 驗證 main 上同紅；CI runner 不受影響）
- 真機：merge 後將跑 `pawai jetson deploy --module brain` 驗 4 套件全綠（今天 smoke 已手動 build 證明 colcon 依賴序正確）

## 風險

僅 CLI metadata + 新測試，不碰 runtime / demo 凍結參數。deploy 多 build `go2_interfaces`（msgs-only，~3s）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)