### PR TITLE
feat(brain): Lane 1 — ISM staged-enable 2a-2d (flag 預設 off)

### DIFF
--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -842,10 +842,44 @@ class BrainNode(Node):
                     IsmSignal(trigger=IsmTrigger.TTS_ACK,
                               detail={"event": "start" if tts else "end"}),
                     now=now)
-            self._ism.tick(now)
+            prev_plan_id = str(getattr(self._ism, "_active_plan_id", "") or "")
+            decision = self._ism.tick(now)
             self._ism_shadow_drain_transitions("")
+            if (
+                decision is not None
+                and str(decision.reason).startswith("watchdog_timeout:executing")
+                and self._ism_stage_on("ism_stage_2c_executing")
+            ):
+                self._watchdog_reset_active_plan(prev_plan_id)
         except Exception as exc:  # noqa: BLE001
             self.get_logger().debug(f"ism shadow tick failed: {exc}")
+
+    def _watchdog_reset_active_plan(self, plan_id: str) -> None:
+        try:
+            with self._lock:
+                active = self._state.active_plan
+                if active is not None and (not plan_id or active.get("plan_id") == plan_id):
+                    cleared_id = active.get("plan_id")
+                    self._state.active_plan = None
+                    self._state.active_step = None
+                else:
+                    cleared_id = None
+            if cleared_id is not None:
+                trace_plan_id = str(plan_id or cleared_id or "")
+                self._trace(TraceEvent(
+                    decision_id=self._plan_decision.get(trace_plan_id, ""),
+                    node="brain_node", kind=TraceKind.STATE_TRANSITION,
+                    verdict=Verdict.SUPPRESSED, gate="watchdog",
+                    reason=f"watchdog_timeout:executing:{trace_plan_id}",
+                    detail={"watchdog": True, "plan_id": trace_plan_id,
+                            "cleanup": "active_plan_reset"},
+                ))
+                self.get_logger().warn(
+                    "[watchdog] EXECUTING timeout - active_plan cleared "
+                    f"(plan_id={trace_plan_id})"
+                )
+        except Exception as exc:  # noqa: BLE001
+            self.get_logger().debug(f"watchdog reset failed: {exc}")
 
     def _ism_shadow_drain_transitions(self, decision_id: str) -> None:
         """Emit STATE_TRANSITION traces for machine history appended since the

--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -17,6 +17,7 @@ from std_msgs.msg import Bool
 from std_msgs.msg import Empty
 from std_msgs.msg import String
 
+from . import interaction_state
 from .attention_machine import AttentionMachine, AttentionState
 # ISM Phase 1 shadow (system Phase 2 / 2A): aliased imports — interaction_state
 # has its own Verdict enum that collides with pawai_contracts.trace_schema.Verdict
@@ -327,20 +328,19 @@ class BrainNode(Node):
     # gesture）。安全鏈（fallen/stop/SafetyLayer）、語音/文字明確指令、Studio
     # skill_request 一律不受 phase 影響 — priority: safety > explicit input > phase。
     # 錄影 SOP：ros2 param set /brain_node demo_phase s3_object（換 take 再切）。
-    _DEMO_PHASES = frozenset({"all", "s2_face", "s3_object", "s4_gesture", "quiet"})
-    _PHASE_ALLOWED_KINDS = {
-        "all": frozenset({"greet", "object", "gesture"}),
-        "s2_face": frozenset({"greet"}),
-        "s3_object": frozenset({"object"}),
-        "s4_gesture": frozenset({"gesture"}),
-        "quiet": frozenset(),
-    }
+    _DEMO_PHASES = frozenset(interaction_state.PHASE_ALLOWED_KINDS)
 
     def _phase_allows(self, kind: str) -> bool:
-        allowed = self._PHASE_ALLOWED_KINDS.get(self.demo_phase)
-        if allowed is None:  # defensive — 未知 phase 視同 all
-            return True
-        if kind in allowed:
+        allowed = interaction_state.PHASE_ALLOWED_KINDS.get(self.demo_phase)
+        legacy_allow = True if allowed is None else kind in allowed
+        allow = legacy_allow
+        if self._ism_stage_on("ism_stage_2a_demo_phase"):
+            try:
+                allow = interaction_state.phase_allows(self.demo_phase, kind)
+            except Exception as exc:  # noqa: BLE001 — takeover must never break callbacks
+                self.get_logger().debug(f"ism demo_phase policy failed: {exc}")
+                allow = legacy_allow
+        if allow:
             return True
         self.get_logger().info(
             f"[phase] {kind} proposal suppressed (demo_phase={self.demo_phase})",

--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -380,6 +380,41 @@ class BrainNode(Node):
             self.get_logger().debug(f"ism confirm preempt check failed: {exc}")
             return False
 
+    def _ism_speaking_queue_marker(self, source_summary: str) -> None:
+        """Additive trace for stage 2d: social candidate QUEUE while SPEAKING.
+
+        Forbidden #6: QUEUE is not replayed in this lane. It is only marked as
+        suppress-with-trace evidence while legacy suppress behavior stays intact.
+        """
+        if not self._ism_stage_on("ism_stage_2d_speaking"):
+            return
+        try:
+            from .interaction_state import (
+                Candidate as _Candidate,
+                InteractionPolicy as _Policy,
+                InteractionState as _State,
+                Priority as _Priority,
+            )
+
+            decision = _Policy.evaluate(
+                _State.SPEAKING,
+                _Candidate(kind="social", priority=_Priority.SOCIAL, source="perception"),
+            )
+            if decision.verdict != IsmVerdict.QUEUE:
+                return
+            self._trace(TraceEvent(
+                decision_id=self._current_decision_id, node="brain_node",
+                kind=TraceKind.STATE_TRANSITION, verdict=Verdict.SUPPRESSED,
+                gate="speaking", reason="gate:speaking",
+                detail={
+                    "queue_v2_pending": True,
+                    "ism_reason": decision.reason,
+                    "source_summary": source_summary,
+                },
+            ))
+        except Exception as exc:  # noqa: BLE001 - takeover must never break callbacks
+            self.get_logger().debug(f"ism speaking queue marker failed: {exc}")
+
     def _set_gesture_enabled(self, enabled: bool, via: str) -> None:
         """gesture_enabled 切換共用路徑（param callback / Studio topic 兩入口）。
 
