### PR TITLE
fix(deploy): rsync excludes 補 runtime/ + artifacts/（6/12 真機 data-loss）

### DIFF
--- a/tools/sync/rsync-excludes.txt
+++ b/tools/sync/rsync-excludes.txt
@@ -9,6 +9,12 @@
 build/
 install/
 log/
+# Jetson-side runtime data (6/12 真機 incident): the dev repo has no runtime/,
+# so rsync --delete wiped the whole Jetson tree — Evidence Center trace JSONL
+# AND nav_capability named_poses/routes — on every deploy since Plan B made
+# builtin rsync the default. Same class for pulled evidence under artifacts/.
+runtime/
+artifacts/
 __pycache__/
 .pytest_cache/
 .venv/


### PR DESCRIPTION
evidence pull 真機驗證抓到的 deploy data-loss：開發機 repo 沒有 `runtime/` → builtin rsync `--delete`（Plan B #151 起為預設）**每次 deploy 都整棵刪掉 Jetson 的 runtime/**——今晚吃掉第一個 trace session + nav_capability 的 named_poses/routes（`e2b3932` 當初把 nav runtime 搬到 `~/elder_and_dog/runtime` 就是為了 deploy-safe，builtin rsync 路徑悄悄退化了這個保證）。`artifacts/` 同類一併補。

**Roy 注意**：Jetson 端 nav named_poses / routes 已被今晚（以及 6/11 起任何一次）deploy 清掉，下次 nav 場測前需要重建（`/log_pose` 重錄或從備份還原）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)