### PR TITLE
feat(ism): Phase 0 — pure interaction_state module + tests (no runtime wiring)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -121,6 +121,7 @@ jobs:
             interaction_executive/test/test_attention_machine.py \
             interaction_executive/test/test_pending_confirm.py \
             interaction_executive/test/test_perception_router.py \
+            interaction_executive/test/test_interaction_state.py \
             interaction_executive/test/test_skill_contract.py \
             interaction_executive/test/test_skill_contract_demo_fields.py \
             interaction_executive/test/test_skill_queue.py \

--- a/docs/superpowers/plans/2026-06-11-plan-ism-interaction-state-machine.md
+++ b/docs/superpowers/plans/2026-06-11-plan-ism-interaction-state-machine.md
@@ -197,7 +197,9 @@ confirm 在飛時，**每個進來的 candidate 都要有明確去向**（這是
 
 ---
 
-## 5. Phase 0：純 ISM 核心（無接線、零行為變更）— 可立即執行
+## 5. Phase 0：純 ISM 核心（無接線、零行為變更）— ✅ 已實作（PR #159）
+
+> **狀態（2026-06-11）**：Phase 0 已實作並 merge — `interaction_executive/interaction_executive/interaction_state.py` + `test/test_interaction_state.py`（33 測試）。實作經 Linus 風格終審補強了下列本節初稿未涵蓋的邊界（以 repo 內程式為準）：① propose→EXECUTING 給 grace deadline（confirm_ok 後 skill 永不 STARTED 不死鎖）② TTS_ACK start 只從 IDLE/LISTENING 讓位（不洗掉 EXECUTING）③ 空 plan_id terminal 不誤觸 ④ ERROR_RECOVERY 改兩步（watchdog→ERROR_RECOVERY→IDLE，狀態真的會進入）⑤ SAFETY priority STARTED→SAFETY_HOLD。下列 Task 0.x 為原始設計步驟（歷史；實作以 repo 為準）。
 
 > 紀律同 Plan C/D 抽取：純模組、逐字對照現行語義、完整單測、**brain_node 尚未 import**。
 