@@ -1363,6 +1398,8 @@ class BrainNode(Node):
                 self._suppressed(gate="conversation_gate",
                                  reason=f"conversation_gate:{reason_str}",
                                  source_summary=f"gesture={gesture}")
+                if tts_playing:
+                    self._ism_speaking_queue_marker(source_summary=f"gesture={gesture}")
                 self._emit_trace(
                     session_id=f"gesture-{int(time.time())}",
                     engine="brain_node",
@@ -1710,9 +1747,10 @@ class BrainNode(Node):
         if not self._phase_allows("greet"):
             return
         # 5/8 [#F-confirm]: PENDING 期間不發 greet_known_person，避免蓋掉 confirm 流
+        tts_in_parts = bool(self._world.snapshot().tts_playing)
         if not stable or self._has_active_skill_or_sequence() \
                 or self._pending_confirm.state == ConfirmState.PENDING \
-                or self._world.snapshot().tts_playing:
+                or tts_in_parts:
             # 5/9 review: also block during TTS to avoid mid-sentence interrupt.
             parts = []
             if not stable:
@@ -1721,11 +1759,13 @@ class BrainNode(Node):
                 parts.append("active_plan")
             if self._pending_confirm.state == ConfirmState.PENDING:
                 parts.append("pending_confirm")
-            if self._world.snapshot().tts_playing:
+            if tts_in_parts:
                 parts.append("tts_playing")
             self._suppressed(gate="greet_gate", reason=",".join(parts) or "greet_gate",
                              source_summary=f"identity={identity}",
                              throttle_key=f"greet_gate:{identity}")
+            if tts_in_parts:
+                self._ism_speaking_queue_marker(source_summary=f"identity={identity}")
             return
         # 2026-06-08 VIS-4 (Roy): drop the ENGAGED distance/dwell gate. D435 depth at
         # ~1.5-2m is too noisy — a distance threshold forced the user to hold an exact
@@ -1928,6 +1968,7 @@ class BrainNode(Node):
             self._suppressed(gate="tts_playing", reason="tts_playing",
                              source_summary=f"class={class_name}",
                              throttle_key=f"obj_tts:{class_name}")
+            self._ism_speaking_queue_marker(source_summary=f"class={class_name}")
             return  # Don't insert object remark while PAI is speaking
 
         # 2026-05-23 5/27 demo video mode: cup + Roy + recent sitting → 複合句

--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -284,8 +284,16 @@ class BrainNode(Node):
                 self.get_logger().info(
                     f"perception_router_enabled set to {self.perception_router_enabled}"
                 )
-            elif p.name in ("stranger_alert_enabled", "greet_require_sitting",
-                            "ism_shadow_enabled"):
+            elif p.name in (
+                "stranger_alert_enabled",
+                "greet_require_sitting",
+                "ism_shadow_enabled",
+                "ism_enabled",
+                "ism_stage_2a_demo_phase",
+                "ism_stage_2b_confirm",
+                "ism_stage_2c_executing",
+                "ism_stage_2d_speaking",
+            ):
                 # Plain-bool runtime params share one branch (logs byte-identical
                 # to the previous per-param branches). ism_shadow_enabled joined
                 # 2026-06-12 — ISM Phase 1 shadow (T2A-2) runtime switch.
@@ -310,6 +318,9 @@ class BrainNode(Node):
                     self.demo_phase = value
                     self.get_logger().info(f"demo_phase set to {self.demo_phase}")
         return SetParametersResult(successful=True)
+
+    def _ism_stage_on(self, stage_attr: str) -> bool:
+        return bool(self.ism_enabled) and bool(getattr(self, stage_attr, False))
 
     # 2026-06-10（Roy 拍板「demo flow controller / phase gate，S2/S3/S4 不搶話」的
     # 最小外科版）：demo_phase 只 gate「自發性社交 proposal」（greet / object_remark /
@@ -423,6 +434,11 @@ class BrainNode(Node):
         # (_on_set_params) — 6/8 reactive_stop "param read once in __init__" lesson;
         # T2A-4 turns shadow on at runtime without touching the frozen demo script.
         self.declare_parameter("ism_shadow_enabled", False)
+        self.declare_parameter("ism_enabled", False)
+        self.declare_parameter("ism_stage_2a_demo_phase", False)
+        self.declare_parameter("ism_stage_2b_confirm", False)
+        self.declare_parameter("ism_stage_2c_executing", False)
+        self.declare_parameter("ism_stage_2d_speaking", False)
         self.perception_router_enabled = bool(
             self.get_parameter("perception_router_enabled").value
         )
@@ -457,6 +473,19 @@ class BrainNode(Node):
         self.greet_cooldown_s = float(self.get_parameter("greet_cooldown_s").value)
         self.demo_phase = str(self.get_parameter("demo_phase").value or "all").strip().lower()
         self.ism_shadow_enabled = bool(self.get_parameter("ism_shadow_enabled").value)
+        self.ism_enabled = bool(self.get_parameter("ism_enabled").value)
+        self.ism_stage_2a_demo_phase = bool(
+            self.get_parameter("ism_stage_2a_demo_phase").value
+        )
+        self.ism_stage_2b_confirm = bool(
+            self.get_parameter("ism_stage_2b_confirm").value
+        )
+        self.ism_stage_2c_executing = bool(
+            self.get_parameter("ism_stage_2c_executing").value
+        )
+        self.ism_stage_2d_speaking = bool(
+            self.get_parameter("ism_stage_2d_speaking").value
+        )
         self._capability_health_cache: dict[str, Any] | None = None
         self._apply_gesture_demo_modes()
 

--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -350,6 +350,36 @@ class BrainNode(Node):
                          throttle_key=f"phase:{kind}")
         return False
 
