### PR TITLE
security(S0-2): gateway access-control mechanism — bind/token/CORS/Origin (env-gated, OFF by default)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -151,6 +151,9 @@ jobs:
           # is a pure dict module, no ROS imports).
           PYTHONPATH=pawai_contracts:object_perception pytest pawai_contracts/test/ \
             -v --tb=short
+          # Invocation 8 (S0 hardening, Tier 1): gateway auth primitives (ROS-free).
+          PYTHONPATH=pawai-studio/gateway pytest pawai-studio/gateway/test_auth.py \
+            -v --tb=short
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4

--- a/pawai-studio/gateway/auth.py
+++ b/pawai-studio/gateway/auth.py
@@ -1,0 +1,101 @@
+"""Gateway access-control primitives — ROS-free, unit-testable (S0 hardening).
+
+Addresses findings GW-01..05 / EXP-01/05 / SEC-02 / GW-04 (CSWSH): the Studio
+gateway today binds 0.0.0.0 with no auth and `CORS=*`, exposing every
+state-changing endpoint (skill_request / text_input / nav/*) to the whole
+LAN/tailnet and any browser origin.
+
+Design constraint — the 6/18 demo freeze: the live demo's browser reaches the
+gateway cross-host via a Tailscale IP, and the gateway is launched from a frozen
+skill script. So enforcement is **env-gated and OFF by default** — with no env
+set, behaviour is byte-identical to today (host 0.0.0.0, no token, CORS *).
+Operators turn protection on post-freeze by setting:
+
+    GATEWAY_HOST=127.0.0.1                  # or a specific iface; default 0.0.0.0
+    GATEWAY_AUTH_TOKEN=<shared-secret>      # unset = no token required
+    GATEWAY_ALLOWED_ORIGINS=http://a,http://b   # unset = allow any origin / CORS *
+
+This module is the single source of that policy; studio_gateway.py only wires it.
+"""
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+
+# Methods that never mutate state — never require a token. OPTIONS must stay
+# open or CORS preflight for browser POSTs breaks.
+_SAFE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
+
+
+@dataclass(frozen=True)
+class AuthConfig:
+    host: str
+    token: str                       # "" → auth disabled
+    allowed_origins: tuple[str, ...]  # () → origin/CORS check disabled
+
+    @property
+    def auth_enabled(self) -> bool:
+        return bool(self.token)
+
+    @property
+    def origin_check_enabled(self) -> bool:
+        return bool(self.allowed_origins)
+
+    @property
+    def cors_origins(self) -> list[str]:
+        """Value for CORSMiddleware allow_origins: the allowlist when set,
+        else the legacy wildcard (preserves current demo behaviour)."""
+        return list(self.allowed_origins) if self.allowed_origins else ["*"]
+
+
+def load_auth_config(env: dict | None = None) -> AuthConfig:
+    """Build AuthConfig from environment (defaults = today's open behaviour)."""
+    import os
+    e = os.environ if env is None else env
+    host = (e.get("GATEWAY_HOST") or "").strip() or "0.0.0.0"
+    token = (e.get("GATEWAY_AUTH_TOKEN") or "").strip()
+    raw = (e.get("GATEWAY_ALLOWED_ORIGINS") or "").strip()
+    origins = tuple(o.strip() for o in raw.split(",") if o.strip())
+    return AuthConfig(host=host, token=token, allowed_origins=origins)
+
+
+def requires_token(method: str) -> bool:
+    """True if this HTTP method mutates state and must carry a token (when
+    auth is enabled). GET/HEAD/OPTIONS are exempt."""
+    return method.upper() not in _SAFE_METHODS
+
+
+def token_ok(authorization_header: str | None, token: str) -> bool:
+    """Validate an `Authorization: Bearer <token>` header (constant-time).
+    token=="" means auth disabled → always True."""
+    if not token:
+        return True
+    if not authorization_header:
+        return False
+    parts = authorization_header.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return False
+    return secrets.compare_digest(parts[1].strip(), token)
+
+
+def token_query_ok(token_param: str | None, token: str) -> bool:
+    """Validate a WebSocket `?token=` query param (browsers can't set the
+    Authorization header on a WS handshake). token=="" → auth disabled."""
+    if not token:
+        return True
+    if not token_param:
+        return False
+    return secrets.compare_digest(token_param.strip(), token)
+
+
+def origin_ok(origin: str | None, allowed: tuple[str, ...]) -> bool:
+    """Validate a browser Origin header against the allowlist.
+    - allowed==() → check disabled, always True.
+    - origin is None → non-browser client (curl/probe sends no Origin) → allow;
+      browsers always send Origin on cross-origin requests, so this only ever
+      lets through same-host tooling, not a cross-site attacker page."""
+    if not allowed:
+        return True
+    if origin is None:
+        return True
+    return origin in allowed

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -26,7 +26,7 @@ import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 import rclpy
@@ -59,10 +59,16 @@ except ImportError:
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / ".." / "speech_processor" / "speech_processor"))
 from intent_classifier import IntentClassifier
 
