### PR TITLE
fix(demo+smoke): ASR provider_order zsh quoting（凍結檔，Roy 授權）+ smoke 支援 demo lane

### DIFF
--- a/scripts/smoke_test_e2e.sh
+++ b/scripts/smoke_test_e2e.sh
@@ -23,11 +23,18 @@ echo "════════════════════════�
 echo ""
 echo "[PRE] Checking nodes..."
 NODES=$(ros2 node list 2>/dev/null)
-for n in go2_driver_node stt_intent_node tts_node llm_bridge_node; do
+# 6/12: brain demo lane (start_full_demo_tmux.sh) runs conversation_graph_node;
+# the legacy llm-e2e session runs llm_bridge_node. Accept either stack.
+if echo "$NODES" | grep -q "conversation_graph_node"; then
+  BRAIN_REQ="conversation_graph_node"
+else
+  BRAIN_REQ="llm_bridge_node"
+fi
+for n in go2_driver_node stt_intent_node tts_node "$BRAIN_REQ"; do
   if echo "$NODES" | grep -q "$n"; then
     echo "  [OK] $n"
   else
-    echo "  [FAIL] $n not found — is llm-e2e session running?"
+    echo "  [FAIL] $n not found — is the demo / llm-e2e session running?"
     exit 1
   fi
 done
@@ -42,6 +49,11 @@ for i in $(seq 1 "$ROUNDS"); do
   # Clear old debug WAV
   rm -f /tmp/megaphone_debug_*.wav 2>/dev/null
 
+  # 6/12: local-playback baseline (USB speaker path has no megaphone WAV —
+  # count tts pane completions before/after instead)
+  LOCAL_BEFORE=$(tmux capture-pane -t demo:tts -p -S -300 2>/dev/null \
+    | grep -c "Local playback completed" || true)
+
   # Send TTS
   echo "  [SEND] /tts: \"$TEST_PHRASE\""
   ros2 topic pub --once /tts std_msgs/msg/String "{data: \"$TEST_PHRASE\"}" >/dev/null 2>&1
@@ -49,15 +61,23 @@ for i in $(seq 1 "$ROUNDS"); do
   # Wait for playback (TTS synthesis ~2.5s + Megaphone ~3s + tail)
   sleep 8
 
-  # ── Check 1: Debug WAV exists (TTS ran) ──
+  # ── Check 1: playback evidence — megaphone debug WAV (datachannel path)
+  # OR tts pane "Local playback completed" increment (USB speaker path, 6/12) ──
   WAV=$(ls -t /tmp/megaphone_debug_*.wav 2>/dev/null | head -1)
-  if [ -z "$WAV" ]; then
-    echo "  [FAIL] No debug WAV — TTS didn't produce audio"
-    FAIL=$((FAIL + 1))
-    continue
+  if [ -n "$WAV" ]; then
+    WAV_SIZE=$(stat -c%s "$WAV" 2>/dev/null || echo "0")
+    echo "  [OK] Debug WAV: $WAV ($WAV_SIZE bytes)"
+  else
+    LOCAL_AFTER=$(tmux capture-pane -t demo:tts -p -S -300 2>/dev/null \
+      | grep -c "Local playback completed" || true)
+    if [ "${LOCAL_AFTER:-0}" -gt "${LOCAL_BEFORE:-0}" ]; then
+      echo "  [OK] Local playback completed (+$((LOCAL_AFTER - LOCAL_BEFORE)))"
+    else
+      echo "  [FAIL] No playback evidence (no megaphone WAV, no local-playback log)"
+      FAIL=$((FAIL + 1))
+      continue
+    fi
   fi
-  WAV_SIZE=$(stat -c%s "$WAV" 2>/dev/null || echo "0")
-  echo "  [OK] Debug WAV: $WAV ($WAV_SIZE bytes)"
 
   # ── Check 2: Megaphone log (Go2 received chunks) ──
   MEGA_LOG=$(tmux capture-pane -t llm-e2e:0.1 -p -J 2>/dev/null | grep "Megaphone playback completed" | tail -1)