+    def _ism_confirm_preempt_active(self) -> bool:
+        """Return True when stage 2b policy preempts CONFIRM_PENDING for ALERT.
+
+        Pure policy check only. Any policy/import failure falls back to legacy
+        confirm behavior so pose callbacks never fail because of takeover logic.
+        """
+        if not self._ism_stage_on("ism_stage_2b_confirm"):
+            return False
+        try:
+            from .interaction_state import (
+                Candidate as _Candidate,
+                InteractionPolicy as _Policy,
+                InteractionState as _State,
+                Priority as _Priority,
+            )
+
+            decision = _Policy.evaluate(
+                _State.CONFIRM_PENDING,
+                _Candidate(
+                    kind="alert",
+                    priority=_Priority.ALERT,
+                    source="pose",
+                    skill="fallen_alert",
+                ),
+            )
+            return decision.verdict == IsmVerdict.PREEMPT
+        except Exception as exc:  # noqa: BLE001 - takeover must never break callbacks
+            self.get_logger().debug(f"ism confirm preempt check failed: {exc}")
+            return False
+
     def _set_gesture_enabled(self, enabled: bool, via: str) -> None:
         """gesture_enabled 切換共用路徑（param callback / Studio topic 兩入口）。
 
@@ -1728,6 +1758,13 @@ class BrainNode(Node):
                         if cached and cached_age <= 30.0:
                             raw_name = cached
                     name = raw_name or "有人"
+                    if self._pending_confirm.state == ConfirmState.PENDING \
+                            and self._ism_confirm_preempt_active():
+                        self._pending_confirm.cancel(reason="preempt:fallen")
+                        self._ism_shadow_confirm_cancelled("preempt:fallen")
+                        self.get_logger().info(
+                            "PendingConfirm preempted by fallen (ism_stage_2b)"
+                        )
                     self._emit(
                         build_plan(
                             "fallen_alert",

--- a/interaction_executive/interaction_executive/interaction_state.py
+++ b/interaction_executive/interaction_executive/interaction_state.py
@@ -30,6 +30,27 @@ from enum import Enum, IntEnum
 from typing import Any
 
 
+PHASE_ALLOWED_KINDS = {
+    "all": frozenset({"greet", "object", "gesture"}),
+    "s2_face": frozenset({"greet"}),
+    "s3_object": frozenset({"object"}),
+    "s4_gesture": frozenset({"gesture"}),
+    "quiet": frozenset(),
+}
+
+
+def phase_allows(demo_phase: str, kind: str) -> bool:
+    """demo_phase scene-mask policy (ISM single source).
+
+    Unknown phases are treated like `all`, matching BrainNode's legacy
+    `allowed is None -> return True` defensive behavior.
+    """
+    allowed = PHASE_ALLOWED_KINDS.get(demo_phase)
+    if allowed is None:
+        return True
+    return kind in allowed
+
+
 class InteractionState(str, Enum):
     IDLE = "idle"                        # 無互動；接受任何候選
     LISTENING = "listening"              # 正在聽語音（chat_buffer 在飛）

--- a/interaction_executive/test/test_interaction_state.py
+++ b/interaction_executive/test/test_interaction_state.py
@@ -16,11 +16,21 @@ from interaction_executive.interaction_state import (
     TransitionSignal,
     TriggerKind as T,
     Verdict as V,
+    phase_allows,
 )
 
 
 def _cand(kind, prio, **kw):
     return Candidate(kind=kind, priority=prio, source=kw.pop("source", "test"), **kw)
+
+
+# ── demo_phase scene-mask policy (T1-1 / stage 2a) ──────────────────────────
+def test_phase_allows_demo_phase_policy():
+    assert phase_allows("s3_object", "object") is True
+    assert phase_allows("s3_object", "gesture") is False
+    assert phase_allows("quiet", "greet") is False
+    assert phase_allows("unknown", "gesture") is True
+    assert all(phase_allows("all", k) is True for k in ("greet", "object", "gesture"))
 
 
 # ── InteractionPolicy: priority iron law + non-black-hole (§3.4 / §3.5) ──────

--- a/interaction_executive/test/test_ism_takeover.py
+++ b/interaction_executive/test/test_ism_takeover.py
@@ -11,6 +11,7 @@ rclpy = pytest.importorskip("rclpy")
 from rclpy.parameter import Parameter  # noqa: E402
 from std_msgs.msg import Empty, String  # noqa: E402
 
+from interaction_executive import interaction_state  # noqa: E402
 from interaction_executive.attention_machine import AttentionState  # noqa: E402
 from interaction_executive.brain_node import BrainNode  # noqa: E402
 
@@ -88,6 +89,26 @@ def _shadow_traces(n: BrainNode) -> list[dict]:
 
 
 _CUP = {"objects": [{"class_name": "cup", "confidence": 0.9, "color": "red"}]}
+_PHASE_KINDS = ("greet", "object", "gesture")
+
+
+def _phase_trace(n: BrainNode) -> list[tuple[str, str]]:
+    return [
+        (t["gate"], t["reason"])
+        for t in n.traces
+        if t["gate"] == "demo_phase"
+    ]
+
+
+def _run_phase_gate(n: BrainNode, *, phase: str, kind: str,
+                    stage_2a_on: bool) -> tuple[bool, list[tuple[str, str]]]:
+    n.demo_phase = phase
+    n.ism_enabled = stage_2a_on
+    n.ism_stage_2a_demo_phase = stage_2a_on
+    n.traces.clear()
+    n._trace_throttle.clear()
+    allowed = n._phase_allows(kind)
+    return allowed, _phase_trace(n)
 
 
 def _run_representative_sequence(n: BrainNode) -> dict:
@@ -167,3 +188,42 @@ def test_all_off_parity_matches_shadow_off_behavior():
     finally:
         baseline.destroy_node()
         all_off.destroy_node()
+
+
+def test_demo_phase_stage_2a_takeover_matches_legacy_phase_kind_matrix():
+    legacy, takeover = _make_node(), _make_node()
+    try:
+        for phase in interaction_state.PHASE_ALLOWED_KINDS:
+            for kind in _PHASE_KINDS:
+                legacy_result = _run_phase_gate(
+                    legacy, phase=phase, kind=kind, stage_2a_on=False
+                )
+                takeover_result = _run_phase_gate(
+                    takeover, phase=phase, kind=kind, stage_2a_on=True
+                )
+                assert takeover_result == legacy_result
+    finally:
+        legacy.destroy_node()
+        takeover.destroy_node()
+
+
+def test_demo_phase_stage_2a_takeover_fallback_never_raises(monkeypatch):
+    legacy, takeover = _make_node(), _make_node()
+    try:
+        phase = "s3_object"
+        kind = "gesture"
+        legacy_result = _run_phase_gate(
+            legacy, phase=phase, kind=kind, stage_2a_on=False
+        )
+
+        def _boom(_demo_phase: str, _kind: str) -> bool:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(interaction_state, "phase_allows", _boom)
+        takeover_result = _run_phase_gate(
+            takeover, phase=phase, kind=kind, stage_2a_on=True
+        )
+        assert takeover_result == legacy_result
+    finally:
+        legacy.destroy_node()
+        takeover.destroy_node()

--- a/interaction_executive/test/test_ism_takeover.py
+++ b/interaction_executive/test/test_ism_takeover.py
@@ -12,6 +12,7 @@ rclpy = pytest.importorskip("rclpy")
 from rclpy.parameter import Parameter  # noqa: E402
 from std_msgs.msg import Empty, String  # noqa: E402
 
+from interaction_executive import brain_node as brain_node_module  # noqa: E402
 from interaction_executive import interaction_state  # noqa: E402
 from interaction_executive.attention_machine import AttentionState  # noqa: E402
 from interaction_executive.brain_node import BrainNode  # noqa: E402
@@ -105,6 +106,37 @@ def _phase_trace(n: BrainNode) -> list[tuple[str, str]]:
 def _enable_stage_2b(n: BrainNode) -> None:
     n.ism_enabled = True
     n.ism_stage_2b_confirm = True
+
+
+def _enable_stage_2c(n: BrainNode) -> None:
+    n.ism_shadow_enabled = True
+    n.ism_enabled = True
+    n.ism_stage_2c_executing = True
+
+
+def _start_wiggle(n: BrainNode, plan_id: str = "p1") -> None:
+    n._on_skill_result(_msg({
+        "plan_id": plan_id,
+        "status": "started",
+        "selected_skill": "wiggle",
+        "priority_class": 3,
+    }))
+
+
+def _watchdog_reset_traces(n: BrainNode) -> list[dict]:
+    return [
+        t for t in n.traces
+        if t["reason"].startswith("watchdog_timeout:executing")
+        and t.get("detail", {}).get("cleanup") == "active_plan_reset"
+    ]
+
+
+def _tick_after_deadline(monkeypatch, n: BrainNode) -> None:
+    deadline = n._ism.deadline
+    assert deadline is not None
+    with monkeypatch.context() as m:
+        m.setattr(brain_node_module.time, "time", lambda: deadline + 1.0)
+        n._ism_shadow_tick()
 
 
 def _enter_pending_confirm(n: BrainNode) -> None:
@@ -378,6 +410,102 @@ def test_2b_explicit_speech_still_cancels_confirm():
             n.destroy_node()
 
     assert results == [ConfirmState.IDLE, ConfirmState.IDLE]
+
+
+def test_2c_watchdog_clears_stuck_active_plan_flag_on(monkeypatch, node):
+    _enable_stage_2c(node)
+
+    _start_wiggle(node, plan_id="p1")
+    with node._lock:
+        node._state.active_step = {"executor": "mock"}
+
+    assert node._state.active_plan is not None
+    assert node._ism.state is interaction_state.InteractionState.EXECUTING
+    assert node._ism.deadline is not None
+
+    _tick_after_deadline(monkeypatch, node)
+
+    assert node._state.active_plan is None
+    assert node._state.active_step is None
+    assert any(
+        "watchdog_timeout:executing" in t["reason"]
+        and t["detail"].get("watchdog") is True
+        for t in _watchdog_reset_traces(node)
+    )
+
+
+def test_2c_watchdog_no_clear_flag_off(monkeypatch, node):
+    node.ism_shadow_enabled = True
+
+    _start_wiggle(node, plan_id="p1")
+    assert node._state.active_plan is not None
+    assert node._ism.state is interaction_state.InteractionState.EXECUTING
+    assert node._ism.deadline is not None
+
+    _tick_after_deadline(monkeypatch, node)
+
+    assert node._state.active_plan is not None
+    assert _watchdog_reset_traces(node) == []
+
+
+def test_2c_healthy_skill_not_killed(monkeypatch, node):
+    _enable_stage_2c(node)
+
+    _start_wiggle(node, plan_id="p1")
+    deadline = node._ism.deadline
+    assert deadline is not None
+    node._on_skill_result(_msg({"plan_id": "p1", "status": "completed"}))
+
+    assert node._state.active_plan is None
+    assert node._ism.state is interaction_state.InteractionState.IDLE
+
+    with monkeypatch.context() as m:
+        m.setattr(brain_node_module.time, "time", lambda: deadline + 1.0)
+        node._ism_shadow_tick()
+
+    assert _watchdog_reset_traces(node) == []
+
+
+def test_2c_zero_timeout_not_armed():
+    machine = interaction_state.InteractionStateMachine(now=5.0)
+    machine.apply_signal(
+        interaction_state.TransitionSignal(
+            interaction_state.TriggerKind.SKILL_RESULT,
+            {"status": "STARTED", "plan_id": "p1", "timeout_s": 0},
+        ),
+        now=5.0,
+    )
+
+    assert machine.state is interaction_state.InteractionState.EXECUTING
+    assert machine.deadline is None
+    assert machine.tick(now=999999.0) is None
+    assert machine.state is interaction_state.InteractionState.EXECUTING
+
+
+def test_2c_watchdog_cleanup_never_raises(monkeypatch, node):
+    _enable_stage_2c(node)
+    _start_wiggle(node, plan_id="p1")
+    monkeypatch.setattr(
+        node._ism,
+        "tick",
+        lambda _now: (_ for _ in ()).throw(RuntimeError("tick boom")),
+    )
+
+    node._ism_shadow_tick()
+
+    trace_node = _make_node()
+    try:
+        _enable_stage_2c(trace_node)
+        _start_wiggle(trace_node, plan_id="p2")
+        monkeypatch.setattr(
+            trace_node,
+            "_trace",
+            lambda _event: (_ for _ in ()).throw(RuntimeError("trace boom")),
+        )
+
+        _tick_after_deadline(monkeypatch, trace_node)
+    finally:
+        trace_node.destroy_node()
 
 
 def test_legacy_sitting_skipped_during_pending_confirm(node):

--- a/interaction_executive/test/test_ism_takeover.py
+++ b/interaction_executive/test/test_ism_takeover.py
@@ -1,0 +1,169 @@
+"""ISM staged takeover flag skeleton tests.
+
+rclpy local tier - NOT in the CI fast gate. This file instantiates BrainNode,
+so environments without rclpy should skip at import time.
+"""
+import json
+
+import pytest
+
+rclpy = pytest.importorskip("rclpy")
+from rclpy.parameter import Parameter  # noqa: E402
+from std_msgs.msg import Empty, String  # noqa: E402
+
+from interaction_executive.attention_machine import AttentionState  # noqa: E402
+from interaction_executive.brain_node import BrainNode  # noqa: E402
+
+
+_ISM_TAKEOVER_FLAGS = (
+    "ism_enabled",
+    "ism_stage_2a_demo_phase",
+    "ism_stage_2b_confirm",
+    "ism_stage_2c_executing",
+    "ism_stage_2d_speaking",
+)
+
+_ISM_STAGE_FLAGS = _ISM_TAKEOVER_FLAGS[1:]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def rclpy_ctx():
+    if not rclpy.ok():
+        rclpy.init()
+    yield
+    if rclpy.ok():
+        rclpy.shutdown()
+
+
+def _make_node() -> BrainNode:
+    n = BrainNode()
+    n.proposals = []
+    n._pub_proposal.publish = (  # type: ignore[method-assign]
+        lambda m: n.proposals.append(json.loads(m.data))
+    )
+    n.traces = []
+    n._pub_trace.publish = (  # type: ignore[method-assign]
+        lambda m: n.traces.append(json.loads(m.data))
+    )
+    return n
+
+
+@pytest.fixture
+def node():
+    n = _make_node()
+    yield n
+    n.destroy_node()
+
+
+def _msg(payload: dict) -> String:
+    m = String()
+    m.data = json.dumps(payload, ensure_ascii=False)
+    return m
+
+
+def _normalize(proposals: list[dict]) -> list[dict]:
+    """Strip volatile fields while keeping emitted proposal payload semantics."""
+    return [
+        {
+            "selected_skill": p["selected_skill"],
+            "steps": p["steps"],
+            "reason": p["reason"],
+            "source": p["source"],
+            "priority_class": p["priority_class"],
+        }
+        for p in proposals
+    ]
+
+
+def _legacy_traces(n: BrainNode) -> list[tuple]:
+    return [
+        (t["kind"], t["gate"], t["reason"])
+        for t in n.traces
+        if not t.get("detail", {}).get("shadow")
+    ]
+
+
+def _shadow_traces(n: BrainNode) -> list[dict]:
+    return [t for t in n.traces if t.get("detail", {}).get("shadow")]
+
+
+_CUP = {"objects": [{"class_name": "cup", "confidence": 0.9, "color": "red"}]}
+
+
+def _run_representative_sequence(n: BrainNode) -> dict:
+    """Run a stable event sequence and return payload-level parity evidence."""
+    n._on_speech_intent(_msg({"transcript": "停", "session_id": "s1"}))
+    n._attention._state = AttentionState.ENGAGED
+    n._on_object(_msg(_CUP))
+    n._on_object(_msg(_CUP))
+    first = n.proposals[0]
+    n._on_skill_result(_msg({
+        "plan_id": first["plan_id"],
+        "status": "started",
+        "selected_skill": first["selected_skill"],
+        "priority_class": first["priority_class"],
+    }))
+    n._on_skill_result(_msg({"plan_id": first["plan_id"], "status": "completed"}))
+    n.gesture_enabled = False
+    n._on_gesture(_msg({"gesture": "wave", "confidence": 0.9}))
+    n.gesture_enabled = True
+    n._on_reset_context(Empty())
+    return {
+        "proposals": _normalize(n.proposals),
+        "legacy_traces": _legacy_traces(n),
+        "shadow_traces": _shadow_traces(n),
+    }
+
+
+def test_stage_flags_declared_default_false(node):
+    for name in _ISM_TAKEOVER_FLAGS:
+        assert node.get_parameter(name).value is False
+        assert getattr(node, name) is False
+
+
+def test_ism_stage_on_requires_master_and_stage(node):
+    for stage in _ISM_STAGE_FLAGS:
+        node.ism_enabled = False
+        setattr(node, stage, True)
+        assert node._ism_stage_on(stage) is False
+
+        node.ism_enabled = True
+        setattr(node, stage, False)
+        assert node._ism_stage_on(stage) is False
+
+        setattr(node, stage, True)
+        assert node._ism_stage_on(stage) is True
+
+        node.ism_enabled = False
+        assert node._ism_stage_on(stage) is False
+
+
+def test_on_set_params_runtime_toggle(node):
+    for name in _ISM_TAKEOVER_FLAGS:
+        assert getattr(node, name) is False
+        result = node._on_set_params([Parameter(name, Parameter.Type.BOOL, True)])
+        assert result.successful is True
+        assert getattr(node, name) is True
+
+        result = node._on_set_params([Parameter(name, Parameter.Type.BOOL, False)])
+        assert result.successful is True
+        assert getattr(node, name) is False
+
+
+def test_all_off_parity_matches_shadow_off_behavior():
+    baseline, all_off = _make_node(), _make_node()
+    try:
+        all_off._on_set_params([
+            Parameter(name, Parameter.Type.BOOL, False)
+            for name in _ISM_TAKEOVER_FLAGS
+        ])
+
+        baseline_evidence = _run_representative_sequence(baseline)
+        all_off_evidence = _run_representative_sequence(all_off)
+
+        assert all_off_evidence["proposals"] == baseline_evidence["proposals"]
+        assert all_off_evidence["legacy_traces"] == baseline_evidence["legacy_traces"]
+        assert all_off_evidence["shadow_traces"] == []
+    finally:
+        baseline.destroy_node()
+        all_off.destroy_node()

--- a/interaction_executive/test/test_ism_takeover.py
+++ b/interaction_executive/test/test_ism_takeover.py
@@ -114,6 +114,11 @@ def _enable_stage_2c(n: BrainNode) -> None:
     n.ism_stage_2c_executing = True
 
 
+def _enable_stage_2d(n: BrainNode) -> None:
+    n.ism_enabled = True
+    n.ism_stage_2d_speaking = True
+
+
 def _start_wiggle(n: BrainNode, plan_id: str = "p1") -> None:
     n._on_skill_result(_msg({
         "plan_id": plan_id,
@@ -158,6 +163,20 @@ def _legacy_suppressed_traces(n: BrainNode) -> list[dict]:
         t for t in n.traces
         if t["verdict"] == "suppressed" and not t.get("detail", {}).get("shadow")
     ]
+
+
+def _queue_marker_traces(n: BrainNode) -> list[dict]:
+    return [
+        t for t in n.traces
+        if t.get("detail", {}).get("queue_v2_pending") is True
+    ]
+
+
+def _has_legacy_suppress(n: BrainNode, *, gate: str, reason: str) -> bool:
+    return any(
+        t["gate"] == gate and t["reason"] == reason
+        for t in _legacy_suppressed_traces(n)
+    )
 
 
 def _stable_trace_payload(t: dict) -> dict:
@@ -506,6 +525,108 @@ def test_2c_watchdog_cleanup_never_raises(monkeypatch, node):
         _tick_after_deadline(monkeypatch, trace_node)
     finally:
         trace_node.destroy_node()
+
+
+def test_2d_object_speaking_suppress_with_queue_marker_flag_on(node):
+    _enable_stage_2d(node)
+    node._world._snap.tts_playing = True
+    node._attention._state = AttentionState.ENGAGED
+
+    node._on_object(_msg({"objects": [{"class_name": "cup", "confidence": 0.9}]}))
+
+    assert node.proposals == []
+    assert _has_legacy_suppress(node, gate="tts_playing", reason="tts_playing")
+    markers = _queue_marker_traces(node)
+    assert len(markers) == 1
+    assert markers[0]["reason"] == "gate:speaking"
+    assert markers[0]["gate"] == "speaking"
+    assert markers[0]["detail"]["ism_reason"] == "gate:speaking"
+    assert markers[0]["detail"]["source_summary"] == "class=cup"
+
+
+def test_2d_object_speaking_byte_identical_flag_off(node):
+    node._world._snap.tts_playing = True
+    node._attention._state = AttentionState.ENGAGED
+
+    node._on_object(_msg({"objects": [{"class_name": "cup", "confidence": 0.9}]}))
+
+    assert node.proposals == []
+    assert _has_legacy_suppress(node, gate="tts_playing", reason="tts_playing")
+    assert _queue_marker_traces(node) == []
+
+
+def test_2d_queue_marker_only_when_speaking(node):
+    _enable_stage_2d(node)
+    node._world._snap.tts_playing = False
+    _enter_pending_confirm(node)
+    node._attention._state = AttentionState.ENGAGED
+
+    node._on_object(_msg({"objects": [{"class_name": "cup", "confidence": 0.9}]}))
+
+    assert _has_legacy_suppress(node, gate="pending_confirm", reason="confirm_in_flight")
+    assert _queue_marker_traces(node) == []
+
+
+def test_2d_speaking_marker_never_raises(monkeypatch, node):
+    _enable_stage_2d(node)
+    node._world._snap.tts_playing = True
+    node._attention._state = AttentionState.ENGAGED
+
+    def _boom(_state, _candidate):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        interaction_state.InteractionPolicy,
+        "evaluate",
+        staticmethod(_boom),
+    )
+
+    node._on_object(_msg({"objects": [{"class_name": "cup", "confidence": 0.9}]}))
+
+    assert node.proposals == []
+    assert _has_legacy_suppress(node, gate="tts_playing", reason="tts_playing")
+    assert _queue_marker_traces(node) == []
+
+
+def test_2d_greet_and_gesture_marker_flag_on():
+    scenarios = (
+        (
+            "greet",
+            lambda n: n._on_face(_msg({"identity": "roy", "identity_stable": True})),
+            "greet_gate",
+            "tts_playing",
+            "identity=roy",
+        ),
+        (
+            "gesture",
+            lambda n: n._on_gesture(_msg({"gesture": "wave", "confidence": 0.95})),
+            "conversation_gate",
+            "conversation_gate:tts_playing",
+            "gesture=wave",
+        ),
+    )
+
+    for _name, fire, gate, reason, source_summary in scenarios:
+        for stage_2d_on in (True, False):
+            n = _make_node()
+            try:
+                if stage_2d_on:
+                    _enable_stage_2d(n)
+                n._world._snap.tts_playing = True
+
+                fire(n)
+
+                assert n.proposals == []
+                assert _has_legacy_suppress(n, gate=gate, reason=reason)
+                markers = _queue_marker_traces(n)
+                if stage_2d_on:
+                    assert len(markers) == 1
+                    assert markers[0]["reason"] == "gate:speaking"
+                    assert markers[0]["detail"]["source_summary"] == source_summary
+                else:
+                    assert markers == []
+            finally:
+                n.destroy_node()
 
 
 def test_legacy_sitting_skipped_during_pending_confirm(node):

--- a/interaction_executive/test/test_ism_takeover.py
+++ b/interaction_executive/test/test_ism_takeover.py
@@ -4,6 +4,7 @@ rclpy local tier - NOT in the CI fast gate. This file instantiates BrainNode,
 so environments without rclpy should skip at import time.
 """
 import json
