### PR TITLE
fix(healthcheck): full mode pane fallback + 冷啟 grace window (B-E smoke Gap 2)

### DIFF
--- a/.claude/skills/brain-studio-lane/scripts/healthcheck.sh
+++ b/.claude/skills/brain-studio-lane/scripts/healthcheck.sh
@@ -14,7 +14,26 @@ echo "═══ brain-studio-lane healthcheck ═══"
 
 # ── conv_graph ready + openrouter on + persona 6 檔 ────────
 # `-J` joins wrapped lines（避免 80 字元換行讓 grep 抓不到 "loaded directory ... 6 files verified"）
-LOG=$(ssh $SSH_OPTS "$JETSON_HOST" "tmux capture-pane -t pawai_brain:conv_graph -pJ -S -300 2>/dev/null" || echo "")
+# 6/11 smoke Gap 2 修正：
+#   a) full mode 的 conv graph 跑在 demo:llm、brain-only mode 在 pawai_brain:conv_graph
+#      — 只抓後者會讓 full mode gate 永遠假失敗，兩個 pane 都抓。
+#   b) conv graph 冷啟 ~22s（LangGraph init）— 在 BRAIN_HC_WAIT_S 預算內輪詢等 ready；
+#      暖 stack 第一輪即通過，不付等待成本；stack 真死則等滿後照常 fail。
+BRAIN_HC_WAIT_S="${BRAIN_HC_WAIT_S:-60}"
+capture_brain_log() {
+  ssh $SSH_OPTS "$JETSON_HOST" \
+    "tmux capture-pane -t pawai_brain:conv_graph -pJ -S -300 2>/dev/null; \
+     tmux capture-pane -t demo:llm -pJ -S -300 2>/dev/null" || true
+}
+LOG=$(capture_brain_log)
+WAITED=0
+while ! echo "$LOG" | grep -q "conversation_graph_node ready"; do
+  if [ "$WAITED" -ge "$BRAIN_HC_WAIT_S" ]; then break; fi
+  echo "    … conv_graph 尚未 ready，等待中 (${WAITED}s/${BRAIN_HC_WAIT_S}s)"
+  sleep 5
+  WAITED=$((WAITED+5))
+  LOG=$(capture_brain_log)
+done
 echo -n "[1] conversation_graph_node ready ... "
 if echo "$LOG" | grep -q "conversation_graph_node ready"; then echo "✅"; else echo "❌"; FAILS=$((FAILS+1)); fi
 


### PR DESCRIPTION
## 問題（6/11 真機 smoke 抓到）

Plan B4 把 brain-studio-lane healthcheck 接成 `pawai demo start` 的 hard gate，但 script 有兩個 full-mode 假失敗根因：

1. **Pane 寫死**：`tmux capture-pane -t pawai_brain:conv_graph`（brain-only 佈局）— full demo 的 conv graph 實際跑在 `demo:llm` → 檢查 [1][2][3] 在 mode=full **永遠 ❌**，gate 永遠不可能過（stack 明明健康、log 有 ready + persona 6 檔）
2. **無 grace window**：conv graph 冷啟 ~22s（LangGraph init），gate 在 start.sh 返回後立即檢查 → 連 [4] topic publisher 都還沒出現

## 修法

- `capture_brain_log()`：兩個 pane 都抓（`pawai_brain:conv_graph` + `demo:llm`）
- `BRAIN_HC_WAIT_S`（預設 60s，env 可覆寫）輪詢等 `conversation_graph_node ready`；**暖 stack 第一輪即通過，不付等待成本**；stack 真死等滿後照常 fail-closed

## 真機驗證（Jetson + Go2，本分支 script 直接驅動 gate）

- **冷啟**：`pawai demo start -y` → gate 輪詢 3 輪（~15s）→ **[1]-[8] 全綠 → `✓ Demo running`、lock starting→running** — full mode 首次走通正向路徑
- **暖路徑**：`pawai health brain` 零等待全綠
- **負向語義不變**：CRLF `.env`（今日 smoke 已實測攔截）下 tmux 永不 spawn → LOG 永無 ready → 等滿 60s 後照常 fail，gate 仍擋假成功

## 範圍

僅 `.claude/skills/brain-studio-lane/scripts/healthcheck.sh`（Roy 6/11 已授權此禁改區改動）。不碰 CLI / runtime / demo 凍結參數。nav-avoidance-lane healthcheck 未檢視（不在本次範圍，如有同型問題另開）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)