--- a/interaction_executive/interaction_executive/interaction_state.py
+++ b/interaction_executive/interaction_executive/interaction_state.py
@@ -1,0 +1,243 @@
+"""Interaction State Machine — ROS-free core (Plan ISM Phase 0, master plan §7).
+
+The PawAI Brain today is an *implicit* state machine: five perception callbacks
+each race for the TTS/plan channel, gated by a scatter of demo flags + cooldowns
++ active_plan + pending_confirm checks (19 separate `_suppressed` early-returns in
+brain_node.py). This module is the *explicit* replacement core.
+
+Phase 0 scope (this file): pure types + policy + machine ONLY. It is NOT imported
+by brain_node yet — no runtime wiring, no behaviour change. Later phases run it in
+shadow mode, then cut brain_node's gates over to it one family at a time behind an
+`ism_enabled` flag. See docs/superpowers/plans/2026-06-11-plan-ism-interaction-state-machine.md.
+
+Design rules honoured here (master plan §7):
+- §7.1 perception events only ever produce a `Candidate`; they never drive a
+  transition directly (the four transition drivers are skill_result lifecycle,
+  confirm result, TTS ack, operator command — plus a safety override).
+- §7.2 priority iron law: safety > explicit command > confirm > spontaneous social.
+- §7.3 every active interaction carries a watchdog deadline → ERROR_RECOVERY on
+  expiry (kills the 6/9 "stranger plan deadlocks everything" failure).
+- §7.4 pending-confirm is not a black hole: every candidate gets an explicit
+  verdict (ACCEPT / PREEMPT / QUEUE / SUPPRESS-with-reason), never a silent drop.
+
+No rclpy, no I/O, no time.time() — `now` is always injected so the machine is
+deterministic and unit-testable.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, IntEnum
+from typing import Any
+
+
+class InteractionState(str, Enum):
+    IDLE = "idle"                        # 無互動；接受任何候選
+    LISTENING = "listening"              # 正在聽語音（chat_buffer 在飛）
+    SPEAKING = "speaking"                # 正在播 TTS（社交候選讓路）
+    CONFIRM_PENDING = "confirm_pending"  # 等 OK 二確；只認 OK/cancel/timeout
+    EXECUTING = "executing"              # 正在執行 skill/sequence（感知只記錄）
+    ALERT_ACTIVE = "alert_active"        # 高優先警示播報中（stranger/fallen）
+    SAFETY_HOLD = "safety_hold"          # 硬安全停止保持（stop/emergency/obstacle）
+    ERROR_RECOVERY = "error_recovery"    # watchdog/STEP_FAILED 後恢復 → 回 IDLE
+
+
+class Priority(IntEnum):
+    """Smaller = higher priority (§3.4 iron law)."""
+    SAFETY = 0
+    ALERT = 1
+    EXPLICIT = 2
+    CONFIRM = 3
+    SOCIAL = 4
+
+
+class Verdict(str, Enum):
+    ACCEPT = "accept"        # 進狀態 / emit
+    SUPPRESS = "suppress"    # 不做，附 reason trace（非黑洞）
+    QUEUE = "queue"          # 短暫保留（SPEAKING 中的社交）
+    PREEMPT = "preempt"      # 搶占當前 active interaction
+
+
+class TriggerKind(str, Enum):
+    """The four legitimate transition drivers (§3.2) plus the safety override."""
+    SKILL_RESULT = "skill_result"
+    CONFIRM_RESULT = "confirm_result"
+    TTS_ACK = "tts_ack"
+    OPERATOR = "operator"
+    SAFETY = "safety"
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A candidate intent produced by perception/speech/gesture.
+
+    `source` is advisory metadata, NOT an authorization (§3.3 source-trust): a
+    perception event cannot self-assert `source=studio_button` to bypass a
+    confirmation. Only the policy, against the current state, decides.
+    """
+    kind: str                  # greet | object_remark | sit_along | gesture_cmd | chat | alert | stop ...
+    priority: Priority
+    source: str                # face | object | gesture | pose | speech | studio | operator
+    skill: str = ""            # skill to emit if ACCEPTed
+    args: dict[str, Any] = field(default_factory=dict)
+    requires_confirmation: bool = False
+    decision_id: str = ""
+    explicit: bool = False     # True = trusted explicit command (§3.3)
+
+
+@dataclass(frozen=True)
+class TransitionSignal:
+    """A non-candidate state driver (§3.2): skill lifecycle / confirm result /
+    TTS ack / operator command."""
+    trigger: TriggerKind
+    detail: dict[str, Any] = field(default_factory=dict)
+    decision_id: str = ""
+
+
+@dataclass(frozen=True)
+class Decision:
+    verdict: Verdict
+    reason: str                                  # gate:executing / preempt:safety / accept ...
+    next_state: InteractionState | None = None   # None = no transition
+    emit_skill: str = ""
+    emit_args: dict[str, Any] = field(default_factory=dict)
+
+
+# Per-state allow-set: which candidate priorities may be admitted / pre-empt the
+# current state (§3.4). A priority NOT in the set is suppressed-with-reason (or
+# queued, for social-during-speaking). This single table replaces the 19 scattered
+# `_suppressed` early-returns in brain_node.py.
+_S = InteractionState
+_P = Priority
+_PREEMPTIBLE_BY: dict[InteractionState, set[Priority]] = {
+    _S.IDLE:            {_P.SAFETY, _P.ALERT, _P.EXPLICIT, _P.CONFIRM, _P.SOCIAL},
+    _S.LISTENING:       {_P.SAFETY, _P.ALERT, _P.EXPLICIT},
+    _S.SPEAKING:        {_P.SAFETY, _P.ALERT, _P.EXPLICIT},
+    _S.CONFIRM_PENDING: {_P.SAFETY, _P.ALERT, _P.EXPLICIT, _P.CONFIRM},
+    _S.EXECUTING:       {_P.SAFETY, _P.ALERT},   # explicit-stop handled as SAFETY candidate
+    _S.ALERT_ACTIVE:    {_P.SAFETY},
+    _S.SAFETY_HOLD:     {_P.SAFETY},             # only safety-clear / operator leaves
+    _S.ERROR_RECOVERY:  {_P.SAFETY},
+}
+# Safety/alert candidates route to their dedicated states when admitted.
+_PRIORITY_TARGET: dict[Priority, InteractionState] = {
+    _P.SAFETY: _S.SAFETY_HOLD,
+    _P.ALERT: _S.ALERT_ACTIVE,
+}
+
+# skill_result terminal statuses that clear EXECUTING/ALERT_ACTIVE (mirrors
+# brain_node._TERMINAL_RESULT_STATUSES).
+_TERMINAL = frozenset({"COMPLETED", "ABORTED", "BLOCKED_BY_SAFETY", "STEP_FAILED"})
+
+# How long a CONFIRM_PENDING waits for OK before the watchdog gives up (§3.6;
+# mirrors pending_confirm.py's existing 30s).
+CONFIRM_TIMEOUT_S = 30.0
+
+
+class InteractionPolicy:
+    """Pure, stateless arbitration: given the current state and a candidate,
+    return a Decision. No side effects — the machine applies it."""
+
+    @staticmethod
+    def evaluate(state: InteractionState, c: Candidate) -> Decision:
+        allowed = _PREEMPTIBLE_BY[state]
+
+        # CONFIRM_PENDING only resolves via a CONFIRM-priority candidate (§3.5).
+        if state is _S.CONFIRM_PENDING and c.priority is _P.CONFIRM:
+            if c.kind == "confirm_ok":
+                return Decision(Verdict.ACCEPT, "confirm_ok", _S.EXECUTING, c.skill, c.args)
+            return Decision(Verdict.ACCEPT, "confirm_cancel", _S.IDLE)
+
+        # Not admitted by this state → suppress (or queue social during speaking).
+        if c.priority not in allowed:
+            verb = Verdict.QUEUE if (state is _S.SPEAKING and c.priority is _P.SOCIAL) else Verdict.SUPPRESS
+            return Decision(verb, f"gate:{state.value}")
+
+        # Safety / alert → dedicated pre-empt target.
+        if c.priority in _PRIORITY_TARGET:
+            return Decision(Verdict.PREEMPT, f"preempt:{c.priority.name.lower()}",
+                            _PRIORITY_TARGET[c.priority], c.skill, c.args)
+
+        # A skill needing confirmation always routes through CONFIRM_PENDING —
+        # never bypassed by a self-asserted source (§3.3 / security P2-1).
+        if c.requires_confirmation:
+            return Decision(Verdict.ACCEPT, "confirm_request", _S.CONFIRM_PENDING, c.skill, c.args)
+
+        # An explicit command supersedes an in-flight confirm (§3.5).
+        if state is _S.CONFIRM_PENDING and c.explicit:
+            return Decision(Verdict.PREEMPT, "confirm_superseded",
+                            _S.EXECUTING if c.skill else _S.LISTENING, c.skill, c.args)
+
+        # Plain accept: explicit-with-skill executes; everything else speaks.
+        target = _S.EXECUTING if (c.explicit and c.skill) else _S.SPEAKING
+        return Decision(Verdict.ACCEPT, "accept", target, c.skill, c.args)
+
+
+class InteractionStateMachine:
+    """Holds the current interaction state + watchdog deadline + a short history.
+
+    Two entry points mirror the design: `propose(candidate)` for perception/intent
+    candidates (arbitrated by InteractionPolicy), and `apply_signal(signal)` for the
+    four transition drivers. `tick(now)` enforces the watchdog. All `now` values are
+    injected — the machine never reads the clock itself.
+    """
+
+    def __init__(self, now: float = 0.0, state: InteractionState = InteractionState.IDLE,
+                 deadline: float | None = None) -> None:
+        self.state = state
+        self._deadline = deadline
+        self._active_plan_id = ""
+        # (ts, from_state, to_state, trigger) — bounded ring for trace/diagnostics.
+        self.history: list[tuple[float, str, str, str]] = []
+
+    @property
+    def deadline(self) -> float | None:
+        return self._deadline
+
+    def propose(self, c: Candidate, now: float) -> Decision:
+        """Arbitrate a candidate against the current state; apply any transition."""
+        d = InteractionPolicy.evaluate(self.state, c)
+        if d.next_state is not None and d.verdict in (Verdict.ACCEPT, Verdict.PREEMPT):
+            deadline = now + CONFIRM_TIMEOUT_S if d.next_state is _S.CONFIRM_PENDING else None
+            self._transition(self.state, d.next_state, f"candidate:{c.kind}", now, deadline=deadline)
+        return d
+
+    def apply_signal(self, sig: TransitionSignal, now: float = 0.0) -> None:
+        """Apply a non-candidate transition driver (§3.2)."""
+        if sig.trigger is TriggerKind.SKILL_RESULT:
+            status = sig.detail.get("status", "")
+            if status == "STARTED":
+                prio = int(sig.detail.get("priority_class", int(Priority.SOCIAL)))
+                nxt = _S.ALERT_ACTIVE if prio == int(Priority.ALERT) else _S.EXECUTING
+                self._active_plan_id = sig.detail.get("plan_id", "")
+                t = float(sig.detail.get("timeout_s", 0) or 0)
+                self._transition(self.state, nxt, "skill_started", now,
+                                 deadline=(now + t) if t > 0 else None)
+            elif status in _TERMINAL and sig.detail.get("plan_id", "") == self._active_plan_id:
+                self._active_plan_id = ""
+                self._transition(self.state, _S.IDLE, f"skill_{status.lower()}", now)
+        elif sig.trigger is TriggerKind.TTS_ACK:
+            if sig.detail.get("event") == "start":
+                self._transition(self.state, _S.SPEAKING, "tts_start", now)
+            elif self.state is _S.SPEAKING:
+                self._transition(self.state, _S.IDLE, "tts_end", now)
+        elif sig.trigger is TriggerKind.OPERATOR and sig.detail.get("op") == "reset":
+            self._active_plan_id = ""
+            self._transition(self.state, _S.IDLE, "operator_reset", now)
+
+    def tick(self, now: float) -> Decision | None:
+        """Watchdog (§3.6): if the current interaction's deadline has passed, drop
+        to ERROR_RECOVERY → IDLE and return a watchdog Decision for tracing."""
+        if self._deadline is not None and now >= self._deadline:
+            stuck = self.state
+            self._active_plan_id = ""
+            self._transition(stuck, _S.IDLE, "watchdog", now)
+            return Decision(Verdict.PREEMPT, f"watchdog_timeout:{stuck.value}", _S.IDLE)
+        return None
+
+    def _transition(self, frm: InteractionState, to: InteractionState, trigger: str,
+                    now: float, deadline: float | None = None) -> None:
+        self.state = to
+        self._deadline = deadline
+        self.history.append((now, frm.value, to.value, trigger))
+        if len(self.history) > 64:
+            self.history = self.history[-64:]

