### PR TITLE
security(S0-1): CI/hook hardening — secret guard + 注入修補 + Actions permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,7 @@
                 ]
             },
             {
-                "matcher": "Edit|Write",
+                "matcher": "Edit|Write|Read",
                 "hooks": [
                     {
                         "type": "command",

--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - 'main'
 
+# CI-05: least-privilege GITHUB_TOKEN — no job here writes to the repo.
+permissions:
+  contents: read
+
 jobs:
   # ── Tier 1: Fast Gate (< 1 min, no ROS2 container) ──────────────
   fast-gate:
@@ -22,6 +26,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - name: Guard hook regression (secret guards + injection)
+        run: bash scripts/hooks/test_secret_guards.sh
       - name: Install dependencies
         run: pip install pytest pytest-cov flake8 numpy opencv-python-headless jsonschema pyyaml requests langgraph click python-dotenv
       - name: Flake8 lint (report-only)

--- a/.github/workflows/studio-ci.yml
+++ b/.github/workflows/studio-ci.yml
@@ -12,6 +12,10 @@ on:
       - 'pawai-studio/**'
       - '.github/workflows/studio-ci.yml'
 
+# CI-05: least-privilege GITHUB_TOKEN — lint/build only, no repo writes.
+permissions:
+  contents: read
+
 jobs:
   frontend:
     name: Frontend — lint + build

--- a/scripts/hooks/post_tool_py_syntax.sh
+++ b/scripts/hooks/post_tool_py_syntax.sh
@@ -33,9 +33,13 @@ if [[ "$FILE" == *.py ]]; then
     exit 2
   fi
   # 2. Quick import sanity: detect duplicate imports (warning only)
-  python3 -c "
+  # CI-03: pass the path via argv — NEVER interpolate $FILE into the python
+  # source, or a crafted filename (e.g. containing a single quote) becomes a
+  # code-injection vector.
+  python3 - "$FILE" <<'PY' 2>&1 || true
 import ast, sys
-with open('$FILE') as f:
+path = sys.argv[1]
+with open(path) as f:
     tree = ast.parse(f.read())
 seen = set()
 for node in ast.walk(tree):
@@ -46,7 +50,7 @@ for node in ast.walk(tree):
             names = ', '.join(a.name for a in node.names)
             print(f'DUPLICATE IMPORT: {mod}.{names} (line {node.lineno})', file=sys.stderr)
         seen.add(key)
-" 2>&1 || true
+PY
   exit 0
 fi
 

--- a/scripts/hooks/pre_tool_safety.sh
+++ b/scripts/hooks/pre_tool_safety.sh
@@ -24,9 +24,13 @@ if echo "$INPUT" | grep -qE 'git\s+push\s+.*--force'; then
 fi
 
 # --- 2) Block secret file access (but allow .example / .sample / .template) ---
-if echo "$INPUT" | grep -qE '\.(env|pem|key)(\s|"|$|/)'; then
+# CI-01: the dotted-env variants (.env.local / .env.production — the REAL key
+# files) must be caught too. `(\.[A-Za-z0-9_]+)*` lets the match extend past
+# `.env` to `.env.local` etc. while a lone `.environment` (no dot after env)
+# stays un-blocked.
+if echo "$INPUT" | grep -qE '\.(env|pem|key)(\.[A-Za-z0-9_]+)*(\s|"|$|/)'; then
   if ! echo "$INPUT" | grep -qE '\.(env|pem|key)\.(example|sample|template)'; then
-    echo "BLOCK: Access to secret files (.env/.pem/.key) is not allowed. Use .env.example instead." >&2
+    echo "BLOCK: Access to secret files (.env/.env.local/.pem/.key) is not allowed. Use .env.example instead." >&2
     exit 2
   fi
 fi

--- a/scripts/hooks/test_secret_guards.sh
+++ b/scripts/hooks/test_secret_guards.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Regression tests for the Claude Code guard hooks (S0 security hardening,
+# findings CI-01 / CI-02 / CI-03).  Each case feeds a crafted CLAUDE_TOOL_INPUT
+# JSON to a hook and asserts its exit code / side effects.
+#
+# Run:  bash scripts/hooks/test_secret_guards.sh
+# Exit: 0 = all pass, 1 = some fail.
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAFETY="$HOOK_DIR/pre_tool_safety.sh"
+GUARD="$HOOK_DIR/pre_tool_secret_guard.sh"
+PYSYN="$HOOK_DIR/post_tool_py_syntax.sh"
+
+PASS=0
+FAIL=0
+
+# run_case <name> <expected_exit> <hook> <json_input>
+run_case() {
+  local name="$1" expected="$2" hook="$3" json="$4"
+  CLAUDE_TOOL_INPUT="$json" bash "$hook" >/dev/null 2>&1
+  local rc=$?
+  if [[ "$rc" == "$expected" ]]; then
+    PASS=$((PASS+1)); echo "  ✅ $name (exit $rc)"
+  else
+    FAIL=$((FAIL+1)); echo "  ❌ $name (got $rc, want $expected)"
+  fi
+}
+
+echo "── CI-01: pre_tool_safety.sh dotted-env (Bash) ──"
+run_case "block cat .env"            2 "$SAFETY" '{"command":"cat .env"}'
+run_case "block cat .env.local"      2 "$SAFETY" '{"command":"cat .env.local"}'
+run_case "block cat .env.production" 2 "$SAFETY" '{"command":"cat .env.production"}'
+run_case "allow cat .env.example"    0 "$SAFETY" '{"command":"cat .env.example"}'
+run_case "allow normal ls"           0 "$SAFETY" '{"command":"ls -la /tmp"}'
+run_case "still block rm -rf"        2 "$SAFETY" '{"command":"rm -rf /tmp/x"}'
+
+echo "── CI-02: pre_tool_secret_guard.sh used by Read ──"
+run_case "block read .env"           2 "$GUARD" '{"file_path":"/repo/.env"}'
+run_case "block read .env.local"     2 "$GUARD" '{"file_path":"/repo/.env.local"}'
+run_case "allow read .env.example"   0 "$GUARD" '{"file_path":"/repo/.env.example"}'
+run_case "allow read normal.py"      0 "$GUARD" '{"file_path":"/repo/normal.py"}'
+run_case "block read id_rsa.key"     2 "$GUARD" '{"file_path":"/repo/id_rsa.key"}'
+
+echo "── CI-03: post_tool_py_syntax.sh passes file_path via argv (no source interpolation) ──"
+# The dup-import check must NOT interpolate $FILE into python source
+# (`open('$FILE')`); it must receive the path as argv (sys.argv). A
+# single-quote in a filename would otherwise break out of the string literal.
+# Static guard: interpolation absent, argv present.
+if grep -qE "open\('\\\$FILE'\)" "$PYSYN"; then
+  FAIL=$((FAIL+1)); echo "  ❌ still interpolates open('\$FILE') into python -c"
+else
+  PASS=$((PASS+1)); echo "  ✅ no open('\$FILE') source interpolation"
+fi
+if grep -q "sys.argv" "$PYSYN"; then
+  PASS=$((PASS+1)); echo "  ✅ passes file_path via sys.argv"
+else
+  FAIL=$((FAIL+1)); echo "  ❌ does not use sys.argv for file_path"
+fi
+# Behavioural: a .py file whose name contains a single quote must still be
+# syntax-checked without the hook crashing (exit 0 on valid content).
+TMPD="$(mktemp -d)"
+QFILE="$TMPD/we'ird.py"
+printf 'x = 1\n' > "$QFILE"
+run_case "quote-in-name .py handled" 0 "$PYSYN" "{\"file_path\":\"$TMPD/we'ird.py\"}"
+rm -rf "$TMPD"
+
+echo "─────────────────────────────"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" == 0 ]]


### PR DESCRIPTION
S0 Security Quick Hardening 第一刀 — 最低風險、零 runtime/demo 影響，落地 [hardening plan](docs/security/2026-06-11-pawai-hardening-plan.md) §P3-2 的 CI/hook 子集。

## 修了什麼（findings ledger CI-01/02/03/05）

| Finding | Sev | 修法 |
|---------|-----|------|
| **CI-01** dotted-env regex 漏接 | 🟡 med | `pre_tool_safety.sh` Bash guard 改 `\.(env\|pem\|key)(\.[A-Za-z0-9_]+)*(\s\|"\|$\|/)` — 現在擋 `.env.local`/`.env.production`（真實 keys 檔），仍放行 `.env.example`、不誤擋 `.environment` |
| **CI-02** Read 工具無守衛 | 🟡 med | `settings.json` PreToolUse matcher `Edit\|Write` → `Edit\|Write\|Read`，重用 `pre_tool_secret_guard.sh`（其 `^\.env\.` 已正確）— 封掉「prompt injection 誘導 Read `.env.local` → 明文進 context」 |
| **CI-03** file_path code-injection | 🟡 med | `post_tool_py_syntax.sh` 的 dup-import 檢查改 `python3 - "$FILE"` argv heredoc — 移除 `open('$FILE')` 字串內插 |
| **CI-05** workflow 無 permissions | 🔵 low | 兩個 workflow 加 `permissions: contents: read`（無 job 寫 repo，auditor 已驗零破壞） |

## 紅綠驗證

新增 `scripts/hooks/test_secret_guards.sh`（14 assertions）：
- **先紅 4**：CI-01 dotted-env ×2 + CI-03 靜態（內插存在/無 argv）×2
- **修後 14/14 綠**，接進 fast-gate「Guard hook regression」step 防回歸
- **功能回歸保留**：`ok.py`→exit 0、`dup.py`→0+DUPLICATE 警告、`bad.py`→exit 2

## 範圍邊界

純 hook/CI 層。**不碰** runtime、demo 凍結參數（executive.yaml / start_full_demo_tmux.sh）、`.claude/skills/`。`.claude/settings.json` 是 hook 設定（非 skills，非禁改區）。

**未含**（風險/SHA 查找另開 PR）：CI-04 第三方 action pin SHA、CI-06 pip 版本 pin、CI-07 fork PR sandbox。

🤖 Generated with [Claude Code](https://claude.com/claude-code)