### PR TITLE
fix(smoke): /tts publish 加 --times 2 避開 discovery race

### DIFF
--- a/scripts/smoke_test_e2e.sh
+++ b/scripts/smoke_test_e2e.sh
@@ -55,8 +55,14 @@ for i in $(seq 1 "$ROUNDS"); do
     | grep -c "Local playback completed" || true)
 
   # Send TTS
+  # 6/12: --once races RELIABLE-subscriber discovery (documented repo trap —
+  # /tts has 3 subscribers; a fresh pub can publish before tts_node matches,
+  # and -w N stalls forever when any one sub is QoS-incompatible). Publish
+  # twice 1s apart: the second copy always lands post-discovery. The phrase
+  # may play twice in a round — harmless for a smoke run (5/5 真機驗證).
   echo "  [SEND] /tts: \"$TEST_PHRASE\""
-  ros2 topic pub --once /tts std_msgs/msg/String "{data: \"$TEST_PHRASE\"}" >/dev/null 2>&1
+  timeout 15 ros2 topic pub -r 1 --times 2 /tts std_msgs/msg/String \
+    "{data: \"$TEST_PHRASE\"}" >/dev/null 2>&1
 
   # Wait for playback (TTS synthesis ~2.5s + Megaphone ~3s + tail)
   sleep 8


### PR DESCRIPTION
真機 5 輪 smoke 只到 3/5：`--once` 每輪新 publisher 會搶在 tts_node match 前發出（repo 文件化老坑）。等 1 個 match 不夠（/tts 有 3 訂閱者，先 match 的可能是 gateway）、等 3 個會永久卡（matching 只數 QoS 相容訂閱）。改 `--times 2 -r 1`：第二發必然落在 discovery 完成後。真機手動驗證 5/5 distinct rounds 全到（一輪可能播兩次，smoke 可接受）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)