--- a/interaction_executive/interaction_executive/interaction_state.py
+++ b/interaction_executive/interaction_executive/interaction_state.py
@@ -157,12 +157,16 @@ class InteractionPolicy:
             return Decision(Verdict.PREEMPT, f"preempt:{c.priority.name.lower()}",
                             _PRIORITY_TARGET[c.priority], c.skill, c.args)
 
-        # A skill needing confirmation always routes through CONFIRM_PENDING —
-        # never bypassed by a self-asserted source (§3.3 / security P2-1).
+        # A skill needing confirmation ALWAYS routes through CONFIRM_PENDING — this
+        # check is deliberately BEFORE the explicit-supersede below: an `explicit`
+        # command that itself requires confirmation must still confirm, never skip
+        # straight to EXECUTING just because it came from a trusted channel
+        # (§3.3 / security P2-1 — confirmation is not bypassable by source).
         if c.requires_confirmation:
             return Decision(Verdict.ACCEPT, "confirm_request", _S.CONFIRM_PENDING, c.skill, c.args)
 
-        # An explicit command supersedes an in-flight confirm (§3.5).
+        # A NON-confirming explicit command supersedes an in-flight confirm (§3.5):
+        # cancel the pending confirm and process the new command.
         if state is _S.CONFIRM_PENDING and c.explicit:
             return Decision(Verdict.PREEMPT, "confirm_superseded",
                             _S.EXECUTING if c.skill else _S.LISTENING, c.skill, c.args)