+import time
 
 import pytest
 
@@ -14,6 +15,7 @@ from std_msgs.msg import Empty, String  # noqa: E402
 from interaction_executive import interaction_state  # noqa: E402
 from interaction_executive.attention_machine import AttentionState  # noqa: E402
 from interaction_executive.brain_node import BrainNode  # noqa: E402
+from interaction_executive.pending_confirm import ConfirmState  # noqa: E402
 
 
 _ISM_TAKEOVER_FLAGS = (
@@ -227,3 +229,61 @@ def test_demo_phase_stage_2a_takeover_fallback_never_raises(monkeypatch):
     finally:
         legacy.destroy_node()
         takeover.destroy_node()
+
+
+def test_legacy_fallen_fires_during_pending_confirm(node):
+    node._on_gesture(_msg({"gesture": "thumbs_up", "confidence": 0.95}))
+    assert node._pending_confirm.state == ConfirmState.PENDING
+    node.proposals.clear()
+
+    node._on_pose(_msg({"pose": "fallen"}))
+    node._state.fallen_first_seen = time.time() - node.fallen_accumulate_s - 0.1
+    node._on_pose(_msg({"pose": "fallen"}))
+
+    assert any(p["selected_skill"] == "fallen_alert" for p in node.proposals)
+    assert node._pending_confirm.state == ConfirmState.PENDING
+
+
+def test_legacy_sitting_skipped_during_pending_confirm(node):
+    node._on_gesture(_msg({"gesture": "thumbs_up", "confidence": 0.95}))
+    assert node._pending_confirm.state == ConfirmState.PENDING
+    node.proposals.clear()
+
+    node._on_pose(_msg({"pose": "sitting"}))
+    node._state.sitting_first_seen = time.time() - 1.1
+    node._on_pose(_msg({"pose": "sitting"}))
+
+    assert not any(p["selected_skill"] == "sit_along" for p in node.proposals)
+
+
+def test_legacy_object_suppressed_during_pending_confirm(node):
+    node._on_gesture(_msg({"gesture": "thumbs_up", "confidence": 0.95}))
+    assert node._pending_confirm.state == ConfirmState.PENDING
+    node.traces.clear()
+    node._attention._state = AttentionState.ENGAGED
+
+    node._on_object(_msg({"objects": [{"class_name": "cup", "confidence": 0.9}]}))
+
+    assert any(
+        t["verdict"] == "suppressed"
+        and t["gate"] == "pending_confirm"
+        and t["reason"] == "confirm_in_flight"
+        and not t.get("detail", {}).get("shadow")
+        for t in node.traces
+    )
+
+
+def test_legacy_gesture_suppressed_during_pending_confirm(node):
+    node._on_gesture(_msg({"gesture": "thumbs_up", "confidence": 0.95}))
+    assert node._pending_confirm.state == ConfirmState.PENDING
+    node.traces.clear()
+
+    node._on_gesture(_msg({"gesture": "wave", "confidence": 0.95}))
+
+    assert any(
+        t["verdict"] == "suppressed"
+        and t["gate"] == "pending_confirm"
+        and t["reason"] == "confirm_in_flight"
+        and not t.get("detail", {}).get("shadow")
+        for t in node.traces
+    )

--- a/interaction_executive/test/test_ism_takeover.py
+++ b/interaction_executive/test/test_ism_takeover.py
@@ -102,6 +102,76 @@ def _phase_trace(n: BrainNode) -> list[tuple[str, str]]:
     ]
 
 
