### PR TITLE
feat(cli): pawai smoke brain + evidence pull + structured errors + test isolation (system Phase 2 / 2C)

### DIFF
--- a/tools/pawai_cli/pawai_cli/errors.py
+++ b/tools/pawai_cli/pawai_cli/errors.py
@@ -1,0 +1,18 @@
+"""Structured CLI errors (system Phase 2 T2C-3).
+
+Rule: every failure a teammate can hit names its fix — the error text carries
+"↳" suggestion lines the user can paste/run (pawai doctor, deploy, env vars),
+instead of a bare exit code they have to come ask Roy about.
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import click
+
+
+def structured_error(message: str, hints: Sequence[str]) -> click.ClickException:
+    """Build a ClickException whose text includes actionable fix lines."""
+    lines = [message]
+    lines.extend(f"  ↳ {hint}" for hint in hints)
+    return click.ClickException("\n".join(lines))

--- a/tools/pawai_cli/pawai_cli/evidence.py
+++ b/tools/pawai_cli/pawai_cli/evidence.py
@@ -1,0 +1,87 @@
+"""pawai evidence — read-only Evidence Center artifact pull (T2C-2).
+
+Roy D5 ruling: trace 單一真相 = pawai_contracts schema + gateway JSONL；
+CLI 只負責「讀取與匯出」。This command rsyncs the gateway trace store
+(runtime/traces/*.jsonl on the Jetson, written by pawai-studio/gateway/
+trace_store.py) back to local artifacts/evidence/traces/ and prints a short
+summary. It never deletes on either side and never rewrites the JSONL.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+
+from . import shell
+from .errors import structured_error
+
+EVIDENCE_DEST_REL = Path("artifacts/evidence/traces")
+
+
+def summarize_jsonl_dir(directory: Path) -> dict:
+    """Pure summary of pulled JSONL: file/event/suppressed counts.
+    Garbage lines are skipped (same tolerance as the gateway export)."""
+    files = sorted(Path(directory).glob("*.jsonl"))
+    events = 0
+    suppressed = 0
+    for path in files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for raw in text.splitlines():
+            raw = raw.strip()
+            if not raw:
+                continue
+            try:
+                ev = json.loads(raw)
+            except (ValueError, TypeError):
+                continue
+            if not isinstance(ev, dict):
+                continue
+            events += 1
+            if ev.get("verdict") == "suppressed":
+                suppressed += 1
+    return {"files": len(files), "events": events, "suppressed": suppressed}
+
+
+@click.group("evidence")
+def evidence() -> None:
+    """Evidence Center artifacts（只讀，不改 Jetson 端任何東西）。"""
+
+
+@evidence.command("pull")
+@click.option("--dest", "dest_str", default=None,
+              help="Local destination dir (default: artifacts/evidence/traces).")
+def pull(dest_str: str | None) -> None:
+    """Pull runtime/traces/*.jsonl from the Jetson gateway trace store."""
+    root = shell.repo_root()
+    dest = Path(dest_str).expanduser() if dest_str else root / EVIDENCE_DEST_REL
+    dest.mkdir(parents=True, exist_ok=True)
+    src = f"{shell.jetson_host()}:{shell.jetson_repo().rstrip('/')}/runtime/traces/"
+    # Read-only pull: -az, NO --delete (local extras stay; remote untouched).
+    argv = ["rsync", "-az", src, f"{dest}/"]
+    code = shell.stream(argv)
+    if code == 127:
+        raise structured_error(
+            "rsync not found on this machine",
+            ["install rsync: sudo apt install rsync (Linux/WSL) / "
+             "brew install rsync (Mac)"],
+        )
+    if code != 0:
+        raise structured_error(
+            f"evidence pull failed (rsync exit {code})",
+            [
+                "SSH 不通？跑 `pawai doctor` 看 Network topology / Tailscale 區塊",
+                f"確認 Jetson 端有 trace：ssh {shell.jetson_host()} "
+                f"'ls {shell.jetson_repo()}/runtime/traces/'",
+                "gateway 沒跑、或 store 被 PAWAI_TRACE_STORE_ENABLED=0 關掉時，"
+                "Jetson 端不會有檔案",
+            ],
+        )
+    summary = summarize_jsonl_dir(dest)
+    click.echo(
+        f"✓ pulled {summary['files']} file(s), {summary['events']} event(s), "
+        f"{summary['suppressed']} suppressed → {dest}"
+    )

--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -16,6 +16,8 @@ import click
 from dotenv import load_dotenv
 
 from . import __version__, shell
+from .errors import structured_error
+from .evidence import evidence as evidence_command
 from .modules import MODULES, existing_docs, get_module
 from .readiness import readiness as readiness_command
 from .status import print_status
@@ -159,6 +161,7 @@ def cli() -> None:
 
 
 cli.add_command(readiness_command)
+cli.add_command(evidence_command)
 
 
 @cli.command()
@@ -790,6 +793,56 @@ _LANE_HEALTHCHECK = {
     "brain": ".claude/skills/brain-studio-lane/scripts/healthcheck.sh",
     "nav_capability": ".claude/skills/nav-avoidance-lane/scripts/healthcheck.sh",
 }
+
+# ── smoke (system Phase 2 T2C-1) ────────────────────────────────────────────
+# Repo-relative scripts run ON THE JETSON over SSH: they publish ROS topics
+# into the live demo stack, so streaming them locally on a dev box would
+# silently no-op (different ROS world). vision/object/nav/full deliberately
+# absent — their 採集 scripts belong to system Phase 3/4/5 (phase 2 plan 2C).
+_SMOKE_SCRIPTS = {
+    "brain": "scripts/smoke_test_e2e.sh",
+}
+
+
+@cli.group()
+def smoke() -> None:
+    """End-to-end smoke runs（包既有腳本，零新 runtime 行為）。"""
+
+
+@smoke.command("brain")
+@click.option("--rounds", default=5, show_default=True, type=click.IntRange(1, 30),
+              help="E2E rounds (smoke_test_e2e.sh argument).")
+def smoke_brain(rounds: int) -> None:
+    """Run the speech E2E smoke (scripts/smoke_test_e2e.sh) on the Jetson.
+
+    前提：demo / llm-e2e tmux session 已在 Jetson 上跑（pawai demo start）。
+    """
+    rel = _SMOKE_SCRIPTS["brain"]
+    repo = shell.jetson_repo()
+    probe = shell.run_remote(f"test -f {repo}/{rel}", timeout=10)
+    if probe.code in (124, 127, 255):
+        raise structured_error(
+            f"SSH to {shell.jetson_host()} failed (exit {probe.code})",
+            [
+                "跑 `pawai doctor` 看 Network topology / Tailscale 區塊",
+                "確認 JETSON_HOST / .env.local 沒有 CRLF（pawai doctor 會驗）",
+            ],
+        )
+    if not probe.ok:
+        raise structured_error(
+            f"{rel} not found on Jetson ({repo})",
+            [
+                "先同步腳本：pawai jetson deploy --module brain --no-build",
+                "或確認 JETSON_REPO 指向正確的 repo 路徑",
+            ],
+        )
+    rc = shell.stream_remote(f"cd {repo} && bash {rel} {rounds}")
+    if rc != 0:
+        click.echo(f"✗ smoke brain failed (exit {rc})")
+        click.echo("  ↳ demo lane 活著嗎？跑 `pawai health brain` 看哪個環節紅")
+        click.echo("  ↳ 沒起 demo 就先 `pawai demo start`，等 ready 再 smoke")
+        sys.exit(rc)
+    click.echo("✓ smoke brain passed")
 
 
 def _run_lane_healthcheck(lane: str) -> int:

--- a/tools/pawai_cli/tests/conftest.py
+++ b/tools/pawai_cli/tests/conftest.py
@@ -1,0 +1,99 @@
+"""Shared CLI test isolation (system Phase 2 T2C-0 — the #150 lesson).
+
+Issue #150: a CLI test escaped to the real repo root, loaded the developer's
+.env.local (real JETSON_HOST), and an un-mocked shell call did a REAL ssh that
+hung ~300s. The same class resurfaced 2026-06-12: doctor tests that mock only
+find_jetson_peer let the topology probes run real `ssh` — 27s per test with
+the Jetson off, indefinitely with a black-holing resolver. Structural fixes:
+
+1. PAWAI_REPO_ROOT always points at an isolated tmp dir; JETSON_HOST /
+   JETSON_REPO pinned to deterministic test values. Tests needing a custom
+   root monkeypatch.setenv on top (wins over the autouse fixture).
+2. Remote/stream shell entry points are REFUSED by default: an un-mocked call
+   returns instantly (255 / 127) with a loud "blocked-by-conftest" marker
+   instead of touching the network. Tests that legitimately exercise these
+   paths already `patch()` them per-test — an inner patch overrides the stub
+   and restores it on exit. shell.run stays real: it only ever runs fast
+   local commands (git / tailscale) in this suite.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from pawai_cli import shell
+
+# readiness delegates verdict logic to benchmarks.core — that package lives at
+# the REAL repo root, which PAWAI_REPO_ROOT isolation (below) hides. Imports
+# resolve against the real tree; filesystem reads stay isolated in tmp_path.
+_REAL_REPO_ROOT = str(Path(__file__).resolve().parents[3])
+if _REAL_REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REAL_REPO_ROOT)
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "real_repo: test reads real repo files (docs/scripts/schemas) — skips the "
+        "PAWAI_REPO_ROOT tmp isolation; remote refusal stubs stay active.",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cli_env(request, tmp_path, monkeypatch):
+    if request.node.get_closest_marker("real_repo"):
+        # Real repo files, but NEVER the developer's .env/.env.local — that is
+        # machine-specific pollution (the #150 class: a real JETSON_TAILSCALE_IP
+        # in .env.local silently overwrites the values these tests simulate via
+        # monkeypatch.setenv). CI has no .env.local; this makes local == CI.
+        from pawai_cli import main as _main
+        monkeypatch.setattr(_main, "_load_env", lambda root: None)
+        yield
+        return
+    monkeypatch.setenv("PAWAI_REPO_ROOT", str(tmp_path))
+    monkeypatch.setenv("JETSON_HOST", "jetson-test")
+    monkeypatch.setenv("JETSON_REPO", "/home/jetson/elder_and_dog")
+    yield
+
+
+_NETWORK_BINARIES = ("ssh", "rsync", "scp")
+
+
+@pytest.fixture(autouse=True)
+def _no_real_remote(monkeypatch):
+    real_run = shell.run
+    real_stream = shell.stream
+
+    def _refuse_run_remote(command, timeout=None):
+        return shell.Result(
+            255, "", f"blocked-by-conftest: un-mocked run_remote({command!r}) — "
+            "tests must patch shell.run_remote explicitly (T2C-0 / #150)")
+
+    def _refuse_stream_remote(command):
+        return 255
+
+    def _guarded_run(argv, cwd=None, timeout=None):
+        # doctor probes ssh via shell.run(shell.ssh_args(...)) — that is still
+        # the network. Local tools (git / tailscale / bash) stay real and fast.
+        argv = list(argv)
+        if argv and argv[0] in _NETWORK_BINARIES:
+            return shell.Result(
+                255, "", f"blocked-by-conftest: un-mocked {argv[0]} call — "
+                "patch shell.run / mock the probe explicitly (T2C-0 / #150)")
+        return real_run(argv, cwd=cwd, timeout=timeout)
+
+    def _guarded_stream(argv, cwd=None, env=None):
+        # Same rule for the streaming runner: local scripts (contract check,
+        # healthcheck wrappers under test) run for real; ssh/rsync never do.
+        argv = list(argv)
+        if argv and argv[0] in _NETWORK_BINARIES:
+            return 127
+        return real_stream(argv, cwd=cwd, env=env)
+
+    monkeypatch.setattr(shell, "run_remote", _refuse_run_remote)
+    monkeypatch.setattr(shell, "stream_remote", _refuse_stream_remote)
+    monkeypatch.setattr(shell, "stream", _guarded_stream)
+    monkeypatch.setattr(shell, "run", _guarded_run)
+    yield

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -525,6 +525,7 @@ def test_demo_stop_own_stale_lock_releases_without_force(monkeypatch):
     mock_rel.assert_called_once_with(user="lubaiyu", host="Roy422deMacBook-Pro.local")
 
 
+@pytest.mark.real_repo  # reads real repo docs/scripts (T2C-0)
 def test_health_brain_passes_jetson_host_env(monkeypatch):
     """Detected live Tailscale peer must override whatever JETSON_TAILSCALE_IP
     the env happened to have (e.g. stale .env.local from a previous Jetson
@@ -911,6 +912,7 @@ def test_demo_start_rejects_invalid_nav_modes():
 
 # ──────────────── L3 tests ────────────────
 
+@pytest.mark.real_repo  # reads real repo docs/scripts (T2C-0)
 def test_pawai_docs_brain_resolves_path():
     runner = CliRunner()
     result = runner.invoke(cli, ["docs", "brain"])
@@ -926,12 +928,14 @@ def test_pawai_docs_unknown_lists_valid():
     assert "brain" in result.output and "face" in result.output  # the list
 
 
+@pytest.mark.real_repo  # reads real repo docs/scripts (T2C-0)
 def test_pawai_docs_onboarding_alias():
     runner = CliRunner()
     result = runner.invoke(cli, ["docs", "onboarding"])
     assert "team-onboarding" in result.output
 
 
+@pytest.mark.real_repo  # reads real repo docs/scripts (T2C-0)
 def test_contract_check_runs_local_when_script_exists(tmp_path, monkeypatch):
     # Stage a fake repo root with the contract script
     script = tmp_path / "scripts/ci/check_topic_contracts.py"

--- a/tools/pawai_cli/tests/test_readiness.py
+++ b/tools/pawai_cli/tests/test_readiness.py
@@ -4,6 +4,8 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from click.testing import CliRunner
 
 from pawai_cli.main import cli
@@ -30,6 +32,7 @@ def _invoke_readiness(args, *, manifest=None):
         return CliRunner().invoke(cli, ["readiness", *args])
 
 
+@pytest.mark.real_repo  # needs real .claude/schemas (T2C-0)
 def test_readiness_json_ready(monkeypatch, tmp_path):
     monkeypatch.setenv("PAWAI_SCOREBOARD_PATH", str(_snapshot_path(tmp_path)))
 
@@ -41,6 +44,7 @@ def test_readiness_json_ready(monkeypatch, tmp_path):
     assert payload["reasons"] == []
 
 
+@pytest.mark.real_repo  # needs real .claude/schemas (T2C-0)
 def test_readiness_accept_warnings_records_override(monkeypatch, tmp_path):
     snapshot_path = _snapshot_path(
         tmp_path,

--- a/tools/pawai_cli/tests/test_smoke_evidence.py
+++ b/tools/pawai_cli/tests/test_smoke_evidence.py
@@ -1,0 +1,164 @@
+"""pawai smoke brain / pawai evidence pull (system Phase 2 T2C-1/2/3).
+
+Every shell interaction is mocked (conftest T2C-0 pins PAWAI_REPO_ROOT /
+JETSON_HOST; per-test patches cover run_remote / stream_remote / stream) —
+no SSH, no rsync, no network, suite stays sub-second. Structured-error paths
+(T2C-3) assert the fix-suggestion lines verbatim enough to catch regressions.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from pawai_cli.main import cli
+from pawai_cli.shell import Result
+
+
+def _invoke(args):
+    return CliRunner().invoke(cli, args)
+
+
+# ── pawai smoke brain (T2C-1) ───────────────────────────────────────────────
+
+def test_smoke_brain_runs_remote_script_with_rounds():
+    calls: dict = {}
+
+    def fake_run_remote(cmd, timeout=None):
+        calls["probe"] = cmd
+        return Result(0, "", "")
+
+    def fake_stream_remote(cmd):
+        calls["stream"] = cmd
+        return 0
+
+    with patch("pawai_cli.main.shell.run_remote", side_effect=fake_run_remote), \
+         patch("pawai_cli.main.shell.stream_remote", side_effect=fake_stream_remote):
+        result = _invoke(["smoke", "brain", "--rounds", "3"])
+
+    assert result.exit_code == 0, result.output
+    assert "scripts/smoke_test_e2e.sh" in calls["probe"]
+    assert "cd /home/jetson/elder_and_dog" in calls["stream"]
+    assert "bash scripts/smoke_test_e2e.sh 3" in calls["stream"]
+
+
+def test_smoke_brain_default_is_5_rounds():
+    calls: dict = {}
+    with patch("pawai_cli.main.shell.run_remote", return_value=Result(0, "", "")), \
+         patch("pawai_cli.main.shell.stream_remote",
+               side_effect=lambda cmd: calls.setdefault("stream", cmd) and 0):
+        result = _invoke(["smoke", "brain"])
+    assert result.exit_code == 0, result.output
+    assert "bash scripts/smoke_test_e2e.sh 5" in calls["stream"]
+
+
+def test_smoke_brain_ssh_unreachable_names_the_fix():
+    with patch("pawai_cli.main.shell.run_remote",
+               return_value=Result(255, "", "ssh: connect to host ... timed out")):
+        result = _invoke(["smoke", "brain"])
+    assert result.exit_code != 0
+    assert "SSH" in result.output
+    assert "pawai doctor" in result.output          # T2C-3 fix hint
+
+
+def test_smoke_brain_missing_remote_script_fail_closed():
+    with patch("pawai_cli.main.shell.run_remote", return_value=Result(1, "", "")):
+        result = _invoke(["smoke", "brain"])
+    assert result.exit_code != 0
+    assert "scripts/smoke_test_e2e.sh" in result.output
+    assert "pawai jetson deploy" in result.output   # sync suggestion
+
+
+def test_smoke_brain_nonzero_rc_propagates_with_hint():
+    with patch("pawai_cli.main.shell.run_remote", return_value=Result(0, "", "")), \
+         patch("pawai_cli.main.shell.stream_remote", return_value=2):
+        result = _invoke(["smoke", "brain"])
+    assert result.exit_code == 2
+    assert "pawai health brain" in result.output    # next-step hint
+
+
+# ── pawai evidence pull (T2C-2) ─────────────────────────────────────────────
+
+def _fake_rsync_writing(files: dict[str, str]):
+    """Return a shell.stream fake that simulates rsync materializing files."""
+    calls: dict = {}
+
+    def fake_stream(argv, cwd=None, env=None):
+        calls["argv"] = list(argv)
+        dest = Path(list(argv)[-1])
+        dest.mkdir(parents=True, exist_ok=True)
+        for name, content in files.items():
+            (dest / name).write_text(content, encoding="utf-8")
+        return 0
+
+    return calls, fake_stream
+
+
+def test_evidence_pull_rsync_argv_read_only():
+    calls, fake = _fake_rsync_writing(
+        {"s1.jsonl": '{"ts": 1, "verdict": "suppressed"}\n{"ts": 2, "verdict": "accepted"}\n'}
+    )
+    with patch("pawai_cli.evidence.shell.stream", side_effect=fake):
+        result = _invoke(["evidence", "pull"])
+    assert result.exit_code == 0, result.output
+    argv = calls["argv"]
+    assert argv[0] == "rsync"
+    assert "--delete" not in argv                       # pull NEVER deletes
+    assert argv[-2] == "jetson-test:/home/jetson/elder_and_dog/runtime/traces/"
+    assert argv[-1].endswith("artifacts/evidence/traces/")
+
+
+def test_evidence_pull_prints_summary():
+    calls, fake = _fake_rsync_writing({
+        "s1.jsonl": '{"ts": 1, "verdict": "suppressed"}\n{"ts": 2, "verdict": "accepted"}\n',
+        "s2.jsonl": '{"ts": 3, "verdict": "suppressed"}\nGARBAGE-LINE\n',
+    })
+    with patch("pawai_cli.evidence.shell.stream", side_effect=fake):
+        result = _invoke(["evidence", "pull"])
+    assert result.exit_code == 0, result.output
+    assert "2 file(s)" in result.output
+    assert "3 event(s)" in result.output                # garbage line skipped
+    assert "2 suppressed" in result.output
+
+
+def test_evidence_pull_custom_dest(tmp_path):
+    calls, fake = _fake_rsync_writing({"s1.jsonl": '{"ts": 1}\n'})
+    dest = tmp_path / "my-evidence"
+    with patch("pawai_cli.evidence.shell.stream", side_effect=fake):
+        result = _invoke(["evidence", "pull", "--dest", str(dest)])
+    assert result.exit_code == 0, result.output
+    assert calls["argv"][-1] == f"{dest}/"
+
+
+def test_evidence_pull_rsync_missing_names_install_fix():
+    with patch("pawai_cli.evidence.shell.stream", return_value=127):
+        result = _invoke(["evidence", "pull"])
+    assert result.exit_code != 0
+    assert "rsync" in result.output
+    assert "install" in result.output                   # install hint
+
+
+def test_evidence_pull_ssh_fail_names_doctor_and_store():
+    with patch("pawai_cli.evidence.shell.stream", return_value=255):
+        result = _invoke(["evidence", "pull"])
+    assert result.exit_code != 0
+    assert "pawai doctor" in result.output
+    assert "PAWAI_TRACE_STORE_ENABLED" in result.output  # empty-store hint
+
+
+# ── summarize helper (pure) ─────────────────────────────────────────────────
+
+def test_summarize_jsonl_dir_counts(tmp_path):
+    from pawai_cli.evidence import summarize_jsonl_dir
+    (tmp_path / "a.jsonl").write_text(
+        '{"ts": 1, "verdict": "suppressed"}\n{"ts": 2}\nnot-json\n', encoding="utf-8")
+    (tmp_path / "b.jsonl").write_text('{"ts": 3, "verdict": "suppressed"}\n',
+                                      encoding="utf-8")
+    summary = summarize_jsonl_dir(tmp_path)
+    assert summary == {"files": 2, "events": 3, "suppressed": 2}
+
+
+def test_summarize_jsonl_dir_empty(tmp_path):
+    from pawai_cli.evidence import summarize_jsonl_dir
+    assert summarize_jsonl_dir(tmp_path) == {"files": 0, "events": 0, "suppressed": 0}


### PR DESCRIPTION
## Summary

系統 Phase 2 Lane 2C（pre-6/18 additive-only）：CLI v2 第二刀。三條命令路徑全部**零 runtime 行為**（只包既有腳本 / rsync），加上 T2C-0 的測試隔離地基。

## 四刀

- **T2C-0 `tests/conftest.py`**（#150 教訓的結構性落地）：`PAWAI_REPO_ROOT`→tmp_path autouse、`JETSON_HOST/JETSON_REPO` 釘死；**未 mock 的 remote 呼叫直接被拒**（run_remote/stream_remote 即回 255 帶 `blocked-by-conftest` 標記；`shell.run`/`shell.stream` 按 argv[0] 攔 ssh/rsync/scp、放行 git/tailscale/bash）；六條讀真 repo 檔案的既有測試掛 `real_repo` marker，且該模式下**中和 .env/.env.local 載入**——開發機真實 `JETSON_TAILSCALE_IP` 會悄悄蓋掉測試 monkeypatch 的模擬值（local==CI 決定性）
- **T2C-1 `pawai smoke brain`**：SSH 到 Jetson 跑 `scripts/smoke_test_e2e.sh`（先 probe 腳本存在，fail-closed；`--rounds` 1-30）。**對 plan 文字的修正**：plan 寫仿 health 的本地 `shell.stream` 包法，但該腳本直接 `ros2 topic pub`、在開發機本地跑會靜默 no-op —— 改走 `stream_remote` 在 Jetson 上執行。smoke vision/object/nav/full 刻意不做（系統 Phase 3/4/5 範圍）
- **T2C-2 `pawai evidence pull`**（新 `evidence.py`，仿 readiness.py 模組模式）：`rsync -az <jetson>:<repo>/runtime/traces/ → artifacts/evidence/traces/`，**全程無 --delete**（CLI 只讀，Roy D5）；拉回後印 files/events/suppressed 摘要；`--dest` 可覆寫
- **T2C-3 structured errors**（新 `errors.py`）：每個失敗都帶可照做的「↳」修法行（pawai doctor / deploy / `PAWAI_TRACE_STORE_ENABLED` 提示），測試逐字斷言

## 量化效果（T2C-0）

本機（Jetson 關機狀態）CLI 套件：**105s+ → 0.65s，173 passed**。先前 doctor 類測試各含 ~10s 真 ssh probe（`shell.run(ssh_args("echo OK"))`）+ 一條 27s topology 探測；#150 的 300s 假掛類在此套件已結構性不可能。

## 紀律對照

- ✅ 零 runtime 行為：不碰 demo/deploy/health 既有路徑；新命令獨立可 revert
- ✅ 既有測試語義不變：`real_repo` 六條 = 加 decorator（4 行 ×2 檔），其餘 161 條零修改
- ✅ flake8：新檔過 blocking gate（`--max-complexity=10`），修改檔零新增違規
- ✅ 凍結檔零接觸
- 真機收尾（`smoke brain` 真跑綠 + `evidence pull` 拉回第一批真 JSONL）需 Jetson 開機 —— 列入 checkpoint report 待 Roy

🤖 Generated with [Claude Code](https://claude.com/claude-code)