@@ -197,7 +201,16 @@ class InteractionStateMachine:
         """Arbitrate a candidate against the current state; apply any transition."""
         d = InteractionPolicy.evaluate(self.state, c)
         if d.next_state is not None and d.verdict in (Verdict.ACCEPT, Verdict.PREEMPT):
-            deadline = now + CONFIRM_TIMEOUT_S if d.next_state is _S.CONFIRM_PENDING else None
+            # CONFIRM_PENDING waits 30s for OK. EXECUTING reached via propose
+            # (confirm_ok / explicit-with-skill) is OPTIMISTIC: the authoritative
+            # skill watchdog arrives at skill_result STARTED (apply_signal overrides
+            # this deadline). Give it a grace deadline anyway so a skill that is
+            # accepted but never launches can't deadlock the machine — that is the
+            # exact 6/9 failure class this machine exists to prevent (§3.6).
+            if d.next_state in (_S.CONFIRM_PENDING, _S.EXECUTING):
+                deadline = now + CONFIRM_TIMEOUT_S
+            else:
+                deadline = None
             self._transition(self.state, d.next_state, f"candidate:{c.kind}", now, deadline=deadline)
         return d
 
@@ -207,17 +220,29 @@ class InteractionStateMachine:
             status = sig.detail.get("status", "")
             if status == "STARTED":
                 prio = int(sig.detail.get("priority_class", int(Priority.SOCIAL)))
-                nxt = _S.ALERT_ACTIVE if prio == int(Priority.ALERT) else _S.EXECUTING
+                if prio == int(Priority.SAFETY):
+                    nxt = _S.SAFETY_HOLD
+                elif prio == int(Priority.ALERT):
+                    nxt = _S.ALERT_ACTIVE
+                else:
+                    nxt = _S.EXECUTING
                 self._active_plan_id = sig.detail.get("plan_id", "")
                 t = float(sig.detail.get("timeout_s", 0) or 0)
                 self._transition(self.state, nxt, "skill_started", now,
                                  deadline=(now + t) if t > 0 else None)
-            elif status in _TERMINAL and sig.detail.get("plan_id", "") == self._active_plan_id:
+            # Terminal only clears when there IS an active plan AND its id matches —
+            # an empty plan_id must never sentinel-match a freshly-reset machine.
+            elif status in _TERMINAL and self._active_plan_id \
+                    and sig.detail.get("plan_id", "") == self._active_plan_id:
                 self._active_plan_id = ""
                 self._transition(self.state, _S.IDLE, f"skill_{status.lower()}", now)
         elif sig.trigger is TriggerKind.TTS_ACK:
             if sig.detail.get("event") == "start":
-                self._transition(self.state, _S.SPEAKING, "tts_start", now)
+                # TTS while EXECUTING / ALERT_ACTIVE / CONFIRM_PENDING is that
+                # interaction's own speech — do NOT clobber it (would orphan the
+                # active plan + watchdog). Only IDLE/LISTENING yield to SPEAKING.
+                if self.state in (_S.IDLE, _S.LISTENING):
+                    self._transition(self.state, _S.SPEAKING, "tts_start", now)
             elif self.state is _S.SPEAKING:
                 self._transition(self.state, _S.IDLE, "tts_end", now)
         elif sig.trigger is TriggerKind.OPERATOR and sig.detail.get("op") == "reset":
@@ -225,13 +250,17 @@ class InteractionStateMachine:
             self._transition(self.state, _S.IDLE, "operator_reset", now)
 
     def tick(self, now: float) -> Decision | None:
-        """Watchdog (§3.6): if the current interaction's deadline has passed, drop
-        to ERROR_RECOVERY → IDLE and return a watchdog Decision for tracing."""
+        """Watchdog (§3.6), two-step so ERROR_RECOVERY is a real, trace-observable
+        state (not a dead enum value): an expired interaction first drops to
+        ERROR_RECOVERY; the next tick returns it to IDLE."""
+        if self.state is _S.ERROR_RECOVERY:
+            self._transition(self.state, _S.IDLE, "recovery_complete", now)
+            return None
         if self._deadline is not None and now >= self._deadline:
             stuck = self.state
             self._active_plan_id = ""