+# Access-control policy (S0 hardening) — pure module, env-gated, OFF by default.
+from auth import (
+    load_auth_config, requires_token, token_ok, token_query_ok, origin_ok,
+)
+
 # ── Config ───────────────────────────────────────────────────────
 import os
 
 PORT = int(os.getenv("GATEWAY_PORT", "8080"))
+AUTH = load_auth_config()
 # E.Mac/School pre-stage 2026-05-11: ASR_URL 改 env override 避免學校 Mac → Jetson
 # 時 127.0.0.1 指 Mac 自己。沿用 PAWAI_ENABLE_S2TWP（line 57）env-aware pattern。
 # 主環變 PAWAI_ASR_URL，向下相容 ASR_URL。
@@ -875,14 +881,43 @@ app = FastAPI(title="PawAI Studio Gateway", lifespan=lifespan)
 # Gateway at Jetson IP (192.168.0.222:8080). WebSocket bypasses CORS so
 # /ws/* worked, but /api/text_input was blocked by browser preflight.
 # 5/7 night fix per Roy's "Brain 文字通道未連線" report.
-# Demo internal network — allow_origins=["*"] is acceptable risk.
+# S0 hardening: allow_origins is the GATEWAY_ALLOWED_ORIGINS allowlist when set,
+# else the legacy ["*"] (unchanged demo behaviour). See auth.py.
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=AUTH.cors_origins,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# ── Access control (S0 hardening, env-gated — OFF unless env set) ──────────
+@app.middleware("http")
+async def _access_control(request, call_next):
+    """Browser-Origin allowlist + Bearer token on state-changing methods.
+    Both checks are no-ops unless GATEWAY_ALLOWED_ORIGINS / GATEWAY_AUTH_TOKEN
+    are set, so default behaviour is byte-identical to the pre-hardening gateway.
+    OPTIONS (CORS preflight) and GET/HEAD are never token-gated."""
+    if AUTH.origin_check_enabled:
+        if not origin_ok(request.headers.get("origin"), AUTH.allowed_origins):
+            return JSONResponse({"error": "origin not allowed"}, status_code=403)
+    if AUTH.auth_enabled and requires_token(request.method):
+        if not token_ok(request.headers.get("authorization"), AUTH.token):
+            return JSONResponse({"error": "unauthorized"}, status_code=401)
+    return await call_next(request)
+
+
+async def _ws_authorized(websocket) -> bool:
+    """WebSocket-handshake guard mirroring _access_control: Origin allowlist +
+    `?token=` query param. No-op unless the matching env is set."""
+    if AUTH.origin_check_enabled:
+        if not origin_ok(websocket.headers.get("origin"), AUTH.allowed_origins):
+            return False
+    if AUTH.auth_enabled:
+        if not token_query_ok(websocket.query_params.get("token"), AUTH.token):
+            return False
+    return True
 
 
 # ── Static & Health ─────────────────────────────────────────────
@@ -1179,6 +1214,9 @@ async def get_nav_control():
 @app.websocket("/ws/events")
 async def ws_events(ws: WebSocket):
     """Broadcast ROS2 perception events to all connected browsers."""
+    if not await _ws_authorized(ws):
+        await ws.close(code=1008)
+        return
     await ws_manager.connect(ws)
     try:
         while True:
@@ -1192,6 +1230,9 @@ async def ws_events(ws: WebSocket):
 @app.websocket("/ws/video/{source}")
 async def ws_video(ws: WebSocket, source: str):
     """Stream JPEG frames for a specific video source."""
+    if not await _ws_authorized(ws):
+        await ws.close(code=1008)
+        return
     if not _VIDEO_AVAILABLE or video_clients is None:
         await ws.close(code=4003, reason="Video streaming not available")
         return
@@ -1212,6 +1253,9 @@ async def ws_video(ws: WebSocket, source: str):
 @app.websocket("/ws/text")
 async def ws_text(ws: WebSocket):
     """Text-only mode: receive text, classify intent, publish to ROS2."""
+    if not await _ws_authorized(ws):
+        await ws.close(code=1008)
+        return
     await ws.accept()
     try:
         while True:
@@ -1259,6 +1303,9 @@ async def ws_text(ws: WebSocket):
 
 @app.websocket("/ws/speech")
 async def ws_speech(ws: WebSocket):