+def _enable_stage_2b(n: BrainNode) -> None:
+    n.ism_enabled = True
+    n.ism_stage_2b_confirm = True
+
+
+def _enter_pending_confirm(n: BrainNode) -> None:
+    n._on_gesture(_msg({"gesture": "thumbs_up", "confidence": 0.95}))
+    assert n._pending_confirm.state == ConfirmState.PENDING
+    n.proposals.clear()
+    n.traces.clear()
+    n._trace_throttle.clear()
+
+
+def _fire_stable_fallen(n: BrainNode) -> None:
+    n._on_pose(_msg({"pose": "fallen"}))
+    n._state.fallen_first_seen = time.time() - n.fallen_accumulate_s - 0.1
+    n._on_pose(_msg({"pose": "fallen"}))
+
+
+def _legacy_suppressed_traces(n: BrainNode) -> list[dict]:
+    return [
+        t for t in n.traces
+        if t["verdict"] == "suppressed" and not t.get("detail", {}).get("shadow")
+    ]
+
+
+def _stable_trace_payload(t: dict) -> dict:
+    detail = t["detail"]
+    return {
+        "kind": t["kind"],
+        "verdict": t["verdict"],
+        "gate": t["gate"],
+        "reason": t["reason"],
+        "detail": {
+            "gate": detail["gate"],
+            "reason": detail["reason"],
+            "active_plan": detail["active_plan"],
+            "pending_confirm": detail["pending_confirm"],
+            "cooldown_remaining_s": detail["cooldown_remaining_s"],
+            "source_summary": detail["source_summary"],
+        },
+    }
+
+
+def _run_social_during_confirm(*, kind: str, stage_2b_on: bool) -> dict:
+    n = _make_node()
+    try:
+        if stage_2b_on:
+            _enable_stage_2b(n)
+        _enter_pending_confirm(n)
+        if kind == "object":
+            n._attention._state = AttentionState.ENGAGED
+            n._on_object(_msg({"objects": [{"class_name": "cup", "confidence": 0.9}]}))
+        elif kind == "gesture":
+            n._on_gesture(_msg({"gesture": "wave", "confidence": 0.95}))
+        else:
+            raise AssertionError(f"unknown social kind {kind!r}")
+        suppressed = [
+            t for t in _legacy_suppressed_traces(n)
+            if t["gate"] == "pending_confirm"
+        ]
+        assert len(suppressed) == 1
+        return {
+            "proposals": _normalize(n.proposals),
+            "trace": _stable_trace_payload(suppressed[0]),
+        }
+    finally:
+        n.destroy_node()
+
+
 def _run_phase_gate(n: BrainNode, *, phase: str, kind: str,
                     stage_2a_on: bool) -> tuple[bool, list[tuple[str, str]]]:
     n.demo_phase = phase