-            self._transition(stuck, _S.IDLE, "watchdog", now)
-            return Decision(Verdict.PREEMPT, f"watchdog_timeout:{stuck.value}", _S.IDLE)
+            self._transition(stuck, _S.ERROR_RECOVERY, "watchdog", now)
+            return Decision(Verdict.PREEMPT, f"watchdog_timeout:{stuck.value}", _S.ERROR_RECOVERY)
         return None
 
     def _transition(self, frm: InteractionState, to: InteractionState, trigger: str,

--- a/interaction_executive/test/test_interaction_state.py
+++ b/interaction_executive/test/test_interaction_state.py
@@ -137,13 +137,16 @@ def test_terminal_for_wrong_plan_id_ignored():
     assert m.state == InteractionState.EXECUTING
 
 
-def test_watchdog_timeout_to_recovery():
+def test_watchdog_timeout_two_step_recovery():
+    # §3.6: expiry → ERROR_RECOVERY (observable) → next tick → IDLE.
     m = InteractionStateMachine(now=0.0)
     m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
                                                      "timeout_s": 5.0}))
     d = m.tick(now=6.0)
-    assert m.state == InteractionState.IDLE
-    assert d is not None and "watchdog_timeout:executing" in d.reason
+    assert m.state == InteractionState.ERROR_RECOVERY
+    assert d is not None and d.next_state == InteractionState.ERROR_RECOVERY
+    assert "watchdog_timeout:executing" in d.reason
+    assert m.tick(now=6.1) is None and m.state == InteractionState.IDLE
 
 
 def test_watchdog_no_premature_fire():
@@ -167,8 +170,66 @@ def test_confirm_timeout_30s():
     m.propose(Candidate(kind="gesture_cmd", priority=P.SOCIAL, source="gesture",
                         skill="wiggle", requires_confirmation=True), now=0.0)
     assert m.state == InteractionState.CONFIRM_PENDING and m.deadline == 30.0
-    m.tick(now=31.0)
+    m.tick(now=31.0)                      # → ERROR_RECOVERY
+    assert m.state == InteractionState.ERROR_RECOVERY
+    m.tick(now=31.1)                      # → IDLE
     assert m.state == InteractionState.IDLE
+
+
+def test_executing_via_confirm_ok_has_watchdog():
+    # BUG fix: EXECUTING reached via confirm_ok must carry a grace deadline so a
+    # skill that is accepted but never launches can't deadlock (the 6/9 class).
+    m = InteractionStateMachine(now=0.0, state=InteractionState.CONFIRM_PENDING, deadline=30.0)
+    m.propose(Candidate(kind="confirm_ok", priority=P.CONFIRM, source="gesture",
+                        skill="wiggle"), now=1.0)
+    assert m.state == InteractionState.EXECUTING
+    assert m.deadline is not None                       # not a deadlock
+    m.tick(now=1.0 + 30.0 + 0.1)                         # never got STARTED → recover
+    assert m.state == InteractionState.ERROR_RECOVERY
+
+
+def test_tts_start_during_executing_does_not_clobber():
+    # BUG fix: a skill speaking mid-execution must not lose its state/plan/watchdog.
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
+                                                     "timeout_s": 10.0}))
+    dl = m.deadline
+    m.apply_signal(TransitionSignal(T.TTS_ACK, {"event": "start"}))
+    assert m.state == InteractionState.EXECUTING and m.deadline == dl
+    # the executing plan can still be terminated normally
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "COMPLETED", "plan_id": "p1"}))
+    assert m.state == InteractionState.IDLE
+
+
+def test_safety_priority_skill_started_holds():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED",
+                                                     "priority_class": int(P.SAFETY),
+                                                     "plan_id": "stop1", "timeout_s": 5.0}))
+    assert m.state == InteractionState.SAFETY_HOLD
+
+
+def test_safety_hold_exits_via_operator_reset():
+    m = InteractionStateMachine(now=0.0, state=InteractionState.SAFETY_HOLD)
+    m.apply_signal(TransitionSignal(T.OPERATOR, {"op": "reset"}))
+    assert m.state == InteractionState.IDLE
+
+
+def test_explicit_requiring_confirmation_still_confirms_not_bypassed():
+    # Safety semantics (§3.3): an explicit command that requires confirmation must
+    # NOT skip the confirm just because it is explicit — it re-arms CONFIRM_PENDING.
+    d = InteractionPolicy.evaluate(S.CONFIRM_PENDING,
+                                   _cand("dangerous", P.EXPLICIT, explicit=True,
+                                         skill="backflip", requires_confirmation=True))
+    assert d.verdict == V.ACCEPT and d.next_state == S.CONFIRM_PENDING
+
+
+def test_empty_plan_id_terminal_does_not_sentinel_match():
+    # BUG fix: a terminal with no plan_id must not clear a freshly-reset machine.
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "COMPLETED"}))  # no plan_id, fresh
+    assert m.state == InteractionState.IDLE  # unchanged, no spurious transition recorded
+    assert m.history == []
 
 
 def test_propose_confirm_ok_transitions_executing():