+    if not await _ws_authorized(ws):
+        await ws.close(code=1008)
+        return
     await ws.accept()
     try:
         while True:
@@ -1333,4 +1380,17 @@ async def ws_speech(ws: WebSocket):
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=PORT, ws="wsproto")
+    # S0 hardening: bind host from GATEWAY_HOST (default 0.0.0.0 — unchanged).
+    # Loud startup banner so an unauthenticated, all-interfaces gateway is never
+    # a silent default (findings GW-01/EXP-01).
+    if not AUTH.auth_enabled:
+        print(
+            f"[gateway] ⚠ SECURITY: no GATEWAY_AUTH_TOKEN — state-changing "
+            f"endpoints are UNAUTHENTICATED (host={AUTH.host}). Set "
+            f"GATEWAY_AUTH_TOKEN + GATEWAY_ALLOWED_ORIGINS to lock down.",
+            flush=True,
+        )
+    else:
+        print(f"[gateway] auth ON (token required on POST, host={AUTH.host}, "
+              f"origins={list(AUTH.allowed_origins) or 'any'})", flush=True)
+    uvicorn.run(app, host=AUTH.host, port=PORT, ws="wsproto")

--- a/pawai-studio/gateway/test_auth.py
+++ b/pawai-studio/gateway/test_auth.py
@@ -1,0 +1,114 @@
+"""Unit tests for gateway access-control primitives (S0 hardening).
+
+ROS-free: imports only auth.py, runs anywhere (CI fast-gate, WSL).
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from auth import (  # noqa: E402
+    AuthConfig,
+    load_auth_config,
+    origin_ok,
+    requires_token,
+    token_ok,
+    token_query_ok,
+)
+
+TOKEN = "s3cret-shared"
+
+
+# ── load_auth_config: defaults preserve today's open behaviour ──────────────
+def test_defaults_are_open():
+    cfg = load_auth_config({})
+    assert cfg.host == "0.0.0.0"
+    assert cfg.token == ""
+    assert cfg.allowed_origins == ()
+    assert cfg.auth_enabled is False
+    assert cfg.origin_check_enabled is False
+    assert cfg.cors_origins == ["*"]
+
+
+def test_env_overrides():
+    cfg = load_auth_config({
+        "GATEWAY_HOST": "127.0.0.1",
+        "GATEWAY_AUTH_TOKEN": TOKEN,
+        "GATEWAY_ALLOWED_ORIGINS": "http://localhost:3001, http://100.83.109.89:3001 ",
+    })
+    assert cfg.host == "127.0.0.1"
+    assert cfg.auth_enabled is True
+    assert cfg.origin_check_enabled is True
+    assert cfg.allowed_origins == ("http://localhost:3001", "http://100.83.109.89:3001")
+    assert cfg.cors_origins == ["http://localhost:3001", "http://100.83.109.89:3001"]
+
+
+def test_blank_env_values_treated_as_unset():
+    cfg = load_auth_config({"GATEWAY_HOST": "  ", "GATEWAY_AUTH_TOKEN": "  ",
+                            "GATEWAY_ALLOWED_ORIGINS": " , ,"})
+    assert cfg.host == "0.0.0.0"
+    assert cfg.auth_enabled is False
+    assert cfg.allowed_origins == ()
+
+
+# ── requires_token: only state-changing methods ─────────────────────────────
+def test_requires_token_by_method():
+    assert requires_token("POST") is True
+    assert requires_token("put") is True
+    assert requires_token("DELETE") is True
+    assert requires_token("PATCH") is True
+    assert requires_token("GET") is False
+    assert requires_token("HEAD") is False
+    assert requires_token("OPTIONS") is False   # CORS preflight must pass
+
+
+# ── token_ok: Bearer header validation ──────────────────────────────────────
+def test_token_disabled_allows_everything():
+    assert token_ok(None, "") is True
+    assert token_ok("garbage", "") is True
+
+
+def test_token_valid_bearer():
+    assert token_ok(f"Bearer {TOKEN}", TOKEN) is True
+    assert token_ok(f"bearer {TOKEN}", TOKEN) is True   # case-insensitive scheme
+
+
+def test_token_rejects_bad():
+    assert token_ok(None, TOKEN) is False
+    assert token_ok("", TOKEN) is False
+    assert token_ok(f"Bearer {TOKEN}x", TOKEN) is False
+    assert token_ok(TOKEN, TOKEN) is False              # missing "Bearer "
+    assert token_ok(f"Basic {TOKEN}", TOKEN) is False
+    assert token_ok("Bearer", TOKEN) is False           # no value
+
+
+# ── token_query_ok: WebSocket ?token= ───────────────────────────────────────
+def test_token_query():
+    assert token_query_ok(None, "") is True             # disabled
+    assert token_query_ok(TOKEN, TOKEN) is True
+    assert token_query_ok(" " + TOKEN + " ", TOKEN) is True
+    assert token_query_ok(None, TOKEN) is False
+    assert token_query_ok("wrong", TOKEN) is False
+
+
+# ── origin_ok: browser Origin allowlist ─────────────────────────────────────
+def test_origin_disabled_allows_any():
+    assert origin_ok("http://evil.example", ()) is True
+    assert origin_ok(None, ()) is True
+
+
+def test_origin_allowlist():
+    allowed = ("http://localhost:3001", "http://100.83.109.89:3001")
+    assert origin_ok("http://localhost:3001", allowed) is True
+    assert origin_ok("http://100.83.109.89:3001", allowed) is True
+    assert origin_ok("http://evil.example", allowed) is False
+    assert origin_ok(None, allowed) is True             # curl/probe (no Origin) allowed
+
+
+def test_authconfig_is_frozen():
+    cfg = AuthConfig(host="0.0.0.0", token="", allowed_origins=())
+    try:
+        cfg.host = "x"  # type: ignore[misc]
+    except Exception:
+        return
+    raise AssertionError("AuthConfig should be immutable")


### PR DESCRIPTION
S0 Security Quick Hardening 第二刀 — 落地 [hardening plan](docs/security/2026-06-11-pawai-hardening-plan.md) §P0-1（findings GW-01..05 / EXP-01/05 / SEC-02 / GW-04 CSWSH）的**機制層**。

## 為什麼是「機制層、預設全關」而非 secure-by-default

調查確認 live demo 的瀏覽器**跨 host 走 Tailscale IP** 連 gateway（WSL browser → Jetson:8080），且 gateway 由**凍結的 `brain-studio-lane/start.sh`** 啟動。在 6/18 demo 凍結期內，若直接 `bind 127.0.0.1` 或強制 token 會**即刻打斷 demo**。

故設計為 **env-gated、預設全關 = 與現行 byte-identical**：env 全未設時 `host=0.0.0.0` / 不檢 token / 不檢 origin / `CORS=*`，零 demo 影響。Roy 可在 6/18 後設兩個 env + 接前端即開啟完整防護。

## 改了什麼

- **新 `pawai-studio/gateway/auth.py`**（ROS-free，pawai_contracts 風格單一真相）：`AuthConfig`/`load_auth_config`、`token_ok`（Bearer，`secrets.compare_digest` constant-time）、`token_query_ok`（WS `?token=`）、`origin_ok`、`requires_token`
- **`studio_gateway.py` 接線**：
  - uvicorn `host` ← `GATEWAY_HOST`（預設 `0.0.0.0` 不變）
  - HTTP middleware：Origin allowlist（`GATEWAY_ALLOWED_ORIGINS`）+ Bearer token（`GATEWAY_AUTH_TOKEN`），**僅** state-changing method；GET/HEAD/**OPTIONS 永不擋**（CORS preflight 不破）
  - 4 個 WS handler 前置 `_ws_authorized`（Origin + `?token=`）
  - CORS `allow_origins` ← allowlist（未設則維持 `["*"]`）
  - 啟動 banner：未設 token 時大聲警告 `UNAUTHENTICATED`

## 紅綠 + 真機驗證

- **`test_auth.py` 11 tests 綠**（blank-env、OPTIONS 豁免、constant-time、frozen、allowlist）→ 接進 fast-gate Invocation 8
- **真機 Jetson 跑實際 rclpy gateway 雙模式驗證**：
  | 情境 | 結果 |
  |------|------|
  | default-off: health GET | **200** |
  | default-off: POST 無 token | **422**（到 handler = 開放，body 驗證）+ banner `UNAUTHENTICATED` |
  | auth-on: probe（無 Origin）health | **200**（probe 不受影響） |
  | auth-on: bad-origin health | **403** |
  | auth-on: good-origin health | **200** |
  | auth-on: POST 無/錯 token | **401 / 401** |
  | auth-on: POST 對 token | **422**（過 auth 到 handler）+ banner `auth ON` |

## 範圍邊界

不碰 demo 凍結參數、不碰 `.claude/skills/`。

**未含（post-6/18 後續 PR，需協調前端 + 解凍 start.sh）**：① secure-default 翻轉（bind 127.0.0.1 + 強制 token）② 前端 13 endpoint + 4 WS 帶 token header/query ③ healthcheck/CLI probe 帶 token ④ `start.sh` 注入 token。這些一起做才能把 demo 從「開放」安全切到「強制認證」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)