### PR TITLE
fix(cli): pawai smoke brain — source ROS env over non-interactive SSH

### DIFF
--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -836,7 +836,15 @@ def smoke_brain(rounds: int) -> None:
                 "或確認 JETSON_REPO 指向正確的 repo 路徑",
             ],
         )
-    rc = shell.stream_remote(f"cd {repo} && bash {rel} {rounds}")
+    # Non-interactive SSH loads no ROS env (zsh -c skips .zshrc) — the smoke
+    # script's `ros2 node list` precheck would see zero nodes and false-FAIL.
+    # Same sourcing precedent as the deploy-side colcon build (6/12 真機驗證).
+    rc = shell.stream_remote(
+        f"cd {repo} && "
+        "source /opt/ros/humble/setup.zsh 2>/dev/null || true; "
+        "source install/setup.zsh 2>/dev/null || true; "
+        f"bash {rel} {rounds}"
+    )
     if rc != 0:
         click.echo(f"✗ smoke brain failed (exit {rc})")
         click.echo("  ↳ demo lane 活著嗎？跑 `pawai health brain` 看哪個環節紅")

--- a/tools/pawai_cli/tests/test_smoke_evidence.py
+++ b/tools/pawai_cli/tests/test_smoke_evidence.py
@@ -40,6 +40,10 @@ def test_smoke_brain_runs_remote_script_with_rounds():
     assert result.exit_code == 0, result.output
     assert "scripts/smoke_test_e2e.sh" in calls["probe"]
     assert "cd /home/jetson/elder_and_dog" in calls["stream"]
+    # Non-interactive SSH loads no ROS env — without sourcing, the script's
+    # `ros2 node list` precheck sees zero nodes and false-FAILs (6/12 真機).
+    assert "source /opt/ros/humble/setup.zsh" in calls["stream"]
+    assert "source install/setup.zsh" in calls["stream"]
     assert "bash scripts/smoke_test_e2e.sh 3" in calls["stream"]
 
 


### PR DESCRIPTION
真機 smoke 抓到的 Lane 3 bug：`ssh jetson 'cmd'` 走 zsh -c 不載 .zshrc → 腳本 precheck 的 `ros2 node list` 看到 0 nodes 而誤判 FAIL（driver 實際活著、19 nodes）。修法照 `_do_rsync_and_build` 既有先例補 source setup.zsh + install/setup.zsh。先改測試（紅）再修（綠），CLI 套件 173 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)