@@ -220,6 +281,8 @@ def test_6_9_replay_alert_stuck_then_social_suppressed_not_blackhole():
     for kind in ("object_remark", "greet"):
         d = m.propose(_cand(kind, P.SOCIAL), now=2.0)
         assert d.verdict == V.SUPPRESS and d.reason == "gate:alert_active"
-    # watchdog frees it (no terminal ever arrived).
+    # watchdog frees it (no terminal ever arrived): ALERT_ACTIVE → ERROR_RECOVERY → IDLE.
     m.tick(now=11.0)
+    assert m.state == InteractionState.ERROR_RECOVERY
+    m.tick(now=11.1)
     assert m.state == InteractionState.IDLE

--- a/interaction_executive/test/test_interaction_state.py
+++ b/interaction_executive/test/test_interaction_state.py
@@ -1,0 +1,225 @@
+"""Pure machine tests for the Interaction State Machine (Plan ISM Phase 0).
+
+CI-safe: imports only interaction_state (no rclpy). These assertions ENCODE the
+master-plan §7 design rules so a later phase can't silently regress them:
+priority iron law, confirm-is-not-a-black-hole, perception-never-executes-directly,
+watchdog. `now` is always injected — the machine is deterministic.
+"""
+from interaction_executive.interaction_state import (
+    Candidate,
+    Decision,
+    InteractionPolicy,
+    InteractionState,
+    InteractionState as S,
+    InteractionStateMachine,
+    Priority as P,
+    TransitionSignal,
+    TriggerKind as T,
+    Verdict as V,
+)
+
+
+def _cand(kind, prio, **kw):
+    return Candidate(kind=kind, priority=prio, source=kw.pop("source", "test"), **kw)
+
+
+# ── InteractionPolicy: priority iron law + non-black-hole (§3.4 / §3.5) ──────
+def test_social_suppressed_while_executing():
+    d = InteractionPolicy.evaluate(S.EXECUTING, _cand("object_remark", P.SOCIAL))
+    assert d.verdict == V.SUPPRESS and d.reason == "gate:executing"
+
+
+def test_safety_preempts_executing():
+    d = InteractionPolicy.evaluate(S.EXECUTING, _cand("stop", P.SAFETY))
+    assert d.verdict == V.PREEMPT and d.next_state == S.SAFETY_HOLD
+
+
+def test_alert_preempts_executing():
+    d = InteractionPolicy.evaluate(S.EXECUTING, _cand("fallen_alert", P.ALERT, skill="fallen_alert"))
+    assert d.verdict == V.PREEMPT and d.next_state == S.ALERT_ACTIVE
+
+
+def test_safety_preempts_alert_but_alert_does_not_preempt_safety():
+    # SAFETY_HOLD only yields to SAFETY (§3.4): an alert during a safety hold is suppressed.
+    d = InteractionPolicy.evaluate(S.SAFETY_HOLD, _cand("fallen_alert", P.ALERT))
+    assert d.verdict == V.SUPPRESS and d.reason == "gate:safety_hold"
+    # but ALERT_ACTIVE yields to SAFETY.
+    d2 = InteractionPolicy.evaluate(S.ALERT_ACTIVE, _cand("stop", P.SAFETY))
+    assert d2.verdict == V.PREEMPT and d2.next_state == S.SAFETY_HOLD
+
+
+def test_confirm_pending_social_suppressed_not_blackhole():
+    # §7.4: a social candidate during confirm gets an explicit suppress-with-reason,
+    # never a silent drop.
+    d = InteractionPolicy.evaluate(S.CONFIRM_PENDING, _cand("greet", P.SOCIAL))
+    assert d.verdict == V.SUPPRESS and d.reason == "gate:confirm_pending"
+
+
+def test_confirm_pending_ok_confirms():
+    d = InteractionPolicy.evaluate(S.CONFIRM_PENDING, _cand("confirm_ok", P.CONFIRM, skill="wiggle"))
+    assert d.verdict == V.ACCEPT and d.next_state == S.EXECUTING and d.emit_skill == "wiggle"
+
+
+def test_confirm_pending_cancel_returns_idle():
+    d = InteractionPolicy.evaluate(S.CONFIRM_PENDING, _cand("confirm_cancel", P.CONFIRM))
+    assert d.verdict == V.ACCEPT and d.next_state == S.IDLE
+
+
+def test_explicit_command_supersedes_confirm():
+    d = InteractionPolicy.evaluate(S.CONFIRM_PENDING, _cand("chat", P.EXPLICIT, explicit=True))
+    assert d.verdict == V.PREEMPT and d.reason == "confirm_superseded"
+
+
+def test_requires_confirmation_routes_to_confirm_pending():
+    d = InteractionPolicy.evaluate(S.IDLE, _cand("gesture_cmd", P.SOCIAL,
+                                                 skill="wiggle", requires_confirmation=True))
+    assert d.verdict == V.ACCEPT and d.next_state == S.CONFIRM_PENDING
+
+
+def test_idle_accepts_social():
+    d = InteractionPolicy.evaluate(S.IDLE, _cand("greet", P.SOCIAL, skill="greet_known_person"))
+    assert d.verdict == V.ACCEPT and d.next_state == S.SPEAKING
+
+
+def test_speaking_queues_social():
+    d = InteractionPolicy.evaluate(S.SPEAKING, _cand("object_remark", P.SOCIAL))
+    assert d.verdict == V.QUEUE and "speaking" in d.reason
+
+
+def test_speaking_suppresses_confirm_priority():
+    # confirm-priority candidate while merely speaking (not confirm_pending) → suppressed.
+    d = InteractionPolicy.evaluate(S.SPEAKING, _cand("confirm_ok", P.CONFIRM))
+    assert d.verdict == V.SUPPRESS and d.reason == "gate:speaking"
+
+
+def test_perception_social_never_enters_executing_directly():
+    # §3.3 source trust: a social perception candidate can never reach EXECUTING.
+    d = InteractionPolicy.evaluate(S.IDLE, _cand("object_remark", P.SOCIAL))
+    assert d.next_state != S.EXECUTING
+
+
+def test_explicit_with_skill_executes():
+    d = InteractionPolicy.evaluate(S.IDLE, _cand("gesture_cmd", P.EXPLICIT,
+                                                 explicit=True, skill="stretch"))
+    assert d.verdict == V.ACCEPT and d.next_state == S.EXECUTING and d.emit_skill == "stretch"
+
+
+# ── InteractionStateMachine: transition drivers + watchdog (§3.2 / §3.6) ─────
+def test_skill_started_enters_executing():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "priority_class": 4,
+                                                     "plan_id": "p1", "timeout_s": 10.0}))
+    assert m.state == InteractionState.EXECUTING
+
+
+def test_alert_priority_skill_enters_alert_active():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED",
+                                                     "priority_class": int(P.ALERT),
+                                                     "plan_id": "a1", "timeout_s": 8.0}))
+    assert m.state == InteractionState.ALERT_ACTIVE
+
+
+def test_skill_terminal_returns_idle():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
+                                                     "timeout_s": 10.0}))
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "COMPLETED", "plan_id": "p1"}))
+    assert m.state == InteractionState.IDLE
+
+
+def test_terminal_for_wrong_plan_id_ignored():
+    # A stale terminal for a different plan must not clear the active one.
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
+                                                     "timeout_s": 10.0}))
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "COMPLETED", "plan_id": "OTHER"}))
+    assert m.state == InteractionState.EXECUTING
+
+
+def test_watchdog_timeout_to_recovery():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
+                                                     "timeout_s": 5.0}))
+    d = m.tick(now=6.0)
+    assert m.state == InteractionState.IDLE
+    assert d is not None and "watchdog_timeout:executing" in d.reason
+
+
+def test_watchdog_no_premature_fire():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
+                                                     "timeout_s": 5.0}))
+    assert m.tick(now=4.9) is None and m.state == InteractionState.EXECUTING
+
+
+def test_timeout_zero_means_no_deadline():
+    # Regression: timeout_s=0 must mean "no watchdog", not "deadline == now".
+    m = InteractionStateMachine(now=5.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
+                                                     "timeout_s": 0}), now=5.0)
+    assert m.deadline is None
+    assert m.tick(now=99.0) is None
+
+
+def test_confirm_timeout_30s():
+    m = InteractionStateMachine(now=0.0)
+    m.propose(Candidate(kind="gesture_cmd", priority=P.SOCIAL, source="gesture",
+                        skill="wiggle", requires_confirmation=True), now=0.0)
+    assert m.state == InteractionState.CONFIRM_PENDING and m.deadline == 30.0
+    m.tick(now=31.0)
+    assert m.state == InteractionState.IDLE
+
+
+def test_propose_confirm_ok_transitions_executing():
+    m = InteractionStateMachine(now=0.0, state=InteractionState.CONFIRM_PENDING, deadline=30.0)
+    d = m.propose(Candidate(kind="confirm_ok", priority=P.CONFIRM, source="gesture",
+                            skill="wiggle"), now=1.0)
+    assert d.verdict == V.ACCEPT and m.state == InteractionState.EXECUTING
+
+
+def test_tts_ack_speaking_then_idle():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.TTS_ACK, {"event": "start"}))
+    assert m.state == InteractionState.SPEAKING
+    m.apply_signal(TransitionSignal(T.TTS_ACK, {"event": "end"}))
+    assert m.state == InteractionState.IDLE
+
+
+def test_operator_reset_returns_idle_and_clears_plan():
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED", "plan_id": "p1",
+                                                     "timeout_s": 10.0}))
+    m.apply_signal(TransitionSignal(T.OPERATOR, {"op": "reset"}))
+    assert m.state == InteractionState.IDLE
+    # a stale terminal afterward must not re-affect state (plan id was cleared)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "COMPLETED", "plan_id": "p1"}))
+    assert m.state == InteractionState.IDLE
+
+
+def test_history_records_transitions_and_is_bounded():
+    m = InteractionStateMachine(now=0.0)
+    for i in range(80):
+        ev = "start" if i % 2 == 0 else "end"
+        m.apply_signal(TransitionSignal(T.TTS_ACK, {"event": ev}), now=float(i))
+    assert len(m.history) <= 64
+    ts, frm, to, trig = m.history[-1]
+    assert frm in {s.value for s in InteractionState} and to in {s.value for s in InteractionState}
+
+
+def test_6_9_replay_alert_stuck_then_social_suppressed_not_blackhole():
+    """6/9 regression net (§7.8): an ALERT plan that never returns terminal must
+    NOT black-hole subsequent social candidates — they get suppress-with-reason,
+    and the watchdog eventually frees the machine."""
+    m = InteractionStateMachine(now=0.0)
+    m.apply_signal(TransitionSignal(T.SKILL_RESULT, {"status": "STARTED",
+                                                     "priority_class": int(P.ALERT),
+                                                     "plan_id": "stranger1", "timeout_s": 10.0}))
+    assert m.state == InteractionState.ALERT_ACTIVE
+    # cup + greet arrive while alert is stuck → each gets an explicit suppress.
+    for kind in ("object_remark", "greet"):
+        d = m.propose(_cand(kind, P.SOCIAL), now=2.0)
+        assert d.verdict == V.SUPPRESS and d.reason == "gate:alert_active"
+    # watchdog frees it (no terminal ever arrived).
+    m.tick(now=11.0)
+    assert m.state == InteractionState.IDLE

