### PR TITLE
feat(studio): Evidence Center first slice — trace JSONL store + auth-gated export + suppressed viewer (system Phase 2 / 2B)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -153,7 +153,10 @@ jobs:
           PYTHONPATH=pawai_contracts:object_perception pytest pawai_contracts/test/ \
             -v --tb=short
           # Invocation 8 (S0 hardening, Tier 1): gateway auth primitives (ROS-free).
+          # + trace_store (Evidence Center T2B-1, 2026-06-12): pure-module JSONL
+          # persistence / retention / PII redaction tests, same ROS-free tier.
           PYTHONPATH=pawai-studio/gateway pytest pawai-studio/gateway/test_auth.py \
+            pawai-studio/gateway/test_trace_store.py \
             -v --tb=short
       - name: Upload coverage report
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,6 @@ node_modules/
 /螢幕擷取畫面*
 /LM*.pdf
 *.py[cod]
+
+## Evidence Center trace JSONL（gateway 落盤產物，含 PII — 永不入 repo）
+/runtime/traces/

--- a/pawai-studio/frontend/components/chat/brain/skill-trace-content.tsx
+++ b/pawai-studio/frontend/components/chat/brain/skill-trace-content.tsx
@@ -47,8 +47,12 @@ export function SkillTraceContent() {
   const brain = useStateStore((s) => s.brainState);
   const proposals = useStateStore((s) => s.brainProposals);
   const traces = useStateStore((s) => s.conversationTraces);
+  const brainTraces = useStateStore((s) => s.brainTraces);
   const capability = useStateStore((s) => s.capability);
   const { planMode, togglePlanMode } = useTogglePlanMode();
+  // Evidence Center first slice (T2B-3): 「為什麼沒反應」 = suppressed verdicts
+  // from /brain/trace (gateway-redacted; PII fields arrive as "[private]").
+  const suppressed = brainTraces.filter((t) => t.verdict === "suppressed");
 
   const planAclass =
     planMode === "A"
@@ -106,6 +110,37 @@ export function SkillTraceContent() {
               <span> · src={proposal.source}</span>
               <span> · prio={proposal.priority_class}</span>
               <span> · {proposal.reason}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* 為什麼沒反應 — suppressed decision-chain verdicts (Evidence Center) */}
+      <div>
+        <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground/70">
+          為什麼沒反應 · Suppressed · {suppressed.length}
+        </div>
+        <div className="space-y-1">
+          {suppressed.length === 0 && (
+            <div className="italic text-muted-foreground/60">尚無 suppressed 決策</div>
+          )}
+          {suppressed.slice(0, 20).map((t, i) => (
+            <div
+              key={`${t.decision_id}-${t.ts}-${i}`}
+              className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 font-mono text-xs text-amber-200"
+              title={`${t.decision_id} · ${t.node} · ${t.kind}`}
+            >
+              <span className="font-semibold">{t.gate || t.kind}</span>
+              <span className="opacity-60"> · </span>
+              <span className="truncate">{t.reason || "(no reason)"}</span>
+              {t.detail?.shadow === true && (
+                <span className="ml-1 rounded border border-violet-500/40 bg-violet-500/10 px-1 text-[10px] text-violet-300">
+                  shadow
+                </span>
+              )}
+              <span className="ml-2 text-[10px] opacity-50">
+                {t.decision_id.split("-")[0]}
+              </span>
             </div>
           ))}
         </div>

--- a/pawai-studio/frontend/contracts/types.ts
+++ b/pawai-studio/frontend/contracts/types.ts
@@ -484,3 +484,28 @@ export interface ScoreboardResponse {
   generated_at?: string;
   capabilities: ScoreboardCapability[];
 }
+
+// ══════════════════════════════════════════════════════════════════
+// Brain decision-chain trace (/brain/trace, Plan E + ISM shadow).
+// Evidence Center first slice (system Phase 2 T2B-3): the gateway broadcasts
+// these REDACTED (T2B-0 PII ruling) — detail PII keys arrive as "[private]".
+// ══════════════════════════════════════════════════════════════════
+export interface BrainTraceEvent {
+  v: number;
+  ts: number;
+  decision_id: string;
+  node: string;
+  kind:
+    | "perception_event"
+    | "candidate"
+    | "policy_decision"
+    | "plan_emitted"
+    | "skill_result"
+    | "tts_state"
+    | "state_transition";
+  verdict: "accepted" | "suppressed" | "blocked";
+  gate: string;
+  reason: string;
+  detail: Record<string, unknown>;
+  plan_id?: string;
+}

--- a/pawai-studio/frontend/hooks/use-event-stream.ts
+++ b/pawai-studio/frontend/hooks/use-event-stream.ts
@@ -14,6 +14,7 @@ import type {
   GestureState,
   PoseState,
   BrainState,
+  BrainTraceEvent,
   PawAIBrainState,
   SkillPlan,
   SkillResult,
@@ -35,6 +36,7 @@ export function useEventStream(): UseEventStreamResult {
   const appendBrainProposal = useStateStore((s) => s.appendBrainProposal);
   const appendBrainResult = useStateStore((s) => s.appendBrainResult);
   const appendConversationTrace = useStateStore((s) => s.appendConversationTrace);
+  const appendBrainTrace = useStateStore((s) => s.appendBrainTrace);
   const updateSystemHealth = useStateStore((s) => s.updateSystemHealth);
   const updateObjectState = useStateStore((s) => s.updateObjectState);
   const updateTts = useStateStore((s) => s.updateTts);
@@ -86,6 +88,12 @@ export function useEventStream(): UseEventStreamResult {
             event.event_type === "conversation_trace_shadow"
           ) {
             appendConversationTrace(data as unknown as ConversationTracePayload);
+          } else if (event.event_type === "trace") {
+            // Evidence Center first slice (T2B-3): /brain/trace decision-chain
+            // events — answers「為什麼沒反應」(gate + reason per decision_id).
+            if ("decision_id" in data && "verdict" in data) {
+              appendBrainTrace(data as unknown as BrainTraceEvent);
+            }
           } else if (event.event_type === "gesture_enabled") {
             // Demo-recording P0 手勢開關廣播（gateway /api/gesture_enabled）。
             if (typeof data.enabled === "boolean") {
@@ -190,6 +198,7 @@ export function useEventStream(): UseEventStreamResult {
       appendBrainProposal,
       appendBrainResult,
       appendConversationTrace,
+      appendBrainTrace,
       updateSystemHealth,
       updateObjectState,
       updateTts,

--- a/pawai-studio/frontend/stores/__tests__/state-store.test.ts
+++ b/pawai-studio/frontend/stores/__tests__/state-store.test.ts
@@ -99,3 +99,49 @@ describe("ttsMessages rate-limit", () => {
     expect(useStateStore.getState().ttsMessages).toHaveLength(1);
   });
 });
+
+describe("brainTraces ring buffer (Evidence Center T2B-3)", () => {
+  beforeEach(() => {
+    useStateStore.setState({ brainTraces: [] });
+  });
+
+  const trace = (i: number, verdict: "accepted" | "suppressed" = "suppressed") => ({
+    v: 1,
+    ts: 1000 + i,
+    decision_id: `gesture-${i}`,
+    node: "brain_node",
+    kind: "policy_decision" as const,
+    verdict,
+    gate: "pending_confirm",
+    reason: "confirm_in_flight",
+    detail: { shadow: false },
+  });
+
+  it("appendBrainTrace prepends entries", () => {
+    useStateStore.getState().appendBrainTrace(trace(1));
+    useStateStore.getState().appendBrainTrace(trace(2));
+    const traces = useStateStore.getState().brainTraces;
+    expect(traces).toHaveLength(2);
+    expect(traces[0].decision_id).toBe("gesture-2"); // newest first
+  });
+
+  it("caps at 50 like conversationTraces", () => {
+    for (let i = 0; i < 55; i++) {
+      useStateStore.getState().appendBrainTrace(trace(i));
+    }
+    const traces = useStateStore.getState().brainTraces;
+    expect(traces).toHaveLength(50);
+    expect(traces[0].decision_id).toBe("gesture-54");
+    expect(traces[49].decision_id).toBe("gesture-5");
+  });
+
+  it("keeps verdict for suppressed-reason filtering", () => {
+    useStateStore.getState().appendBrainTrace(trace(1, "accepted"));
+    useStateStore.getState().appendBrainTrace(trace(2, "suppressed"));
+    const suppressed = useStateStore
+      .getState()
+      .brainTraces.filter((t) => t.verdict === "suppressed");
+    expect(suppressed).toHaveLength(1);
+    expect(suppressed[0].gate).toBe("pending_confirm");
+  });
+});

--- a/pawai-studio/frontend/stores/state-store.ts
+++ b/pawai-studio/frontend/stores/state-store.ts
@@ -12,6 +12,7 @@ import type {
   GestureState,
   PoseState,
   BrainState,
+  BrainTraceEvent,
   SkillPlan,
   SkillResult,
   SystemHealth,
@@ -71,6 +72,9 @@ interface StateStore {
   brainProposals: SkillPlan[];
   brainResults: SkillResult[];
   conversationTraces: ConversationTracePayload[];
+  // Evidence Center first slice (T2B-3): /brain/trace decision-chain events
+  // (Plan E + ISM shadow), redacted by the gateway before broadcast.
+  brainTraces: BrainTraceEvent[];
   systemHealth: SystemHealth | null;
   objectState: ObjectState | null;
   lastTtsText: string | null;
@@ -94,6 +98,7 @@ interface StateStore {
   appendBrainProposal: (proposal: SkillPlan) => void;
   appendBrainResult: (result: SkillResult) => void;
   appendConversationTrace: (trace: ConversationTracePayload) => void;
+  appendBrainTrace: (trace: BrainTraceEvent) => void;
   updateSystemHealth: (state: SystemHealth) => void;
   updateObjectState: (state: ObjectState) => void;
   updateTts: (text: string) => void;
@@ -114,6 +119,7 @@ export const useStateStore = create<StateStore>((set) => ({
   brainProposals: [],
   brainResults: [],
   conversationTraces: [],
+  brainTraces: [],
   systemHealth: null,
   objectState: null,
   lastTtsText: null,
@@ -143,6 +149,10 @@ export const useStateStore = create<StateStore>((set) => ({
   appendConversationTrace: (trace) =>
     set((state) => ({
       conversationTraces: [trace, ...state.conversationTraces].slice(0, 50),
+    })),
+  appendBrainTrace: (trace) =>
+    set((state) => ({
+      brainTraces: [trace, ...state.brainTraces].slice(0, 50),
     })),
   updateSystemHealth: (state) => set({ systemHealth: state }),
   updateObjectState: (state) => set({ objectState: state }),

--- a/pawai-studio/gateway/auth.py
+++ b/pawai-studio/gateway/auth.py
@@ -88,6 +88,26 @@ def token_query_ok(token_param: str | None, token: str) -> bool:
     return secrets.compare_digest(token_param.strip(), token)
 
 
+def export_access(*, auth_enabled: bool, header_token_ok: bool,
+                  want_full: bool) -> int:
+    """Access decision for GET /api/trace/export (A-11 + T2B-0, Roy 2026-06-12).
+
+    Returns 0 = allow, else the HTTP status to refuse with:
+    - 401: auth is ON and the Bearer token is missing/bad. Export gets NO
+      safe-method bypass — unlike the global middleware, a GET here still
+      needs the token, because the response body is the trace archive.
+    - 403: caller wants the FULL (unredacted) export but the token system is
+      OFF — nobody can be authenticated, so PII never leaves redacted.
+    Default-off posture stays usable: redacted export is open (matches the
+    S0-2 byte-identical-by-default principle; PII protected by redaction).
+    """
+    if auth_enabled and not header_token_ok:
+        return 401
+    if want_full and not auth_enabled:
+        return 403
+    return 0
+
+
 def origin_ok(origin: str | None, allowed: tuple[str, ...]) -> bool:
     """Validate a browser Origin header against the allowlist.
     - allowed==() → check disabled, always True.

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -23,10 +23,10 @@ from datetime import datetime
 from pathlib import Path
 
 import uvicorn
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 import rclpy
@@ -62,6 +62,12 @@ from intent_classifier import IntentClassifier
 # Access-control policy (S0 hardening) — pure module, env-gated, OFF by default.
 from auth import (
     load_auth_config, requires_token, token_ok, token_query_ok, origin_ok,
+    export_access,
+)
+# Evidence Center trace store (system Phase 2 T2B-1) — pure module; persistence
+# of /brain/trace JSONL + the T2B-0 PII redaction single source.
+from trace_store import (  # noqa: E402 — same-dir import after sys.path setup
+    TraceStore, iter_export_lines, redact_trace_event, store_enabled, trace_dir,
 )
 
 # ── Config ───────────────────────────────────────────────────────
@@ -710,6 +716,7 @@ class GatewayNode(Node):
                 return
             self._last_face_broadcast = now
 
+        payload = self._maybe_persist_trace(source, payload)
         data = dict(payload)
         if source.startswith("brain:"):
             event_source = "brain"
@@ -749,6 +756,21 @@ class GatewayNode(Node):
         asyncio.run_coroutine_threadsafe(
             ws_manager.broadcast(envelope), self._loop
         )
+
+    @staticmethod
+    def _maybe_persist_trace(source: str, payload: dict) -> dict:
+        """Evidence Center (T2B-1/T2B-0, 2026-06-12): /brain/trace is persisted
+        FULL to the local JSONL store (Jetson-disk evidence) and broadcast
+        REDACTED — Roy's PII ruling: safe summary visible; name / transcript /
+        image path / full text private by default. No frontend consumed this WS
+        event before this slice, so redaction breaks no existing consumer.
+        Non-trace sources pass through untouched."""
+        if source != "brain:trace":
+            return payload
+        store = _trace_store
+        if store is not None:
+            store.append(payload)
+        return redact_trace_event(payload)
 
     def _on_tts_msg(self, msg: String) -> None:
         """Parse /tts msg (plain text or JSON envelope) and broadcast."""
@@ -823,6 +845,9 @@ class GatewayNode(Node):
 # ── FastAPI App ──────────────────────────────────────────────────
 node: GatewayNode | None = None
 classifier: IntentClassifier | None = None
+# Evidence Center store — created in lifespan when PAWAI_TRACE_STORE_ENABLED
+# (default on; env off = pure bridge, byte-identical to the pre-T2B gateway).
+_trace_store: TraceStore | None = None
 
 
 class SkillRequestPayload(BaseModel):
@@ -862,16 +887,25 @@ from contextlib import asynccontextmanager
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global node, classifier
+    global node, classifier, _trace_store
     rclpy.init()
     loop = asyncio.get_running_loop()
     node = GatewayNode(loop)
     classifier = IntentClassifier()
+    if store_enabled():
+        _trace_store = TraceStore(trace_dir(repo_root=_REPO_ROOT))
+        print(f"[gateway] trace store ON → {_trace_store.current_path}", flush=True)
+    else:
+        print("[gateway] trace store OFF (PAWAI_TRACE_STORE_ENABLED) — pure bridge",
+              flush=True)
     spin_thread = threading.Thread(target=_spin_ros2, args=(node,), daemon=True)
     spin_thread.start()
     yield
     if node:
         node.destroy_node()
+    if _trace_store is not None:
+        _trace_store.close()
+        _trace_store = None
     rclpy.try_shutdown()
 
 
@@ -1082,6 +1116,34 @@ def _read_scoreboard(path: Path) -> dict:
 async def get_scoreboard():
     """Read-only frozen baseline_snapshot.json (issue #76). No live recompute."""
     return _read_scoreboard(_scoreboard_path())
+
+
+# ── Evidence Center: trace export (T2B-2, A-11 + T2B-0 rulings) ─────────────
+
+@app.get("/api/trace/export")
+async def get_trace_export(request: Request, since: float = 0.0, redact: int = 1):
+    """Stream persisted /brain/trace JSONL (application/x-ndjson).
+
+    Query: since=<unix ts> (events with ts >= since), redact=0 for the FULL
+    (unredacted) archive. Auth (A-11, Roy 2026-06-12): the global middleware
+    exempts GET — this endpoint deliberately does NOT get that bypass; when
+    auth is on, even redacted GET export needs the Bearer token, and the full
+    export refuses entirely while the token system is off (PII never leaves
+    the machine unredacted without an authenticated caller).
+    """
+    want_full = int(redact) == 0
+    status = export_access(
+        auth_enabled=AUTH.auth_enabled,
+        header_token_ok=token_ok(request.headers.get("authorization"), AUTH.token),
+        want_full=want_full,
+    )
+    if status == 401:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    if status == 403:
+        return JSONResponse({"error": "full_export_requires_auth"}, status_code=403)
+    lines = iter_export_lines(trace_dir(repo_root=_REPO_ROOT),
+                              since=since or None, redact=not want_full)
+    return StreamingResponse(lines, media_type="application/x-ndjson")
 
 
 class PlanModePayload(BaseModel):

--- a/pawai-studio/gateway/test_auth.py
+++ b/pawai-studio/gateway/test_auth.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from auth import (  # noqa: E402
     AuthConfig,
+    export_access,
     load_auth_config,
     origin_ok,
     requires_token,
@@ -103,6 +104,27 @@ def test_origin_allowlist():
     assert origin_ok("http://100.83.109.89:3001", allowed) is True
     assert origin_ok("http://evil.example", allowed) is False
     assert origin_ok(None, allowed) is True             # curl/probe (no Origin) allowed
+
+
+# ── export_access: trace-export gate (A-11 + T2B-0 PII ruling, 2026-06-12) ──
+def test_export_access_auth_on_requires_token_even_for_get():
+    # A-11: export has NO safe-method bypass — auth on + bad/missing token = 401.
+    assert export_access(auth_enabled=True, header_token_ok=False, want_full=False) == 401
+    assert export_access(auth_enabled=True, header_token_ok=False, want_full=True) == 401
+    assert export_access(auth_enabled=True, header_token_ok=True, want_full=False) == 0
+    assert export_access(auth_enabled=True, header_token_ok=True, want_full=True) == 0
+
+
+def test_export_access_full_export_requires_auth_system_on():
+    # T2B-0: full (unredacted) export ALWAYS needs an authenticated caller —
+    # with the token system off nobody can authenticate → 403, PII stays redacted.
+    assert export_access(auth_enabled=False, header_token_ok=True, want_full=True) == 403
+    assert export_access(auth_enabled=False, header_token_ok=False, want_full=True) == 403
+
+
+def test_export_access_default_open_posture_redacted_only():
+    # S0-2 default-off posture: redacted export stays reachable without a token.
+    assert export_access(auth_enabled=False, header_token_ok=False, want_full=False) == 0
 
 
 def test_authconfig_is_frozen():

--- a/pawai-studio/gateway/test_trace_store.py
+++ b/pawai-studio/gateway/test_trace_store.py
@@ -1,0 +1,204 @@
+"""Unit tests for the Evidence Center trace store (system Phase 2 T2B-1).
+
+ROS-free: imports only trace_store.py, runs anywhere (CI fast-gate Invocation 8,
+WSL). Covers JSONL persistence, rotation, retention, queue flush, the env
+kill-switch, the T2B-0 PII redaction ruling and the export line iterator.
+"""
+import json
+import sys
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from trace_store import (  # noqa: E402
+    PII_DETAIL_KEYS,
+    TraceStore,
+    iter_export_lines,
+    redact_trace_event,
+    store_enabled,
+    trace_dir,
+)
+
+
+def _ev(ts: float = 100.0, **over) -> dict:
+    ev = {
+        "v": 1, "ts": ts, "decision_id": "face-abc123", "node": "brain_node",
+        "kind": "policy_decision", "verdict": "suppressed",
+        "gate": "greet_cooldown", "reason": "cooldown:greet:Roy",
+        "detail": {
+            "gate": "greet_cooldown", "reason": "cooldown:greet:Roy",
+            "demo_phase": "all", "active_plan": "wiggle",
+            "pending_confirm": "IDLE:", "cooldown_remaining_s": 12.5,
+            "source_summary": "identity=Roy conf=0.93",
+        },
+    }
+    ev.update(over)
+    return ev
+
+
+# ── env config ───────────────────────────────────────────────────────────────
+
+def test_store_enabled_default_on_with_kill_switch():
+    assert store_enabled({}) is True
+    assert store_enabled({"PAWAI_TRACE_STORE_ENABLED": "0"}) is False
+    assert store_enabled({"PAWAI_TRACE_STORE_ENABLED": "false"}) is False
+    assert store_enabled({"PAWAI_TRACE_STORE_ENABLED": "1"}) is True
+
+
+def test_trace_dir_env_override_and_default(tmp_path):
+    assert trace_dir({"PAWAI_TRACE_DIR": str(tmp_path / "x")},
+                     repo_root=tmp_path) == tmp_path / "x"
+    assert trace_dir({}, repo_root=tmp_path) == tmp_path / "runtime" / "traces"
+
+
+# ── append / flush / JSONL ───────────────────────────────────────────────────
+
+def test_append_flush_writes_full_jsonl(tmp_path):
+    store = TraceStore(tmp_path, session_id="s1", autostart=False)
+    store.append(_ev(ts=1.0))
+    store.append(_ev(ts=2.0, verdict="accepted"))
+    store.flush()
+    lines = (tmp_path / "s1.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    # Disk copy is FULL (local-only) — PII fields present verbatim (T2B-0).
+    assert json.loads(lines[0])["detail"]["source_summary"] == "identity=Roy conf=0.93"
+    assert json.loads(lines[1])["verdict"] == "accepted"
+
+
+def test_append_is_enqueue_only_until_flush(tmp_path):
+    store = TraceStore(tmp_path, session_id="s1", autostart=False)
+    store.append(_ev())
+    assert not (tmp_path / "s1.jsonl").exists()
+    store.flush()
+    assert (tmp_path / "s1.jsonl").exists()
+
+
+def test_append_never_raises_on_garbage(tmp_path):
+    store = TraceStore(tmp_path, session_id="s1", autostart=False)
+    store.append({"ts": object()})       # not JSON-serializable
+    store.flush()                        # must not raise; garbage dropped
+
+
+def test_background_writer_thread_and_close(tmp_path):
+    store = TraceStore(tmp_path, session_id="s1", autostart=True,
+                       flush_interval_s=0.05)
+    try:
+        assert any(t.daemon for t in threading.enumerate()
+                   if t.name == "trace-store-writer")
+        store.append(_ev())
+    finally:
+        store.close()                     # close() flushes + joins
+    assert (tmp_path / "s1.jsonl").exists()
+    assert not any(t.name == "trace-store-writer" and t.is_alive()
+                   for t in threading.enumerate())
+
+
+# ── rotation / retention ─────────────────────────────────────────────────────
+
+def test_rotation_when_file_exceeds_max_bytes(tmp_path):
+    store = TraceStore(tmp_path, session_id="s1", autostart=False, max_bytes=200)
+    for i in range(20):
+        store.append(_ev(ts=float(i)))
+        store.flush()
+    files = sorted(p.name for p in tmp_path.glob("s1*.jsonl"))
+    assert len(files) >= 2, files          # rotated past 200 bytes
+    assert "s1.jsonl" in files
+
+
+def test_retention_prunes_oldest_beyond_max_sessions(tmp_path):
+    import os
+    for i in range(25):
+        p = tmp_path / f"old-{i:02d}.jsonl"
+        p.write_text("{}\n", encoding="utf-8")
+        os.utime(p, (1000 + i, 1000 + i))
+    store = TraceStore(tmp_path, session_id="s-new", autostart=False,
+                       max_sessions=20)
+    store.append(_ev())
+    store.flush()
+    remaining = sorted(p.name for p in tmp_path.glob("*.jsonl"))
+    assert len(remaining) == 20
+    assert "s-new.jsonl" in remaining
+    assert "old-00.jsonl" not in remaining     # oldest pruned
+    assert "old-24.jsonl" in remaining
+
+
+# ── PII redaction (T2B-0 Roy ruling 2026-06-12) ─────────────────────────────
+
+def test_redact_masks_pii_detail_keys_and_keeps_safe_summary():
+    out = redact_trace_event(_ev())
+    assert out["detail"]["source_summary"] == "[private]"
+    # Safe summary fields stay visible:
+    assert out["detail"]["gate"] == "greet_cooldown"
+    assert out["detail"]["demo_phase"] == "all"
+    assert out["detail"]["cooldown_remaining_s"] == 12.5
+    assert out["gate"] == "greet_cooldown"
+    assert out["kind"] == "policy_decision" and out["verdict"] == "suppressed"
+
+
+def test_redact_masks_name_in_reason_but_keeps_structure():
+    out = redact_trace_event(_ev())
+    assert out["reason"] == "cooldown:greet:[private]"
+    assert out["detail"]["reason"] == "cooldown:greet:[private]"
+    out2 = redact_trace_event(_ev(reason="identity:roy"))
+    assert out2["reason"] == "identity:[private]"
+    out3 = redact_trace_event(_ev(reason="gate:executing"))
+    assert out3["reason"] == "gate:executing"          # structural reason untouched
+    out4 = redact_trace_event(_ev(reason="phase:s3_object:gesture"))
+    assert out4["reason"] == "phase:s3_object:gesture"
+
+
+def test_redact_masks_transcript_like_keys():
+    ev = _ev()
+    ev["detail"].update({"transcript": "我想喝水", "text": "hello",
+                         "name": "Roy", "image_path": "/data/x.jpg"})
+    out = redact_trace_event(ev)
+    for key in ("transcript", "text", "name", "image_path", "source_summary"):
+        assert out["detail"][key] == "[private]", key
+
+
+def test_redact_is_pure_and_shadow_fields_survive():
+    ev = _ev()
+    ev["detail"].update({"shadow": True, "ism_state": "executing",
+                         "ism_verdict": "suppress", "ism_reason": "gate:executing"})
+    before = json.dumps(ev, sort_keys=True)
+    out = redact_trace_event(ev)
+    assert json.dumps(ev, sort_keys=True) == before    # input not mutated
+    assert out["detail"]["shadow"] is True
+    assert out["detail"]["ism_reason"] == "gate:executing"
+
+
+def test_pii_keys_constant_covers_roy_ruling():
+    for key in ("source_summary", "transcript", "text", "name", "identity",
+                "image_path", "image", "full_text"):
+        assert key in PII_DETAIL_KEYS
+
+
+# ── export iterator ──────────────────────────────────────────────────────────
+
+def _write_session(tmp_path, name, events):
+    store = TraceStore(tmp_path, session_id=name, autostart=False)
+    for ev in events:
+        store.append(ev)
+    store.flush()
+
+
+def test_iter_export_lines_since_and_redact(tmp_path):
+    _write_session(tmp_path, "a", [_ev(ts=10.0), _ev(ts=20.0)])
+    _write_session(tmp_path, "b", [_ev(ts=30.0)])
+    all_lines = [json.loads(line) for line in iter_export_lines(tmp_path)]
+    assert len(all_lines) == 3
+    assert all(ev["detail"]["source_summary"] == "[private]" for ev in all_lines)
+
+    since = [json.loads(line) for line in iter_export_lines(tmp_path, since=15.0)]
+    assert sorted(ev["ts"] for ev in since) == [20.0, 30.0]
+
+    full = [json.loads(line) for line in iter_export_lines(tmp_path, redact=False)]
+    assert any(ev["detail"]["source_summary"].startswith("identity=") for ev in full)
+
+
+def test_iter_export_lines_skips_garbage_and_missing_dir(tmp_path):
+    (tmp_path / "bad.jsonl").write_text("not-json\n{\"ts\": 5}\n", encoding="utf-8")
+    lines = [json.loads(line) for line in iter_export_lines(tmp_path)]
+    assert len(lines) == 1 and lines[0]["ts"] == 5
+    assert list(iter_export_lines(tmp_path / "nope")) == []

--- a/pawai-studio/gateway/trace_store.py
+++ b/pawai-studio/gateway/trace_store.py
@@ -1,0 +1,222 @@
+"""Evidence Center trace store — ROS-free, unit-testable (system Phase 2 T2B-1).
+
+Roy D5 ruling (2026-06-10): trace 的單一真相 = pawai_contracts schema + gateway
+JSONL。Brain 只發射、gateway 只落盤呈現、CLI 只讀取匯出。This module is the
+gateway's "落盤" half: studio_gateway.py wires it to the /brain/trace bridge.
+
+T2B-0 rulings (Roy 2026-06-12, AFK instruction):
+  - PII conservative default: safe summary fields stay visible; name /
+    transcript / image path / full text are PRIVATE by default. The on-disk
+    JSONL keeps the FULL event (local-only evidence); everything that leaves
+    the machine through the WS bridge or the default export is run through
+    redact_trace_event() first.
+  - Export auth: see auth.export_access() — token required even on GET when
+    auth is on; full (unredacted) export refuses unless the token system is on.
+
+Threading: the gateway's ROS executor thread calls append() — that is enqueue
+ONLY (no file I/O on the hot path). A daemon writer thread flushes every
+flush_interval_s; close() joins it. Nothing here ever raises into the caller.
+
+Env:
+  PAWAI_TRACE_STORE_ENABLED=0|false   kill-switch (default on; off = pure
+                                      bridge, byte-identical to pre-T2B gateway)
+  PAWAI_TRACE_DIR=<path>              override the default <repo>/runtime/traces
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import threading
+import time
+from collections import deque
+from collections.abc import Iterator
+from pathlib import Path
+
+DEFAULT_MAX_BYTES = 20 * 1024 * 1024     # ~20MB per file (Roy: 20MB × 20 sessions)
+DEFAULT_MAX_SESSIONS = 20                # newest N .jsonl files kept
+PRIVATE = "[private]"
+
+# detail keys that may carry PII (T2B-0). Masked — key kept so analysts can see
+# the field existed without seeing the value.
+PII_DETAIL_KEYS = frozenset({
+    "source_summary", "transcript", "text", "name", "identity",
+    "image_path", "image", "full_text",
+})
+
+# Names ride inside reason strings as "identity:roy" / "identity=roy" /
+# "cooldown:greet:Roy". Mask the value segment, keep the structural prefix.
+# Structural reasons ("gate:executing", "phase:s3_object:gesture") never match.
+_PII_REASON_RE = re.compile(r"((?:identity|name|greet)[:=])[^:,\s]+")
+
+
+def store_enabled(env: dict | None = None) -> bool:
+    """Kill-switch (default ON — persistence is additive observability; the
+    rollback story is env-off = pure bridge)."""
+    e = os.environ if env is None else env
+    return str(e.get("PAWAI_TRACE_STORE_ENABLED", "1")).strip().lower() \
+        not in ("0", "false", "no", "off")
+
+
+def trace_dir(env: dict | None = None, repo_root: Path | None = None) -> Path:
+    """Trace directory: PAWAI_TRACE_DIR override, else <repo>/runtime/traces
+    (the established Jetson runtime-data convention — never install/share)."""
+    e = os.environ if env is None else env
+    override = str(e.get("PAWAI_TRACE_DIR") or "").strip()
+    if override:
+        return Path(override).expanduser()
+    root = repo_root if repo_root is not None else Path(__file__).resolve().parents[2]
+    return root / "runtime" / "traces"
+
+
+def redact_trace_event(ev: dict) -> dict:
+    """Pure, conservative redaction (T2B-0): returns a new dict, never mutates.
+
+    - detail keys in PII_DETAIL_KEYS → "[private]"
+    - reason / detail.reason: name-bearing segments masked via _PII_REASON_RE
+    - everything else (gate, kind, verdict, decision_id, ism_* shadow fields,
+      demo_phase, cooldown_remaining_s, …) passes through — that is the "safe
+      summary" Roy ruled visible.
+    """
+    out = dict(ev)
+    reason = out.get("reason")
+    if isinstance(reason, str):
+        out["reason"] = _PII_REASON_RE.sub(r"\g<1>" + PRIVATE, reason)
+    detail = out.get("detail")
+    if isinstance(detail, dict):
+        d = dict(detail)
+        for key in d:
+            if key in PII_DETAIL_KEYS:
+                d[key] = PRIVATE
+        d_reason = d.get("reason")
+        if isinstance(d_reason, str):
+            d["reason"] = _PII_REASON_RE.sub(r"\g<1>" + PRIVATE, d_reason)
+        out["detail"] = d
+    return out
+
+
+class TraceStore:
+    """Append-only JSONL store: runtime/traces/{session_id}.jsonl with size
+    rotation ({session_id}.2.jsonl, …) and newest-N retention pruning."""
+
+    def __init__(self, directory: Path | str, *, session_id: str | None = None,
+                 max_bytes: int = DEFAULT_MAX_BYTES,
+                 max_sessions: int = DEFAULT_MAX_SESSIONS,
+                 flush_interval_s: float = 1.0, autostart: bool = True) -> None:
+        self._dir = Path(directory)
+        self._session_id = session_id or time.strftime("%Y%m%d-%H%M%S")
+        self._max_bytes = int(max_bytes)
+        self._max_sessions = int(max_sessions)
+        self._flush_interval_s = float(flush_interval_s)
+        self._queue: deque[str] = deque()
+        self._q_lock = threading.Lock()
+        self._io_lock = threading.Lock()
+        self._part = 1
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        if autostart:
+            self._thread = threading.Thread(
+                target=self._writer_loop, name="trace-store-writer", daemon=True
+            )
+            self._thread.start()
+
+    # ── hot path (ROS executor thread) ────────────────────────────────────
+
+    def append(self, event: dict) -> None:
+        """Enqueue one event. No file I/O here; never raises."""
+        try:
+            line = json.dumps(event, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return  # non-serializable garbage — drop, never break the bridge
+        with self._q_lock:
+            self._queue.append(line)
+
+    # ── writer side ───────────────────────────────────────────────────────
+
+    @property
+    def current_path(self) -> Path:
+        name = f"{self._session_id}.jsonl" if self._part == 1 \
+            else f"{self._session_id}.{self._part}.jsonl"
+        return self._dir / name
+
+    def flush(self) -> None:
+        """Drain the queue to disk now (writer thread or caller). Never raises."""
+        with self._io_lock:
+            with self._q_lock:
+                if not self._queue:
+                    return
+                lines = list(self._queue)
+                self._queue.clear()
+            try:
+                self._dir.mkdir(parents=True, exist_ok=True)
+                path = self.current_path
+                with path.open("a", encoding="utf-8") as f:
+                    f.write("\n".join(lines) + "\n")
+                if path.stat().st_size >= self._max_bytes:
+                    self._part += 1
+                self._prune()
+            except OSError:
+                return  # disk trouble must never bubble into the gateway
+
+    def close(self) -> None:
+        """Stop the writer thread (if any) and do a final flush."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+        self.flush()
+
+    def _writer_loop(self) -> None:
+        while not self._stop.wait(self._flush_interval_s):
+            self.flush()
+        self.flush()
+
+    def _prune(self) -> None:
+        """Keep the newest max_sessions .jsonl files, delete the rest."""
+        files = sorted(self._dir.glob("*.jsonl"),
+                       key=lambda p: p.stat().st_mtime, reverse=True)
+        for stale in files[self._max_sessions:]:
+            try:
+                stale.unlink()
+            except OSError:
+                continue
+
+
+def _iter_file_events(path: Path) -> Iterator[dict]:
+    """Parse one JSONL file defensively: garbage lines / unreadable files skip."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            ev = json.loads(raw)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(ev, dict):
+            yield ev
+
+
+def iter_export_lines(directory: Path | str, since: float | None = None,
+                      redact: bool = True) -> Iterator[str]:
+    """Yield JSONL lines ("...json...\\n") for the export endpoint.
+
+    Reads session files oldest-first (mtime), filters by event ts >= since,
+    applies redact_trace_event unless redact=False (auth-gated by the caller —
+    see auth.export_access).
+    """
+    d = Path(directory)
+    if not d.is_dir():
+        return
+    for path in sorted(d.glob("*.jsonl"), key=lambda p: p.stat().st_mtime):
+        for ev in _iter_file_events(path):
+            if since is not None:
+                ts = ev.get("ts")
+                if not isinstance(ts, (int, float)) or ts < since:
+                    continue
+            if redact:
+                ev = redact_trace_event(ev)
+            yield json.dumps(ev, ensure_ascii=False) + "\n"


### PR DESCRIPTION
## Summary

系統 Phase 2 Lane 2B（pre-6/18 additive-only）：Plan E 的 `/brain/trace` 從「live 可見」升級到「gateway JSONL 落盤 + export endpoint + 前端 suppressed-reason viewer」。

## T2B-0 兩決策已照 Roy 6/12 AFK 指令落實（plan 附錄將回填）

| 決策 | 落實 |
|---|---|
| **PII 保守預設** | 磁碟 JSONL 存完整事件（僅本機證據）；**離機的每一路**（WS 廣播 + 預設 export）都過 `redact_trace_event()` — name/transcript/image path/full text → `[private]`，safe summary（gate/kind/verdict/demo_phase/ism_*）可見；reason 內人名段遮蔽（`cooldown:greet:Roy`→`cooldown:greet:[private]`），結構性 reason（`gate:executing`）不動 |
| **export 即使 GET 也要 auth（A-11）** | `auth.export_access()`：auth-on 時 GET export 一樣要 Bearer token（**不吃** middleware 的 safe-method 豁免）→ 401；`redact=0` 完整匯出在 token 系統關閉時一律 403（無法驗證身分 → PII 永不離機）。預設 default-off 姿態仍可用：redacted export 開放（與 S0-2 byte-identical 原則一致） |

## 三刀

- **T2B-1** `trace_store.py`（比照 `auth.py` ROS-free pure-module 先例）：`append()` 只 enqueue（ROS executor thread 零檔案 I/O）、daemon writer 1s flush、`runtime/traces/{session_id}.jsonl`、~20MB rotation、留新 20 檔；`PAWAI_TRACE_STORE_ENABLED=0` kill-switch = 回純 bridge（rollback 故事）；15 條純測 + CI Invocation 8 接入
- **T2B-2** gateway：lifespan 管生命週期；`_maybe_persist_trace()` 掛 `/brain/trace` bridge（存全量 → 廣播 redacted；此 WS 事件**先前無任何前端消費者**，零既有行為破壞）；`GET /api/trace/export?since=&redact=` streaming x-ndjson
- **T2B-3** 前端：`BrainTraceEvent` type、`brainTraces` slice（cap 50 比照 conversationTraces）、event-stream `trace` 分支、`SkillTraceContent` 加「為什麼沒反應 · Suppressed」區（DevPanel/dev page 三處共用，shadow badge 標 ISM shadow 事件）

## 紀律對照

- ✅ D5 邊界：schema=contracts（未動）、發射=Brain（未動）、落盤=gateway、CLI 只讀（Lane 2C 接）
- ✅ 既有 gateway 測試零修改全綠（80 passed）；`test_gateway.py` 原樣
- ✅ flake8 零新增違規（trace 分支抽 helper 保住 `_on_ros2_msg` 複雜度 10；新檔過 blocking `--max-complexity=10`）
- ✅ `/runtime/traces/` 入 .gitignore（PII + 體積，永不進 repo）
- ✅ 凍結檔零接觸；Plan E 表外 6 處未插樁 suppression 未動（trace v2 另案）

## Tests

- gateway：**80 passed**（含新 15 trace_store + 3 export_access）
- frontend：vitest **16/16** + `tsc --noEmit` 乾淨
- 真機驗證（export curl + evidence pull 對接）留待 Lane 2C + Roy HITL

🤖 Generated with [Claude Code](https://claude.com/claude-code)