--- a/scripts/start_full_demo_tmux.sh
+++ b/scripts/start_full_demo_tmux.sh
@@ -67,7 +67,11 @@ if [[ "$CONVERSATION_ENGINE" != "langgraph" && "$CONVERSATION_ENGINE" != "legacy
 fi
 
 # ── ASR ──
-ASR_PROVIDER_ORDER="${ASR_PROVIDER_ORDER:-'[\"qwen_cloud\",\"sensevoice_local\",\"whisper_local\"]'}"
+# 值保持「乾淨的 yaml 陣列」（不內嵌殼層引號）— 引號統一在 send-keys 那層補
+# （window 5）。歷史坑（6/12 真機）：預設值內嵌 '...' 時預設路徑能跑，但 .env
+# 來的值經 bash source 剝掉引號後，未加引號展開進 zsh pane → `[` glob 炸掉
+# → stt_intent_node 靜默死亡（zsh: no matches found）。
+ASR_PROVIDER_ORDER="${ASR_PROVIDER_ORDER:-[\"qwen_cloud\",\"sensevoice_local\",\"whisper_local\"]}"
 QWEN_ASR_BASE_URL="${QWEN_ASR_BASE_URL:-http://127.0.0.1:8001/v1/audio/transcriptions}"
 QWEN_ASR_TIMEOUT="${QWEN_ASR_TIMEOUT:-3.0}"
 INPUT_DEVICE="${INPUT_DEVICE:-24}"
@@ -181,7 +185,7 @@ tmux new-window -t "$SESSION" -n asr
 tmux send-keys -t "$SESSION:asr" \
   "$ROS_SETUP && \
   ros2 run speech_processor stt_intent_node --ros-args \
-    -p provider_order:=$ASR_PROVIDER_ORDER \
+    -p provider_order:='$ASR_PROVIDER_ORDER' \
     -p qwen_asr.base_url:='$QWEN_ASR_BASE_URL' \
     -p qwen_asr.timeout_sec:=$QWEN_ASR_TIMEOUT \
     -p qwen_asr.model_name:=sensevoice \


### PR DESCRIPTION
## 真機 Phase 2 驗收抓到的兩個既有問題（Roy 在場授權修復）

### 1. `start_full_demo_tmux.sh`（凍結檔——Roy 6/12 現場明示授權）

**症狀**：demo lane 的 stt_intent_node 從沒起來過（`zsh: no matches found: provider_order:=[...]`），19-node stack 沒有 ASR。
**根因**：`.env` 的 `ASR_PROVIDER_ORDER=["a","b"]` 被 bash source 剝掉內層引號 → line 184 未加引號展開進 zsh pane → `[` glob 炸。預設值（line 70）自帶內嵌引號所以「預設路徑能跑、.env 路徑必死」——長期地雷，非今晚 regression（今晚凍結檔 diff 全程 = 0 直到本授權修復）。
**修法**：引號統一收斂到 send-keys 一層（line 184 wrap `'...'`），預設值去內嵌引號（line 70）。zsh 層紅綠驗證：未引號重現 `no matches found`、修後乾淨通過。

### 2. `smoke_test_e2e.sh`（非凍結）

原 precheck 寫死 llm-e2e stack（要 `llm_bridge_node`）+ Check 1 只認 Megaphone debug WAV——對 brain demo lane（`conversation_graph_node` + USB 喇叭 local playback）永遠不會綠。改為雙 stack precheck + 播放證據雙路徑（WAV 優先、`demo:tts` pane「Local playback completed」增量為後備）。llm-e2e 原行為保留。

### 驗證計畫（merge 後立即真機）
deploy → `pawai demo stop && pawai demo start` → 確認 stt_intent_node 在 node list → `pawai smoke brain` 5 輪期望全綠。

🤖 Generated with [Claude Code](https://claude.com/claude-code)