--- a/scripts/hooks/git-pre-commit.sh
+++ b/scripts/hooks/git-pre-commit.sh
@@ -82,7 +82,7 @@ SUITES=(
   "speech_processor/|speech_processor|speech_processor/test/"
   "vision_perception/|vision_perception|vision_perception/test/"
   "face_perception/|face_perception|face_perception/test/"
-  "interaction_executive/|pawai_contracts:interaction_executive|interaction_executive/test/test_attention_machine.py interaction_executive/test/test_pending_confirm.py interaction_executive/test/test_perception_router.py interaction_executive/test/test_skill_contract.py interaction_executive/test/test_skill_contract_demo_fields.py interaction_executive/test/test_skill_queue.py interaction_executive/test/test_state_machine.py"
+  "interaction_executive/|pawai_contracts:interaction_executive|interaction_executive/test/test_attention_machine.py interaction_executive/test/test_pending_confirm.py interaction_executive/test/test_perception_router.py interaction_executive/test/test_interaction_state.py interaction_executive/test/test_skill_contract.py interaction_executive/test/test_skill_contract_demo_fields.py interaction_executive/test/test_skill_queue.py interaction_executive/test/test_state_machine.py"
   "pawai_brain/|pawai_contracts:pawai_brain|pawai_brain/test/"
   "nav_capability/|nav_capability|nav_capability/test/ --ignore=nav_capability/test/integration"
   "object_perception/|object_perception|object_perception/test/"


### PR DESCRIPTION
Plan ISM Phase 0 — [施工圖](docs/superpowers/plans/2026-06-11-plan-ism-interaction-state-machine.md) 的第一刀。**ROS-free 純核心，完全不接 runtime**：不 import 進 `brain_node`、零行為變更、不碰 demo。

## 內容

`interaction_executive/interaction_executive/interaction_state.py`（新，純 stdlib）：
- **8 態 enum**：IDLE / LISTENING / SPEAKING / CONFIRM_PENDING / EXECUTING / ALERT_ACTIVE / SAFETY_HOLD / ERROR_RECOVERY
- **Candidate / TransitionSignal / Decision** model — `source` 是 metadata 非授權（§3.3 source-trust，接安全 P2-1）
- **`InteractionPolicy.evaluate`** — 優先序鐵律 `safety > explicit command > confirm > social` 收斂成單一 `_PREEMPTIBLE_BY` 表，取代 `brain_node` 散落的 19 個 `_suppressed` if（§3.4）
- **`InteractionStateMachine`** — 四種合法轉移驅動（skill lifecycle / confirm / TTS ack / operator）+ **watchdog tick**（殺 6/9「stranger plan 卡死全系統」，§3.6）
- **suppressed reason** 字串（`gate:executing` / `gate:confirm_pending` / `watchdog_timeout:...`）

## 紅綠

`test_interaction_state.py`（新，27 測試）涵蓋：完整 preemption 表、confirm 非黑洞、感知永不直接進 EXECUTING、watchdog 邊界（含 `timeout_s=0` 與 `now>0` 回歸）、**6/9 重演網**（ALERT 卡住 → social 候選 suppressed-with-reason 非黑洞 → watchdog 自癒）。

- 新測試 **27 passed**
- 零影響驗證：IE CI-safe subset **149 passed**（含本測試）、contracts **10**、brain pure **278**
- 接進 fast-gate Inv3 + pre-commit hook（與 Plan D `perception_router` 同位置）

## 範圍邊界（嚴格遵守指示）

**不接 runtime、不改 `brain_node`、不改 demo 行為。** 這只是 Phase 0 純模組地基。Phase 1（shadow 觀測）→ Phase 2（逐 gate family flag-gated 切換）→ Phase 3（權威化）待後續，全程 `ism_enabled` 預設關 + v1 fallback。

🤖 Generated with [Claude Code](https://claude.com/claude-code)