@@ -242,6 +312,72 @@ def test_legacy_fallen_fires_during_pending_confirm(node):
 
     assert any(p["selected_skill"] == "fallen_alert" for p in node.proposals)
     assert node._pending_confirm.state == ConfirmState.PENDING
+
+
+def test_2b_fallen_preempts_pending_confirm_flag_on(node):
+    _enable_stage_2b(node)
+    _enter_pending_confirm(node)
+
+    _fire_stable_fallen(node)
+
+    assert any(p["selected_skill"] == "fallen_alert" for p in node.proposals)
+    assert node._pending_confirm.state == ConfirmState.IDLE
+
+
+def test_2b_fallen_orphans_confirm_flag_off(node):
+    _enter_pending_confirm(node)
+
+    _fire_stable_fallen(node)
+
+    assert any(p["selected_skill"] == "fallen_alert" for p in node.proposals)
+    assert node._pending_confirm.state == ConfirmState.PENDING
+
+
+def test_2b_social_suppress_byte_identical_flag_on_vs_off():
+    for kind in ("object", "gesture"):
+        legacy = _run_social_during_confirm(kind=kind, stage_2b_on=False)
+        takeover = _run_social_during_confirm(kind=kind, stage_2b_on=True)
+
+        assert takeover == legacy
+        assert takeover["proposals"] == []
+        assert takeover["trace"]["gate"] == "pending_confirm"
+        assert takeover["trace"]["reason"] == "confirm_in_flight"
+        assert takeover["trace"]["detail"]["gate"] == "pending_confirm"
+        assert takeover["trace"]["detail"]["reason"] == "confirm_in_flight"
+
+
+def test_2b_confirm_preempt_never_raises(monkeypatch, node):
+    _enable_stage_2b(node)
+    _enter_pending_confirm(node)
+
+    def _boom(_state, _candidate):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        interaction_state.InteractionPolicy,
+        "evaluate",
+        staticmethod(_boom),
+    )
+    _fire_stable_fallen(node)
+
+    assert any(p["selected_skill"] == "fallen_alert" for p in node.proposals)
+    assert node._pending_confirm.state == ConfirmState.PENDING
+
+
+def test_2b_explicit_speech_still_cancels_confirm():
+    results = []
+    for stage_2b_on in (False, True):
+        n = _make_node()
+        try:
+            if stage_2b_on:
+                _enable_stage_2b(n)
+            _enter_pending_confirm(n)
+            n._on_speech_intent(_msg({"transcript": "你好", "session_id": "s1"}))
+            results.append(n._pending_confirm.state)
+        finally:
+            n.destroy_node()
+
+    assert results == [ConfirmState.IDLE, ConfirmState.IDLE]
 
 
 def test_legacy_sitting_skipped_during_pending_confirm(node):


### PR DESCRIPTION
系統重構 Lane 1：ISM 從 shadow 進階到 staged-enable 2a-2d。

- T1-0 flag 架構（ism_enabled master kill + 4 子開關，全預設 False）
- T1-1 2a demo_phase 接管（PHASE_ALLOWED_KINDS 單源化）
- T1-2 2b confirm 接管（fallen preempt PendingConfirm，6/9 黑洞修法）
- T1-3 2c executing watchdog（active_plan 逾時自癒）
- T1-4 2d speaking 接管（QUEUE→SUPPRESS+queue_v2_pending）

**所有 stage flag 預設 off = byte-identical**（all-off parity 測試證明）。
親驗：IE 全套 346 passed（含 parity）+ contracts 11。

⚠️ HITL pending：2a-2d 真機 smoke 在 Roy HITL Queue。不做 2e/2f/2g/source-trust（post-6/18）。
Plan: docs/superpowers/plans/2026-06-13-lane1-brain-ism-staged-enable-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)