### PR TITLE
feat(studio): Lane 2 — Evidence Center v2（session/timeline/zh/report）

### DIFF
--- a/pawai-studio/backend/mock_server.py
+++ b/pawai-studio/backend/mock_server.py
@@ -6,18 +6,21 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import math
 import os
 import random
 import sys
 import time
 import uuid
+from collections import Counter
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 
 # Import the real SKILL_REGISTRY (pure-Python dataclass module, no ROS deps)
@@ -219,6 +222,367 @@ MOCK_GENERATORS = {
     "pose": mock_pose_event,
     "object": mock_object_event,
 }
+
+
+# ── Mock Evidence Center trace data（T2-7, gateway-free WSL dev）──────
+
+_TRACE_SESSION_STARTS = {
+    "20260613-083000": 1781301000.0,
+    "20260612-100000": 1781229600.0,
+    "20260611-235959": 1781193599.0,
+}
+
+_SESSION_ID_CHARS = set(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+)
+
+
+def _valid_mock_session_id(session_id: str) -> bool:
+    return bool(session_id) and all(ch in _SESSION_ID_CHARS for ch in session_id)
+
+
+def build_mock_trace_events(session_id: str, n: int = 24) -> list[dict]:
+    """Build deterministic, redacted fake /brain/trace events for Studio dev."""
+    base_ts = _TRACE_SESSION_STARTS.get(session_id, 1781229600.0)
+    session_tag = session_id.replace("-", "")
+
+    def event(
+        idx: int,
+        decision_id: str,
+        kind: str,
+        verdict: str,
+        gate: str,
+        reason: str,
+        detail: dict,
+        *,
+        node: str = "mock_brain",
+    ) -> dict:
+        return {
+            "v": 1,
+            "ts": round(base_ts + idx * 0.73, 3),
+            "decision_id": f"{session_tag}-{decision_id}",
+            "node": node,
+            "kind": kind,
+            "verdict": verdict,
+            "gate": gate,
+            "reason": reason,
+            "detail": detail,
+        }
+
+    events = [
+        event(0, "greet-001", "candidate", "accepted", "greet_cooldown",
+              "candidate:greet_intent", {
+                  "source": "speech",
+                  "intent": "greet",
+                  "transcript": "[private]",
+                  "identity": "[private]",
+                  "confidence": 0.94,
+              }),
+        event(1, "greet-001", "policy_decision", "accepted", "safety",
+              "policy:allow:greet", {
+                  "nav_safe": True,
+                  "tts_playing": False,
+                  "source_summary": "[private]",
+              }),
+        event(2, "greet-001", "plan_emitted", "accepted", "active_plan",
+              "plan:greet_emitted", {
+                  "plan_id": "p-mock-greet-001",
+                  "selected_skill": "wave_hello",
+                  "step_total": 2,
+              }),
+        event(3, "greet-001", "skill_result", "accepted", "tts_playing",
+              "skill:completed", {
+                  "plan_id": "p-mock-greet-001",
+                  "status": "completed",
+                  "text": "[private]",
+              }),
+        event(4, "greet-002", "candidate", "suppressed", "greet_cooldown",
+              "cooldown:greet:[private]", {
+                  "cooldown_remaining_s": 5.2,
+                  "source": "face",
+                  "name": "[private]",
+              }),
+        event(5, "gesture-001", "candidate", "suppressed", "demo_phase",
+              "phase:s3_object:gesture", {
+                  "demo_phase": "s3_object",
+                  "gesture": "wave",
+                  "image_path": "[private]",
+              }),
+        event(6, "speech-001", "candidate", "suppressed", "tts_playing",
+              "gate:tts_playing", {
+                  "tts_playing": True,
+                  "transcript": "[private]",
+              }),
+        event(7, "confirm-001", "candidate", "suppressed", "pending_confirm",
+              "gate:confirm_pending", {
+                  "pending_confirm": True,
+                  "intent": "come_here",
+                  "source_summary": "[private]",
+              }),
+        event(8, "plan-001", "policy_decision", "suppressed", "active_plan",
+              "gate:active_plan", {
+                  "active_plan": "p-mock-greet-001",
+                  "candidate_skill": "dance",
+              }),
+        event(9, "gesture-002", "candidate", "blocked", "gesture_enabled",
+              "gate:gesture_disabled", {
+                  "gesture_enabled": False,
+                  "gesture": "point",
+                  "identity": "[private]",
+              }),
+        event(10, "nav-001", "candidate", "accepted", "safety",
+              "candidate:follow_request", {
+                  "intent": "follow",
+                  "source": "studio_button",
+              }),
+        event(11, "nav-001", "policy_decision", "blocked", "safety",
+              "gate:safety:obstacle", {
+                  "obstacle_distance_m": 0.28,
+                  "nav_safe": False,
+                  "source_summary": "[private]",
+              }),
+        event(12, "shadow-001", "candidate", "accepted", "ism_shadow",
+              "ism_shadow:legacy_suppressed_ism_accept", {
+                  "shadow": True,
+                  "ism_verdict": "accept",
+                  "legacy_action": "suppressed:greet_cooldown",
+                  "legacy_gate": "greet_cooldown",
+                  "legacy_reason": "cooldown:greet:[private]",
+                  "candidate_skill": "wave_hello",
+              }),
+        event(13, "shadow-002", "candidate", "suppressed", "ism_shadow",
+              "ism_shadow:legacy_emitted_ism_suppress", {
+                  "shadow": True,
+                  "ism_verdict": "suppress",
+                  "legacy_action": "emitted:wave_hello",
+                  "legacy_gate": "pending_confirm",
+                  "legacy_reason": "gate:confirm_pending",
+                  "candidate_skill": "wave_hello",
+              }),
+        event(14, "shadow-003", "candidate", "accepted", "ism_shadow",
+              "ism_shadow:agreement_accept", {
+                  "shadow": True,
+                  "ism_verdict": "accept",
+                  "legacy_action": "emitted:status_report",
+                  "legacy_gate": "",
+                  "candidate_skill": "status_report",
+              }),
+        event(15, "shadow-004", "candidate", "suppressed", "ism_shadow",
+              "ism_shadow:agreement_suppress", {
+                  "shadow": True,
+                  "ism_verdict": "suppress",
+                  "legacy_action": "suppressed:demo_phase",
+                  "legacy_gate": "demo_phase",
+                  "candidate_skill": "come_here",
+              }),
+        event(16, "status-001", "candidate", "accepted", "safety",
+              "candidate:status", {
+                  "intent": "status",
+                  "source": "text",
+                  "text": "[private]",
+              }),
+        event(17, "status-001", "policy_decision", "accepted", "active_plan",
+              "policy:allow:status", {
+                  "selected_skill": "status_report",
+                  "priority_class": 4,
+              }),
+        event(18, "status-001", "plan_emitted", "accepted", "active_plan",
+              "plan:status_emitted", {
+                  "plan_id": "p-mock-status-001",
+                  "selected_skill": "status_report",
+                  "step_total": 1,
+              }),
+        event(19, "status-001", "skill_result", "accepted", "tts_playing",
+              "skill:completed", {
+                  "plan_id": "p-mock-status-001",
+                  "status": "completed",
+                  "full_text": "[private]",
+              }),
+    ]
+
+    for idx in range(len(events), max(n, len(events))):
+        gate = ["greet_cooldown", "demo_phase", "pending_confirm", "safety"][idx % 4]
+        verdict = ["accepted", "suppressed", "blocked"][idx % 3]
+        kind = ["candidate", "policy_decision", "skill_result"][idx % 3]
+        reason = {
+            "accepted": "mock:accepted",
+            "suppressed": f"gate:{gate}",
+            "blocked": f"blocked:{gate}",
+        }[verdict]
+        events.append(event(idx, f"extra-{idx:03d}", kind, verdict, gate, reason, {
+            "mock_extra": True,
+            "source_summary": "[private]",
+        }))
+
+    return events[:n]
+
+
+MOCK_TRACE_EVENTS_BY_SESSION: dict[str, list[dict]] = {
+    session_id: build_mock_trace_events(session_id, n=n)
+    for session_id, n in {
+        "20260613-083000": 24,
+        "20260612-100000": 22,
+        "20260611-235959": 20,
+    }.items()
+}
+
+
+def _mock_trace_json_line(event: dict) -> str:
+    return json.dumps(event, ensure_ascii=False, sort_keys=True) + "\n"
+
+
+def _mock_trace_session_meta(session_id: str, events: list[dict]) -> dict:
+    started_ts = min((ev["ts"] for ev in events if isinstance(ev.get("ts"), (int, float))),
+                     default=0.0)
+    file_size = sum(len(_mock_trace_json_line(ev).encode("utf-8")) for ev in events)
+    return {
+        "session_id": session_id,
+        "started_ts": started_ts,
+        "line_count": len(events),
+        "file_size": file_size,
+        "parts": [f"{session_id}.jsonl"],
+    }
+
+
+def _mock_trace_events_for_export(session: str, since: float) -> list[dict]:
+    if session:
+        sessions = [(session, MOCK_TRACE_EVENTS_BY_SESSION[session])]
+    else:
+        sessions = sorted(
+            MOCK_TRACE_EVENTS_BY_SESSION.items(),
+            key=lambda item: _mock_trace_session_meta(item[0], item[1])["started_ts"],
+        )
+    events: list[dict] = []
+    for _, session_events in sessions:
+        for event in session_events:
+            ts = event.get("ts")
+            if isinstance(ts, (int, float)) and ts >= since:
+                events.append(event)
+    return events
+
+
+async def _iter_mock_trace_lines(events: list[dict]):
+    for event in events:
+        yield _mock_trace_json_line(event)
+
+
+def _empty_mock_trace_summary(session_id: str) -> dict:
+    return {
+        "session_id": session_id,
+        "event_count": 0,
+        "time_range": {"start": None, "end": None},
+        "verdict_distribution": {},
+        "top_suppressed_gates": [],
+        "shadow_divergence": {"total": 0, "by_gate": []},
+    }
+
+
+def _summarize_mock_trace_events(session_id: str, events: list[dict]) -> dict:
+    summary = _empty_mock_trace_summary(session_id)
+    verdicts: Counter[str] = Counter()
+    suppressed_gates: Counter[str] = Counter()
+    divergence_by_gate: Counter[str] = Counter()
+    start_ts: float | None = None
+    end_ts: float | None = None
+
+    for event in events:
+        summary["event_count"] += 1
+
+        ts = event.get("ts")
+        if isinstance(ts, (int, float)) and not isinstance(ts, bool):
+            start_ts = float(ts) if start_ts is None else min(start_ts, float(ts))
+            end_ts = float(ts) if end_ts is None else max(end_ts, float(ts))
+
+        verdict = event.get("verdict")
+        if isinstance(verdict, str) and verdict:
+            verdicts[verdict] += 1
+            if verdict == "suppressed":
+                gate = event.get("gate")
+                if isinstance(gate, str) and gate:
+                    suppressed_gates[gate] += 1
+
+        if event.get("kind") != "candidate" or event.get("gate") != "ism_shadow":
+            continue
+        detail = event.get("detail")
+        if not isinstance(detail, dict) or detail.get("shadow") is not True:
+            continue
+        ism_verdict = detail.get("ism_verdict")
+        if not isinstance(ism_verdict, str) or not ism_verdict:
+            continue
+        would_act = ism_verdict in {"accept", "preempt"}
+        legacy_action = detail.get("legacy_action")
+        acted = isinstance(legacy_action, str) and (
+            legacy_action.startswith("emitted")
+            or legacy_action.startswith("confirm_requested")
+        )
+        if would_act == acted:
+            continue
+        legacy_gate = detail.get("legacy_gate")
+        gate_key = legacy_gate if isinstance(legacy_gate, str) and legacy_gate else "(none)"
+        divergence_by_gate[gate_key] += 1
+
+    summary["time_range"] = {"start": start_ts, "end": end_ts}
+    summary["verdict_distribution"] = dict(sorted(verdicts.items()))
+    summary["top_suppressed_gates"] = [
+        {"gate": gate, "count": count}
+        for gate, count in sorted(suppressed_gates.items(), key=lambda item: (-item[1], item[0]))
+    ]
+    by_gate = [
+        {"gate": gate, "count": count}
+        for gate, count in sorted(divergence_by_gate.items(), key=lambda item: (-item[1], item[0]))
+    ]
+    summary["shadow_divergence"] = {
+        "total": sum(divergence_by_gate.values()),
+        "by_gate": by_gate,
+    }
+    return summary
+
+
+def _render_mock_trace_report_md(summary: dict) -> str:
+    time_range = summary.get("time_range") if isinstance(summary.get("time_range"), dict) else {}
+    lines = [
+        "# Trace Session Report",
+        "",
+        f"- Session: `{summary.get('session_id', '')}`",
+        f"- Event count / 事件數: {summary.get('event_count', 0)}",
+        f"- Time range / 時間範圍: {time_range.get('start', 'n/a')} "
+        f"to {time_range.get('end', 'n/a')}",
+        "",
+        "## Verdict Distribution",
+    ]
+    verdict_distribution = summary.get("verdict_distribution")
+    if isinstance(verdict_distribution, dict) and verdict_distribution:
+        for verdict, count in sorted(verdict_distribution.items()):
+            lines.append(f"- `{verdict}`: {count}")
+    else:
+        lines.append("- (none): 0")
+
+    lines.extend(["", "## Top Suppressed Gates"])
+    top_suppressed_gates = summary.get("top_suppressed_gates")
+    if isinstance(top_suppressed_gates, list) and top_suppressed_gates:
+        for row in top_suppressed_gates:
+            if isinstance(row, dict):
+                lines.append(f"- `{row.get('gate', '')}`: {row.get('count', 0)}")
+    else:
+        lines.append("- (none): 0")
+
+    shadow_divergence = summary.get("shadow_divergence")
+    if not isinstance(shadow_divergence, dict):
+        shadow_divergence = {}
+    lines.extend([
+        "",
+        "## Shadow Divergence",
+        f"- Total / 總數: {shadow_divergence.get('total', 0)}",
+    ])
+    by_gate = shadow_divergence.get("by_gate")
+    if isinstance(by_gate, list) and by_gate:
+        for row in by_gate:
+            if isinstance(row, dict):
+                lines.append(f"- `{row.get('gate', '')}`: {row.get('count', 0)}")
+    else:
+        lines.append("- (none): 0")
+    return "\n".join(lines) + "\n"
+
 
 # ── 背景推送任務 ────────────────────────────────────────────────────
 
@@ -474,6 +838,42 @@ async def ws_text(ws: WebSocket):
         pass
 
 # ── REST: Gateway 端點 ──────────────────────────────────────────────
+
+@app.get("/api/trace/sessions")
+async def get_mock_trace_sessions():
+    sessions = [
+        _mock_trace_session_meta(session_id, events)
+        for session_id, events in MOCK_TRACE_EVENTS_BY_SESSION.items()
+    ]
+    sessions.sort(key=lambda row: (row["started_ts"], row["session_id"]), reverse=True)
+    return {"ok": True, "sessions": sessions}
+
+
+@app.get("/api/trace/export")
+async def get_mock_trace_export(session: str = "", since: float = 0.0, redact: int = 1):
+    _ = redact  # Mock events are already redacted; keep query parity with gateway.
+    if session and (
+        not _valid_mock_session_id(session) or session not in MOCK_TRACE_EVENTS_BY_SESSION
+    ):
+        return JSONResponse({"error": "invalid_session"}, status_code=400)
+    events = _mock_trace_events_for_export(session, since or 0.0)
+    return StreamingResponse(_iter_mock_trace_lines(events), media_type="application/x-ndjson")
+
+
+@app.get("/api/trace/report")
+async def get_mock_trace_report(session: str = "", format: str = "json"):
+    if (
+        not session
+        or not _valid_mock_session_id(session)
+        or session not in MOCK_TRACE_EVENTS_BY_SESSION
+    ):
+        return JSONResponse({"error": "invalid_session"}, status_code=400)
+
+    summary = _summarize_mock_trace_events(session, MOCK_TRACE_EVENTS_BY_SESSION[session])
+    if format.lower() in {"md", "markdown"}:
+        return PlainTextResponse(_render_mock_trace_report_md(summary), media_type="text/markdown")
+    return summary
+
 
 @app.get("/api/scoreboard")
 async def get_scoreboard():

--- a/pawai-studio/backend/test_mock_trace.py
+++ b/pawai-studio/backend/test_mock_trace.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2026, PawAI contributors
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Tests for mock Evidence Center trace endpoints.
+
+The mock server must let the Studio frontend develop against the trace session,
+export, and report APIs without a running gateway.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+from urllib.parse import urlencode, urlsplit
+
+from fastapi.testclient import TestClient
+from httpx import Request, Response
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def _patch_testclient_for_sandbox() -> None:
+    """Run TestClient requests in-process when AnyIO's portal is unavailable.
+
+    The local sandbox currently hangs in anyio.from_thread.start_blocking_portal()
+    even for a minimal FastAPI app. The tests still instantiate FastAPI's
+    TestClient; this swaps only the request transport used during pytest.
+    """
+    if getattr(TestClient, "_pawai_direct_asgi_patch", False):
+        return
+
+    def direct_request(self, method: str, url, **kwargs):
+        target = str(url)
+        if target.startswith("http://") or target.startswith("https://"):
+            split = urlsplit(target)
+            path = split.path or "/"
+            raw_query = split.query
+        else:
+            path, _, raw_query = target.partition("?")
+            path = path or "/"
+
+        params = kwargs.get("params")
+        if params:
+            param_query = urlencode(params, doseq=True)
+            raw_query = "&".join(part for part in (raw_query, param_query) if part)
+
+        headers = [(b"host", b"testserver")]
+        for key, value in (kwargs.get("headers") or {}).items():
+            headers.append((str(key).lower().encode(), str(value).encode()))
+
+        body = b""
+        if "json" in kwargs:
+            body = json.dumps(kwargs["json"]).encode("utf-8")
+            if not any(key == b"content-type" for key, _ in headers):
+                headers.append((b"content-type", b"application/json"))
+            headers.append((b"content-length", str(len(body)).encode()))
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": method.upper(),
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode(),
+            "query_string": raw_query.encode(),
+            "root_path": getattr(self, "root_path", ""),
+            "headers": headers,
+            "client": ("testclient", 50000),
+            "server": ("testserver", 80),
+            "state": getattr(self, "app_state", {}).copy(),
+        }
+
+        sent = False
+        status_code = 500
+        response_headers = []
+        chunks = []
+
+        async def receive():
+            nonlocal sent
+            if sent:
+                return {"type": "http.disconnect"}
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        async def send(message):
+            nonlocal status_code, response_headers
+            if message["type"] == "http.response.start":
+                status_code = message["status"]
+                response_headers = [
+                    (key.decode(), value.decode()) for key, value in message.get("headers", [])
+                ]
+            elif message["type"] == "http.response.body":
+                chunks.append(message.get("body", b""))
+
+        import asyncio
+
+        asyncio.run(self.app(scope, receive, send))
+        request = Request(method.upper(), f"http://testserver{path}")
+        return Response(
+            status_code=status_code,
+            headers=response_headers,
+            content=b"".join(chunks),
+            request=request,
+        )
+
+    TestClient.request = direct_request
+    TestClient._pawai_direct_asgi_patch = True
+
+
+_patch_testclient_for_sandbox()
+
+
+def _patch_asyncio_to_thread_for_sandbox() -> None:
+    import asyncio
+
+    if getattr(asyncio, "_pawai_direct_to_thread_patch", False):
+        return
+
+    async def direct_to_thread(func, /, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    asyncio.to_thread = direct_to_thread
+    asyncio._pawai_direct_to_thread_patch = True
+
+
+_patch_asyncio_to_thread_for_sandbox()
+
+
+def _reload_mock_server():
+    """Reload mock_server with current module-level fixtures."""
+    if "mock_server" in sys.modules:
+        del sys.modules["mock_server"]
+    import mock_server  # noqa: F401
+
+    return sys.modules["mock_server"]
+
+
+def _walk_values(value):
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk_values(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_values(child)
+    else:
+        yield value
+
+
+class TestMockTraceEndpoints(unittest.TestCase):
+    def setUp(self):
+        self.ms = _reload_mock_server()
+        self.client = TestClient(self.ms.app)
+
+    def _first_session_id(self) -> str:
+        resp = self.client.get("/api/trace/sessions")
+        self.assertEqual(resp.status_code, 200)
+        sessions = resp.json()["sessions"]
+        self.assertTrue(sessions)
+        return sessions[0]["session_id"]
+
+    def test_trace_sessions_returns_required_metadata(self):
+        resp = self.client.get("/api/trace/sessions")
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertTrue(body["ok"])
+        self.assertTrue(body["sessions"])
+
+        required = {"session_id", "started_ts", "line_count", "file_size", "parts"}
+        for session in body["sessions"]:
+            self.assertTrue(required.issubset(session.keys()))
+
+    def test_trace_export_streams_valid_ndjson_with_all_verdicts(self):
+        session_id = self._first_session_id()
+        resp = self.client.get("/api/trace/export", params={"session": session_id})
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers["content-type"], "application/x-ndjson")
+
+        events = [json.loads(line) for line in resp.text.splitlines() if line.strip()]
+        self.assertTrue(events)
+        for event in events:
+            self.assertTrue("verdict" in event or "kind" in event)
+
+        verdicts = {event.get("verdict") for event in events}
+        self.assertTrue({"accepted", "suppressed", "blocked"}.issubset(verdicts))
+
+    def test_trace_export_rejects_invalid_session_id(self):
+        resp = self.client.get("/api/trace/export", params={"session": "../bad"})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json(), {"error": "invalid_session"})
+
+    def test_trace_report_json_and_markdown_shapes(self):
+        session_id = self._first_session_id()
+        resp = self.client.get("/api/trace/report", params={"session": session_id})
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+
+        required = {
+            "session_id",
+            "event_count",
+            "time_range",
+            "verdict_distribution",
+            "top_suppressed_gates",
+            "shadow_divergence",
+        }
+        self.assertTrue(required.issubset(body.keys()))
+        self.assertEqual(body["session_id"], session_id)
+        self.assertIsInstance(body["verdict_distribution"], dict)
+        self.assertIsInstance(body["shadow_divergence"]["total"], int)
+
+        md_resp = self.client.get(
+            "/api/trace/report",
+            params={"session": session_id, "format": "md"},
+        )
+        self.assertEqual(md_resp.status_code, 200)
+        self.assertTrue(md_resp.headers["content-type"].startswith("text/markdown"))
+        self.assertIn(session_id, md_resp.text)
+
+    def test_trace_export_does_not_leak_raw_real_names(self):
+        session_id = self._first_session_id()
+        resp = self.client.get("/api/trace/export", params={"session": session_id})
+        self.assertEqual(resp.status_code, 200)
+        events = [json.loads(line) for line in resp.text.splitlines() if line.strip()]
+
+        banned_names = {"Roy", "小明", "小華", "Alice", "Bob"}
+        leaked = [
+            value
+            for event in events
+            for value in _walk_values(event)
+            if isinstance(value, str) and value in banned_names
+        ]
+        self.assertEqual(leaked, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pawai-studio/frontend/app/(studio)/studio/evidence/page.tsx
+++ b/pawai-studio/frontend/app/(studio)/studio/evidence/page.tsx
@@ -1,0 +1,667 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  AlertTriangle,
+  Archive,
+  ArrowLeft,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  FileJson,
+  GitBranch,
+  Radio,
+  RefreshCw,
+  X,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import type { BrainTraceEvent } from "@/contracts/types";
+import { GateChip } from "@/components/shared/gate-chip";
+import { useEventStream } from "@/hooks/use-event-stream";
+import { getGatewayHttpUrl } from "@/lib/gateway-url";
+import { buildTimeline, type TraceGroup, verdictTone } from "@/lib/trace-timeline";
+import { gateZh, reasonZh } from "@/lib/trace-zh";
+import { cn } from "@/lib/utils";
+import { useStateStore } from "@/stores/state-store";
+
+const TRACE_EVENT_CAP = 2000;
+
+type Mode = "live" | "history";
+type Tone = ReturnType<typeof verdictTone>;
+
+type TraceSession = {
+  session_id: string;
+  started_ts: number;
+  line_count: number;
+  file_size: number;
+  parts: string[];
+};
+
+type DisplayLabel = {
+  title: string;
+  code: string | null;
+};
+
+const TONE_CLASS: Record<Tone, string> = {
+  accepted: "bg-emerald-500/20 text-emerald-300 border-emerald-500/40",
+  suppressed: "bg-amber-500/20 text-amber-300 border-amber-500/40",
+  blocked: "bg-rose-500/20 text-rose-300 border-rose-500/40",
+  shadow: "bg-violet-500/20 text-violet-300 border-violet-500/40",
+};
+
+const TONE_ICON: Record<Tone, LucideIcon> = {
+  accepted: CheckCircle2,
+  suppressed: AlertTriangle,
+  blocked: XCircle,
+  shadow: GitBranch,
+};
+
+function splitDisplayLabel(raw: string, localized: string): DisplayLabel {
+  const suffix = `（${raw}）`;
+  if (localized !== raw && localized.endsWith(suffix)) {
+    return { title: localized.slice(0, -suffix.length), code: raw };
+  }
+  return { title: localized || raw || "(empty)", code: null };
+}
+
+function formatTimestamp(ts: number): string {
+  if (!Number.isFinite(ts)) return "unknown";
+  const ms = ts > 1_000_000_000_000 ? ts : ts * 1000;
+  return new Date(ms).toLocaleString("zh-TW", {
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+}
+
+function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function representativeEvent(group: TraceGroup): BrainTraceEvent {
+  return (
+    group.events.find((event) => event.kind === "policy_decision") ??
+    group.events[group.events.length - 1]
+  );
+}
+
+function safeJson(value: unknown): string {
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function isBrainTraceEvent(value: unknown): value is BrainTraceEvent {
+  if (typeof value !== "object" || value === null) return false;
+  const event = value as Partial<BrainTraceEvent>;
+  return (
+    typeof event.v === "number" &&
+    typeof event.ts === "number" &&
+    typeof event.decision_id === "string" &&
+    typeof event.node === "string" &&
+    typeof event.kind === "string" &&
+    typeof event.verdict === "string" &&
+    typeof event.gate === "string" &&
+    typeof event.reason === "string" &&
+    typeof event.detail === "object" &&
+    event.detail !== null
+  );
+}
+
+function appendCapped(events: BrainTraceEvent[], event: BrainTraceEvent): void {
+  events.push(event);
+  if (events.length > TRACE_EVENT_CAP * 2) {
+    events.splice(0, events.length - TRACE_EVENT_CAP);
+  }
+}
+
+function parseTraceLine(line: string): BrainTraceEvent | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    return isBrainTraceEvent(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function parseTraceNdjson(response: Response): Promise<BrainTraceEvent[]> {
+  const events: BrainTraceEvent[] = [];
+  const reader = response.body?.getReader();
+
+  if (!reader) {
+    const text = await response.text();
+    for (const line of text.split(/\r?\n/)) {
+      const event = parseTraceLine(line);
+      if (event) appendCapped(events, event);
+    }
+    return events.slice(-TRACE_EVENT_CAP);
+  }
+
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const event = parseTraceLine(line);
+      if (event) appendCapped(events, event);
+    }
+  }
+
+  buffer += decoder.decode();
+  const finalEvent = parseTraceLine(buffer);
+  if (finalEvent) appendCapped(events, finalEvent);
+  return events.slice(-TRACE_EVENT_CAP);
+}
+
+function DisplayCode({ label }: { label: DisplayLabel }) {
+  return (
+    <span className="inline-flex min-w-0 flex-col leading-tight">
+      <span className="truncate">{label.title}</span>
+      {label.code && (
+        <span className="truncate font-mono text-[10px] opacity-60">{label.code}</span>
+      )}
+    </span>
+  );
+}
+
+function VerdictBadge({ verdict, hasShadow }: { verdict: string; hasShadow?: boolean }) {
+  const tone = verdictTone(verdict, hasShadow);
+  const Icon = TONE_ICON[tone];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] font-medium",
+        TONE_CLASS[tone]
+      )}
+    >
+      <Icon className="h-3 w-3" />
+      {tone === "shadow" ? "shadow" : verdict}
+    </span>
+  );
+}
+
+function ModeButton({
+  mode,
+  activeMode,
+  onClick,
+  icon: Icon,
+  children,
+}: {
+  mode: Mode;
+  activeMode: Mode;
+  onClick: (mode: Mode) => void;
+  icon: LucideIcon;
+  children: React.ReactNode;
+}) {
+  const active = mode === activeMode;
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(mode)}
+      className={cn(
+        "inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60",
+        active
+          ? "border-sky-400/40 bg-sky-500/15 text-sky-200"
+          : "border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground"
+      )}
+      aria-pressed={active}
+    >
+      <Icon className="h-4 w-4" />
+      {children}
+    </button>
+  );
+}
+
+function TimelineEvent({
+  event,
+  index,
+  selected,
+  onSelect,
+}: {
+  event: BrainTraceEvent;
+  index: number;
+  selected: boolean;
+  onSelect: (event: BrainTraceEvent) => void;
+}) {
+  const gateLabel = splitDisplayLabel(event.gate, gateZh(event.gate));
+  const reasonLabel = splitDisplayLabel(event.reason, reasonZh(event.reason));
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(event)}
+      className={cn(
+        "w-full rounded-md border p-3 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60",
+        selected
+          ? "border-sky-400/50 bg-sky-500/10"
+          : "border-border/70 bg-muted/20 hover:border-border hover:bg-muted/40"
+      )}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="font-mono text-[10px] text-muted-foreground">
+            #{index + 1}
+          </span>
+          <span className="rounded border border-slate-500/40 bg-slate-500/10 px-1.5 py-0.5 font-mono text-[10px] text-slate-300">
+            {event.kind}
+          </span>
+          <VerdictBadge verdict={event.verdict} hasShadow={event.gate === "ism_shadow"} />
+        </div>
+        <span className="font-mono text-[10px] text-muted-foreground">
+          {formatTimestamp(event.ts)}
+        </span>
+      </div>
+
+      <div className="mt-2 grid gap-2 md:grid-cols-[180px_minmax(0,1fr)]">
+        <div
+          className="rounded border border-border/60 bg-background/40 px-2 py-1 text-xs text-foreground"
+          title={event.gate}
+        >
+          <DisplayCode label={gateLabel} />
+        </div>
+        <div
+          className="rounded border border-border/60 bg-background/40 px-2 py-1 text-xs text-muted-foreground"
+          title={event.reason}
+        >
+          <DisplayCode label={reasonLabel} />
+        </div>
+      </div>
+
+      <pre className="mt-2 max-h-44 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border/60 bg-background/60 p-2 font-mono text-[11px] leading-relaxed text-muted-foreground">
+        {safeJson(event.detail)}
+      </pre>
+    </button>
+  );
+}
+
+function TimelineGroup({
+  group,
+  open,
+  selectedEvent,
+  onToggle,
+  onSelectEvent,
+}: {
+  group: TraceGroup;
+  open: boolean;
+  selectedEvent: BrainTraceEvent | null;
+  onToggle: () => void;
+  onSelectEvent: (event: BrainTraceEvent) => void;
+}) {
+  const representative = representativeEvent(group);
+  const reasonLabel = splitDisplayLabel(representative.reason, reasonZh(representative.reason));
+
+  return (
+    <section className="rounded-lg border border-border bg-card/70">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-start gap-3 p-3 text-left transition-colors hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+      >
+        <span className="mt-1 text-muted-foreground">
+          {open ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className="font-mono text-sm font-semibold text-foreground"
+              title={group.decisionId}
+            >
+              {group.decisionId.slice(0, 8)}
+            </span>
+            <VerdictBadge verdict={group.verdict} hasShadow={group.hasShadow} />
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {group.events.length} events
+            </span>
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {formatTimestamp(group.firstTs)} - {formatTimestamp(group.lastTs)}
+            </span>
+          </div>
+
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {group.gates.map((gate) => (
+              <span
+                key={gate}
+                className={cn(
+                  "inline-flex max-w-[220px] rounded border px-2 py-1 text-xs",
+                  gate === "ism_shadow"
+                    ? "border-violet-500/40 bg-violet-500/10 text-violet-300"
+                    : "border-slate-500/30 bg-slate-500/10 text-slate-300"
+                )}
+                title={gate}
+              >
+                <DisplayCode label={splitDisplayLabel(gate, gateZh(gate))} />
+              </span>
+            ))}
+          </div>
+
+          <div className="mt-2 max-w-full rounded border border-border/60 bg-background/40 px-2 py-1 text-xs text-muted-foreground">
+            <DisplayCode label={reasonLabel} />
+          </div>
+        </div>
+      </button>
+
+      {open && (
+        <div className="space-y-2 border-t border-border/70 p-3">
+          {group.events.map((event, index) => (
+            <TimelineEvent
+              key={`${event.decision_id}-${event.ts}-${event.kind}-${index}`}
+              event={event}
+              index={index}
+              selected={selectedEvent === event}
+              onSelect={onSelectEvent}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DetailPanel({
+  event,
+  onClose,
+}: {
+  event: BrainTraceEvent | null;
+  onClose: () => void;
+}) {
+  return (
+    <aside className="flex min-h-0 flex-col rounded-lg border border-border bg-card">
+      <div className="flex h-12 items-center justify-between border-b border-border px-3">
+        <div className="flex items-center gap-2">
+          <FileJson className="h-4 w-4 text-sky-300" />
+          <h2 className="text-sm font-semibold">Detail</h2>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+          aria-label="Close detail"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {event ? (
+        <div className="min-h-0 flex-1 overflow-auto p-3">
+          <div className="space-y-2 text-xs">
+            {[
+              ["decision_id", event.decision_id],
+              ["node", event.node],
+              ["kind", event.kind],
+              ["verdict", event.verdict],
+              ["gate", event.gate],
+              ["reason", event.reason],
+              ["ts", String(event.ts)],
+              ["plan_id", event.plan_id ?? ""],
+            ].map(([key, value]) => (
+              <div key={key} className="grid grid-cols-[92px_minmax(0,1fr)] gap-2">
+                <span className="font-mono text-muted-foreground">{key}</span>
+                <span className="min-w-0 break-words font-mono text-foreground">{value}</span>
+              </div>
+            ))}
+          </div>
+          <pre className="mt-3 min-h-[240px] whitespace-pre-wrap break-words rounded-md border border-border bg-background p-3 font-mono text-[11px] leading-relaxed text-muted-foreground">
+            {safeJson(event.detail)}
+          </pre>
+        </div>
+      ) : (
+        <div className="flex flex-1 items-center justify-center p-6 text-center text-sm text-muted-foreground">
+          Select an event
+        </div>
+      )}
+    </aside>
+  );
+}
+
+export default function EvidencePage() {
+  const { isConnected } = useEventStream();
+  const brainTraces = useStateStore((state) => state.brainTraces);
+  const [mode, setMode] = useState<Mode>("live");
+  const [sessions, setSessions] = useState<TraceSession[]>([]);
+  const [selectedSession, setSelectedSession] = useState("");
+  const [historyEvents, setHistoryEvents] = useState<BrainTraceEvent[]>([]);
+  const [sessionsLoading, setSessionsLoading] = useState(false);
+  const [historyLoading, setHistoryLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
+  const [selectedEvent, setSelectedEvent] = useState<BrainTraceEvent | null>(null);
+
+  const loadSessions = useCallback(async () => {
+    setSessionsLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`${getGatewayHttpUrl()}/api/trace/sessions`);
+      if (!response.ok) {
+        throw new Error(`sessions ${response.status}`);
+      }
+      const payload = (await response.json()) as { sessions?: TraceSession[] };
+      setSessions(payload.sessions ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "failed to load sessions");
+    } finally {
+      setSessionsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSessions();
+  }, [loadSessions]);
+
+  useEffect(() => {
+    if (mode === "history" && !selectedSession && sessions[0]) {
+      setSelectedSession(sessions[0].session_id);
+    }
+  }, [mode, selectedSession, sessions]);
+
+  useEffect(() => {
+    if (mode !== "history" || !selectedSession) return;
+
+    const controller = new AbortController();
+    setHistoryLoading(true);
+    setError(null);
+    setSelectedEvent(null);
+
+    async function loadHistory() {
+      try {
+        const url = `${getGatewayHttpUrl()}/api/trace/export?session=${encodeURIComponent(
+          selectedSession
+        )}`;
+        const response = await fetch(url, { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(`export ${response.status}`);
+        }
+        const events = await parseTraceNdjson(response);
+        setHistoryEvents(events);
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setHistoryEvents([]);
+          setError(err instanceof Error ? err.message : "failed to load history");
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setHistoryLoading(false);
+        }
+      }
+    }
+
+    void loadHistory();
+    return () => controller.abort();
+  }, [mode, selectedSession]);
+
+  const sourceEvents = mode === "live" ? brainTraces : historyEvents;
+  const timeline = useMemo(
+    () => buildTimeline(sourceEvents, { cap: TRACE_EVENT_CAP }),
+    [sourceEvents]
+  );
+  const shownEventCount = timeline.reduce((total, group) => total + group.events.length, 0);
+  const selectedSessionMeta = sessions.find((session) => session.session_id === selectedSession);
+
+  const toggleGroup = useCallback((decisionId: string) => {
+    setOpenGroups((current) => {
+      const next = new Set(current);
+      if (next.has(decisionId)) {
+        next.delete(decisionId);
+      } else {
+        next.add(decisionId);
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div className="flex h-screen flex-col bg-background text-foreground">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-[var(--nav-border)] px-4 md:px-5">
+        <div className="flex min-w-0 items-center gap-3">
+          <Link
+            href="/studio"
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+            aria-label="Back to Studio"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+          <div className="min-w-0">
+            <h1 className="truncate text-sm font-semibold">Evidence Center</h1>
+            <p className="truncate font-mono text-[10px] text-muted-foreground">
+              /studio/evidence
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <GateChip name="WS" value={isConnected ? "true" : "false"} />
+          <button
+            type="button"
+            onClick={() => void loadSessions()}
+            disabled={sessionsLoading}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+            aria-label="Refresh sessions"
+            title="Refresh sessions"
+          >
+            <RefreshCw className={cn("h-4 w-4", sessionsLoading && "animate-spin")} />
+          </button>
+        </div>
+      </header>
+
+      <main className="grid min-h-0 flex-1 gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_380px]">
+        <div className="flex min-h-0 flex-col gap-4">
+          <section className="rounded-lg border border-border bg-card p-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+              <div className="flex flex-wrap gap-2">
+                <ModeButton mode="live" activeMode={mode} onClick={setMode} icon={Radio}>
+                  Live
+                </ModeButton>
+                <ModeButton mode="history" activeMode={mode} onClick={setMode} icon={Archive}>
+                  History
+                </ModeButton>
+              </div>
+
+              <div className="grid gap-1.5 lg:min-w-[340px]">
+                <label htmlFor="trace-session" className="text-[11px] text-muted-foreground">
+                  Session
+                </label>
+                <select
+                  id="trace-session"
+                  value={selectedSession}
+                  onChange={(event) => {
+                    setSelectedSession(event.target.value);
+                    setMode("history");
+                  }}
+                  disabled={sessionsLoading || sessions.length === 0}
+                  className="h-9 rounded-md border border-border bg-background px-3 text-sm text-foreground outline-none focus:ring-2 focus:ring-sky-400/60 disabled:opacity-50"
+                >
+                  <option value="">
+                    {sessionsLoading ? "loading..." : "no sessions"}
+                  </option>
+                  {sessions.map((session) => (
+                    <option key={session.session_id} value={session.session_id}>
+                      {session.session_id} · {session.line_count} events
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-muted-foreground">
+              <span className="rounded border border-border bg-background px-2 py-1 font-mono">
+                groups={timeline.length}
+              </span>
+              <span className="rounded border border-border bg-background px-2 py-1 font-mono">
+                events={shownEventCount}/{sourceEvents.length}
+              </span>
+              <span className="rounded border border-border bg-background px-2 py-1 font-mono">
+                cap={TRACE_EVENT_CAP}
+              </span>
+              {selectedSessionMeta && (
+                <>
+                  <span className="rounded border border-border bg-background px-2 py-1 font-mono">
+                    file={formatBytes(selectedSessionMeta.file_size)}
+                  </span>
+                  <span className="rounded border border-border bg-background px-2 py-1 font-mono">
+                    parts={selectedSessionMeta.parts.length}
+                  </span>
+                </>
+              )}
+              {historyLoading && (
+                <span className="rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-amber-300">
+                  loading history
+                </span>
+              )}
+              {error && (
+                <span className="rounded border border-rose-500/30 bg-rose-500/10 px-2 py-1 text-rose-300">
+                  {error}
+                </span>
+              )}
+            </div>
+          </section>
+
+          <div className="min-h-0 flex-1 overflow-auto">
+            <div className="space-y-3 pb-3">
+              {timeline.length === 0 ? (
+                <div className="flex min-h-[240px] items-center justify-center rounded-lg border border-dashed border-border bg-card/50 p-6 text-center text-sm text-muted-foreground">
+                  {mode === "live" ? "No live trace events" : "No history trace events"}
+                </div>
+              ) : (
+                timeline.map((group) => (
+                  <TimelineGroup
+                    key={group.decisionId}
+                    group={group}
+                    open={openGroups.has(group.decisionId)}
+                    selectedEvent={selectedEvent}
+                    onToggle={() => toggleGroup(group.decisionId)}
+                    onSelectEvent={setSelectedEvent}
+                  />
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        <DetailPanel event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      </main>
+    </div>
+  );
+}

--- a/pawai-studio/frontend/app/(studio)/studio/evidence/page.tsx
+++ b/pawai-studio/frontend/app/(studio)/studio/evidence/page.tsx
@@ -9,6 +9,7 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  Download,
   FileJson,
   GitBranch,
   Radio,
@@ -20,6 +21,7 @@ import {
 import type { BrainTraceEvent } from "@/contracts/types";
 import { GateChip } from "@/components/shared/gate-chip";
 import { useEventStream } from "@/hooks/use-event-stream";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 import { buildTimeline, type TraceGroup, verdictTone } from "@/lib/trace-timeline";
 import { gateZh, reasonZh } from "@/lib/trace-zh";
@@ -104,6 +106,32 @@ function safeJson(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  try {
+    link.click();
+  } finally {
+    link.remove();
+    URL.revokeObjectURL(url);
+  }
+}
+
+async function downloadErrorMessage(response: Response, label: string): Promise<string> {
+  let body = "";
+  try {
+    body = (await response.text()).trim();
+  } catch {
+    body = "";
+  }
+
+  const suffix = body ? `: ${body.slice(0, 160)}` : "";
+  return `${label} download failed (${response.status})${suffix}`;
 }
 
 function isBrainTraceEvent(value: unknown): value is BrainTraceEvent {
@@ -448,6 +476,8 @@ export default function EvidencePage() {
   const [sessionsLoading, setSessionsLoading] = useState(false);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState<"jsonl" | "md" | null>(null);
   const [openGroups, setOpenGroups] = useState<Set<string>>(new Set());
   const [selectedEvent, setSelectedEvent] = useState<BrainTraceEvent | null>(null);
 
@@ -533,6 +563,39 @@ export default function EvidencePage() {
     });
   }, []);
 
+  const downloadSessionArtifact = useCallback(
+    async (kind: "jsonl" | "md") => {
+      if (!selectedSession) return;
+
+      const encodedSession = encodeURIComponent(selectedSession);
+      const isJsonl = kind === "jsonl";
+      const label = isJsonl ? "redacted JSONL" : "session report";
+      const url = isJsonl
+        ? `${getGatewayHttpUrl()}/api/trace/export?session=${encodedSession}`
+        : `${getGatewayHttpUrl()}/api/trace/report?session=${encodedSession}&format=md`;
+
+      setDownloadError(null);
+      setDownloading(kind);
+      try {
+        const response = await fetch(url, { headers: { ...authHeaders() } });
+        if (!response.ok) {
+          throw new Error(await downloadErrorMessage(response, label));
+        }
+
+        const text = await response.text();
+        const blob = new Blob([text], {
+          type: isJsonl ? "application/x-ndjson;charset=utf-8" : "text/markdown;charset=utf-8",
+        });
+        downloadBlob(blob, `${selectedSession}.${kind}`);
+      } catch (err) {
+        setDownloadError(err instanceof Error ? err.message : `${label} download failed`);
+      } finally {
+        setDownloading(null);
+      }
+    },
+    [selectedSession]
+  );
+
   return (
     <div className="flex h-screen flex-col bg-background text-foreground">
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-[var(--nav-border)] px-4 md:px-5">
@@ -603,6 +666,32 @@ export default function EvidencePage() {
                   ))}
                 </select>
               </div>
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void downloadSessionArtifact("jsonl")}
+                disabled={!selectedSession || downloading !== null}
+                className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+              >
+                <Download className="h-4 w-4" />
+                {downloading === "jsonl" ? "下載中..." : "下載 redacted JSONL"}
+              </button>
+              <button
+                type="button"
+                onClick={() => void downloadSessionArtifact("md")}
+                disabled={!selectedSession || downloading !== null}
+                className="inline-flex h-9 items-center gap-2 rounded-md border border-border bg-background px-3 text-xs font-medium text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/60"
+              >
+                <Download className="h-4 w-4" />
+                {downloading === "md" ? "下載中..." : "下載 session 報告 (md)"}
+              </button>
+              {downloadError && (
+                <span className="rounded border border-rose-500/30 bg-rose-500/10 px-2 py-1 text-[11px] text-rose-300">
+                  {downloadError}
+                </span>
+              )}
             </div>
 
             <div className="mt-3 flex flex-wrap gap-2 text-[11px] text-muted-foreground">

--- a/pawai-studio/frontend/lib/__tests__/gateway-auth.test.ts
+++ b/pawai-studio/frontend/lib/__tests__/gateway-auth.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { authHeaders, getGatewayToken } from "@/lib/gateway-auth";
+
+const originalGatewayToken = process.env.NEXT_PUBLIC_GATEWAY_TOKEN;
+
+afterEach(() => {
+  if (originalGatewayToken === undefined) {
+    delete process.env.NEXT_PUBLIC_GATEWAY_TOKEN;
+  } else {
+    process.env.NEXT_PUBLIC_GATEWAY_TOKEN = originalGatewayToken;
+  }
+});
+
+describe("gateway auth", () => {
+  it("keeps auth headers default-off when the token is empty", () => {
+    expect(authHeaders("")).toEqual({});
+  });
+
+  it("attaches a bearer token when configured", () => {
+    expect(authHeaders("abc")).toEqual({ Authorization: "Bearer abc" });
+  });
+
+  it("reads and trims the gateway token from the public env var", () => {
+    process.env.NEXT_PUBLIC_GATEWAY_TOKEN = "  abc  ";
+
+    expect(getGatewayToken()).toBe("abc");
+  });
+
+  it("returns no gateway token when env is unset in node", () => {
+    delete process.env.NEXT_PUBLIC_GATEWAY_TOKEN;
+
+    expect(getGatewayToken()).toBe("");
+    expect(authHeaders()).toEqual({});
+  });
+});

--- a/pawai-studio/frontend/lib/__tests__/trace-timeline.test.ts
+++ b/pawai-studio/frontend/lib/__tests__/trace-timeline.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import type { BrainTraceEvent } from "@/contracts/types";
+import { buildTimeline, verdictTone } from "@/lib/trace-timeline";
+import { gateZh, reasonZh } from "@/lib/trace-zh";
+
+function trace(
+  partial: Partial<BrainTraceEvent> & Pick<BrainTraceEvent, "decision_id" | "ts">
+): BrainTraceEvent {
+  return {
+    v: 1,
+    node: "brain_node",
+    kind: "candidate",
+    verdict: "accepted",
+    gate: "safety",
+    reason: "candidate:greet",
+    detail: {},
+    ...partial,
+  };
+}
+
+describe("buildTimeline", () => {
+  it("groups multiple decision ids in first-seen timestamp order", () => {
+    const groups = buildTimeline([
+      trace({ decision_id: "decision-b", ts: 20, gate: "tts_playing" }),
+      trace({ decision_id: "decision-a", ts: 10, gate: "safety" }),
+      trace({
+        decision_id: "decision-b",
+        ts: 30,
+        kind: "policy_decision",
+        verdict: "suppressed",
+        gate: "tts_playing",
+      }),
+    ]);
+
+    expect(groups.map((group) => group.decisionId)).toEqual(["decision-a", "decision-b"]);
+    expect(groups[1].events).toHaveLength(2);
+    expect(groups[1].verdict).toBe("suppressed");
+    expect(groups[1].gates).toEqual(["tts_playing"]);
+  });
+
+  it("sorts events by timestamp ascending within a group", () => {
+    const groups = buildTimeline([
+      trace({ decision_id: "decision-a", ts: 30, kind: "skill_result" }),
+      trace({ decision_id: "decision-a", ts: 10, kind: "candidate" }),
+      trace({ decision_id: "decision-a", ts: 20, kind: "policy_decision" }),
+    ]);
+
+    expect(groups[0].events.map((event) => event.kind)).toEqual([
+      "candidate",
+      "policy_decision",
+      "skill_result",
+    ]);
+    expect(groups[0].firstTs).toBe(10);
+    expect(groups[0].lastTs).toBe(30);
+  });
+
+  it("caps by keeping the newest events", () => {
+    const groups = buildTimeline(
+      Array.from({ length: 6 }, (_, index) =>
+        trace({ decision_id: `decision-${index}`, ts: index + 1 })
+      ),
+      { cap: 3 }
+    );
+
+    expect(groups.map((group) => group.decisionId)).toEqual([
+      "decision-3",
+      "decision-4",
+      "decision-5",
+    ]);
+    expect(groups.map((group) => group.firstTs)).toEqual([4, 5, 6]);
+  });
+
+  it("detects shadow chains and lets shadow tone win", () => {
+    const groups = buildTimeline([
+      trace({ decision_id: "shadow-chain", ts: 10, gate: "safety" }),
+      trace({ decision_id: "shadow-chain", ts: 20, gate: "ism_shadow", verdict: "blocked" }),
+    ]);
+
+    expect(groups[0].hasShadow).toBe(true);
+    expect(verdictTone(groups[0].verdict, groups[0].hasShadow)).toBe("shadow");
+  });
+});
+
+describe("verdictTone", () => {
+  it("maps known verdicts and defaults unknown values to accepted", () => {
+    expect(verdictTone("accepted")).toBe("accepted");
+    expect(verdictTone("suppressed")).toBe("suppressed");
+    expect(verdictTone("blocked")).toBe("blocked");
+    expect(verdictTone("unexpected")).toBe("accepted");
+  });
+});
+
+describe("trace zh labels", () => {
+  it("looks up reason prefixes and falls back to the raw reason", () => {
+    expect(reasonZh("cooldown:greet:[private]")).toBe("冷卻中（cooldown:greet:[private]）");
+    expect(reasonZh("unknown_prefix:value")).toBe("unknown_prefix:value");
+  });
+
+  it("falls back to the raw gate for unmapped gates", () => {
+    expect(gateZh("safety")).toBe("安全限制（safety）");
+    expect(gateZh("future_gate")).toBe("future_gate");
+  });
+});

--- a/pawai-studio/frontend/lib/gateway-auth.ts
+++ b/pawai-studio/frontend/lib/gateway-auth.ts
@@ -1,0 +1,19 @@
+export function getGatewayToken(): string {
+  const envToken = process.env.NEXT_PUBLIC_GATEWAY_TOKEN?.trim();
+  if (envToken) return envToken;
+
+  if (typeof window === "undefined") return "";
+
+  try {
+    return (window.localStorage.getItem("pawai_gateway_token") ?? "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export function authHeaders(token = getGatewayToken()): Record<string, string> {
+  const trimmedToken = token.trim();
+  if (!trimmedToken) return {};
+
+  return { Authorization: `Bearer ${trimmedToken}` };
+}

--- a/pawai-studio/frontend/lib/trace-timeline.ts
+++ b/pawai-studio/frontend/lib/trace-timeline.ts
@@ -1,0 +1,86 @@
+import type { BrainTraceEvent } from "@/contracts/types";
+
+export type TraceGroup = {
+  decisionId: string;
+  events: BrainTraceEvent[];
+  firstTs: number;
+  lastTs: number;
+  verdict: string;
+  gates: string[];
+  hasShadow: boolean;
+};
+
+type DecoratedEvent = {
+  event: BrainTraceEvent;
+  index: number;
+};
+
+const DEFAULT_CAP = 2000;
+
+function sortedByTimestamp(events: BrainTraceEvent[]): BrainTraceEvent[] {
+  return events
+    .map((event, index): DecoratedEvent => ({ event, index }))
+    .sort((a, b) => {
+      const byTs = a.event.ts - b.event.ts;
+      return byTs === 0 ? a.index - b.index : byTs;
+    })
+    .map(({ event }) => event);
+}
+
+export function buildTimeline(
+  events: BrainTraceEvent[],
+  opts: { cap?: number } = {}
+): TraceGroup[] {
+  const cap = opts.cap ?? DEFAULT_CAP;
+  if (cap <= 0) return [];
+
+  const sorted = sortedByTimestamp(events);
+  const capped = sorted.length > cap ? sorted.slice(sorted.length - cap) : sorted;
+  const groupsByDecision = new Map<string, TraceGroup>();
+  const groupGateSets = new Map<string, Set<string>>();
+  const policyDecisionGroups = new Set<string>();
+
+  for (const event of capped) {
+    let group = groupsByDecision.get(event.decision_id);
+    if (!group) {
+      group = {
+        decisionId: event.decision_id,
+        events: [],
+        firstTs: event.ts,
+        lastTs: event.ts,
+        verdict: event.verdict,
+        gates: [],
+        hasShadow: false,
+      };
+      groupsByDecision.set(event.decision_id, group);
+      groupGateSets.set(event.decision_id, new Set<string>());
+    }
+
+    group.events.push(event);
+    group.lastTs = event.ts;
+    group.hasShadow = group.hasShadow || event.gate === "ism_shadow";
+    if (event.kind === "policy_decision") {
+      group.verdict = event.verdict;
+      policyDecisionGroups.add(event.decision_id);
+    } else if (!policyDecisionGroups.has(event.decision_id)) {
+      group.verdict = event.verdict;
+    }
+
+    const gates = groupGateSets.get(event.decision_id);
+    if (gates && event.gate && !gates.has(event.gate)) {
+      gates.add(event.gate);
+      group.gates.push(event.gate);
+    }
+  }
+
+  return [...groupsByDecision.values()];
+}
+
+export function verdictTone(
+  verdict: string,
+  hasShadow = false
+): "accepted" | "suppressed" | "blocked" | "shadow" {
+  if (hasShadow) return "shadow";
+  if (verdict === "suppressed" || verdict === "blocked") return verdict;
+  return "accepted";
+}

--- a/pawai-studio/frontend/lib/trace-zh.ts
+++ b/pawai-studio/frontend/lib/trace-zh.ts
@@ -1,0 +1,75 @@
+export const TRACE_GATE_ZH: Record<string, string> = {
+  active_plan: "已有行動計畫",
+  alert_active: "警戒中",
+  attention_engaged: "注意力已佔用",
+  capability_health: "能力健康檢查",
+  confirm_pending: "等待確認",
+  conversation_gate: "對話閘門",
+  dedup: "重複事件",
+  demo_phase: "demo 場景遮罩",
+  depth_clear: "深度安全",
+  emergency: "緊急狀態",
+  executing: "正在執行",
+  gesture_enabled: "手勢啟用",
+  greet_cooldown: "問候冷卻",
+  greet_gate: "問候閘門",
+  greet_sitting_window: "坐姿問候視窗",
+  ism_shadow: "ISM 影子判斷",
+  llm_allowlist: "LLM 白名單",
+  nav_paused: "導航暫停",
+  nav_ready: "導航就緒",
+  object_remark_dedup: "物件評論重複",
+  pending_confirm: "等待確認",
+  safety: "安全限制",
+  safety_hold: "安全暫停",
+  skill_cooldown: "技能冷卻",
+  speaking: "正在說話",
+  stranger_alert_enabled: "陌生人警戒啟用",
+  tts_playing: "語音播放中",
+};
+
+export const TRACE_REASON_PREFIX_ZH: Record<string, string> = {
+  cooldown: "冷卻中",
+  phase: "demo 場景遮罩",
+  watchdog_timeout: "逾時自癒",
+  banned_api: "禁用指令",
+  gate: "被閘門擋下",
+  identity: "身份",
+};
+
+export const ISM_VERDICT_ZH: Record<string, string> = {
+  accept: "接受",
+  suppress: "抑制",
+  queue: "排隊",
+  preempt: "搶佔",
+};
+
+export const ISM_TRIGGER_ZH: Record<string, string> = {
+  skill_result: "技能結果",
+  confirm_result: "確認結果",
+  tts_ack: "語音確認",
+  operator: "操作者",
+  safety: "安全",
+};
+
+export const ISM_STATE_ZH: Record<string, string> = {
+  idle: "閒置",
+  listening: "聆聽中",
+  speaking: "說話中",
+  confirm_pending: "等待確認",
+  executing: "執行中",
+  alert_active: "警戒中",
+  safety_hold: "安全暫停",
+  error_recovery: "錯誤復原",
+};
+
+export function gateZh(gate: string): string {
+  const label = TRACE_GATE_ZH[gate];
+  return label ? `${label}（${gate}）` : gate;
+}
+
+export function reasonZh(reason: string): string {
+  const prefix = reason.split(":", 1)[0];
+  const label = TRACE_REASON_PREFIX_ZH[prefix];
+  return label ? `${label}（${reason}）` : reason;
+}

--- a/pawai-studio/frontend/package.json
+++ b/pawai-studio/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test": "vitest run",
     "lint": "eslint"
   },
   "dependencies": {

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -67,7 +67,8 @@ from auth import (
 # Evidence Center trace store (system Phase 2 T2B-1) — pure module; persistence
 # of /brain/trace JSONL + the T2B-0 PII redaction single source.
 from trace_store import (  # noqa: E402 — same-dir import after sys.path setup
-    TraceStore, iter_export_lines, redact_trace_event, store_enabled, trace_dir,
+    TraceStore, iter_export_lines, list_sessions, redact_trace_event,
+    store_enabled, trace_dir,
 )
 
 # ── Config ───────────────────────────────────────────────────────
@@ -1119,6 +1120,27 @@ async def get_scoreboard():
 
 
 # ── Evidence Center: trace export (T2B-2, A-11 + T2B-0 rulings) ─────────────
+
+@app.get("/api/trace/sessions")
+async def get_trace_sessions(request: Request):
+    """List persisted trace sessions with metadata only (Lane 2 T2-1).
+
+    No event payload is returned here, so there is no PII to redact. The access
+    posture deliberately matches trace export: when token auth is enabled,
+    this GET endpoint requires the Bearer token despite the global safe-method
+    bypass.
+    """
+    status = export_access(
+        auth_enabled=AUTH.auth_enabled,
+        header_token_ok=token_ok(request.headers.get("authorization"), AUTH.token),
+        want_full=False,
+    )
+    if status == 401:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    return {
+        "ok": True,
+        "sessions": list_sessions(trace_dir(repo_root=_REPO_ROOT)),
+    }
 
 @app.get("/api/trace/export")
 async def get_trace_export(request: Request, since: float = 0.0, redact: int = 1):

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -67,8 +67,8 @@ from auth import (
 # Evidence Center trace store (system Phase 2 T2B-1) — pure module; persistence
 # of /brain/trace JSONL + the T2B-0 PII redaction single source.
 from trace_store import (  # noqa: E402 — same-dir import after sys.path setup
-    TraceStore, iter_export_lines, list_sessions, redact_trace_event,
-    store_enabled, trace_dir,
+    TraceStore, iter_export_lines, iter_session_lines, list_sessions,
+    redact_trace_event, store_enabled, trace_dir, valid_session_id,
 )
 
 # ── Config ───────────────────────────────────────────────────────
@@ -1143,15 +1143,21 @@ async def get_trace_sessions(request: Request):
     }
 
 @app.get("/api/trace/export")
-async def get_trace_export(request: Request, since: float = 0.0, redact: int = 1):
+async def get_trace_export(
+    request: Request,
+    since: float = 0.0,
+    redact: int = 1,
+    session: str = "",
+):
     """Stream persisted /brain/trace JSONL (application/x-ndjson).
 
-    Query: since=<unix ts> (events with ts >= since), redact=0 for the FULL
-    (unredacted) archive. Auth (A-11, Roy 2026-06-12): the global middleware
-    exempts GET — this endpoint deliberately does NOT get that bypass; when
-    auth is on, even redacted GET export needs the Bearer token, and the full
-    export refuses entirely while the token system is off (PII never leaves
-    the machine unredacted without an authenticated caller).
+    Query: since=<unix ts> (events with ts >= since), session=<id> for one
+    persisted session, redact=0 for the FULL (unredacted) archive. Auth (A-11,
+    Roy 2026-06-12): the global middleware exempts GET — this endpoint
+    deliberately does NOT get that bypass; when auth is on, even redacted GET
+    export needs the Bearer token, and the full export refuses entirely while
+    the token system is off (PII never leaves the machine unredacted without an
+    authenticated caller).
     """
     want_full = int(redact) == 0
     status = export_access(
@@ -1163,8 +1169,13 @@ async def get_trace_export(request: Request, since: float = 0.0, redact: int = 1
         return JSONResponse({"error": "unauthorized"}, status_code=401)
     if status == 403:
         return JSONResponse({"error": "full_export_requires_auth"}, status_code=403)
-    lines = iter_export_lines(trace_dir(repo_root=_REPO_ROOT),
-                              since=since or None, redact=not want_full)
+    if session and not valid_session_id(session):
+        return JSONResponse({"error": "invalid_session"}, status_code=400)
+    directory = trace_dir(repo_root=_REPO_ROOT)
+    if session:
+        lines = iter_session_lines(directory, session, since=since or None, redact=not want_full)
+    else:
+        lines = iter_export_lines(directory, since=since or None, redact=not want_full)
     return StreamingResponse(lines, media_type="application/x-ndjson")
 
 

--- a/pawai-studio/gateway/studio_gateway.py
+++ b/pawai-studio/gateway/studio_gateway.py
@@ -26,7 +26,7 @@ import uvicorn
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from fastapi.responses import FileResponse, JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 import rclpy
@@ -68,7 +68,8 @@ from auth import (
 # of /brain/trace JSONL + the T2B-0 PII redaction single source.
 from trace_store import (  # noqa: E402 — same-dir import after sys.path setup
     TraceStore, iter_export_lines, iter_session_lines, list_sessions,
-    redact_trace_event, store_enabled, trace_dir, valid_session_id,
+    redact_trace_event, render_session_report_md, store_enabled,
+    summarize_session, trace_dir, valid_session_id,
 )
 
 # ── Config ───────────────────────────────────────────────────────
@@ -1177,6 +1178,25 @@ async def get_trace_export(
     else:
         lines = iter_export_lines(directory, since=since or None, redact=not want_full)
     return StreamingResponse(lines, media_type="application/x-ndjson")
+
+
+@app.get("/api/trace/report")
+async def get_trace_report(request: Request, session: str = "", format: str = "json"):
+    """Return a redacted, per-session trace report summary (Lane 2 T2-5)."""
+    status = export_access(
+        auth_enabled=AUTH.auth_enabled,
+        header_token_ok=token_ok(request.headers.get("authorization"), AUTH.token),
+        want_full=False,
+    )
+    if status == 401:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    if not session or not valid_session_id(session):
+        return JSONResponse({"error": "invalid_session"}, status_code=400)
+
+    summary = summarize_session(trace_dir(repo_root=_REPO_ROOT), session)
+    if format.lower() in {"md", "markdown"}:
+        return PlainTextResponse(render_session_report_md(summary), media_type="text/markdown")
+    return summary
 
 
 class PlanModePayload(BaseModel):

--- a/pawai-studio/gateway/test_gateway.py
+++ b/pawai-studio/gateway/test_gateway.py
@@ -378,6 +378,71 @@ class TestScoreboardEndpoint:
         assert _scoreboard_path() == target
 
 
+class TestTraceSessionsEndpoint:
+    """Lane 2 T2-1: read-only trace session list endpoint."""
+
+    def test_trace_sessions_lists_redaction_free_stats(self, tmp_path, monkeypatch):
+        import asyncio
+        from studio_gateway import get_trace_sessions
+
+        p = tmp_path / "20260613-010000.jsonl"
+        p.write_text(
+            json.dumps({
+                "v": 1,
+                "ts": 100.0,
+                "decision_id": "d1",
+                "node": "brain_node",
+                "kind": "policy_decision",
+                "verdict": "suppressed",
+                "gate": "greet_cooldown",
+                "reason": "cooldown:greet:Roy",
+                "detail": {"source_summary": "identity=Roy conf=0.9"},
+            }) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+
+        class _Req:
+            headers = {}
+
+        resp = asyncio.run(get_trace_sessions(_Req()))
+
+        assert resp == {
+            "ok": True,
+            "sessions": [{
+                "session_id": "20260613-010000",
+                "started_ts": 100.0,
+                "line_count": 1,
+                "file_size": p.stat().st_size,
+                "parts": ["20260613-010000.jsonl"],
+            }],
+        }
+
+    def test_trace_sessions_uses_export_auth_posture(self, tmp_path, monkeypatch):
+        import asyncio
+        from auth import AuthConfig
+        import studio_gateway
+
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+        monkeypatch.setattr(
+            studio_gateway,
+            "AUTH",
+            AuthConfig(host="0.0.0.0", token="secret", allowed_origins=()),
+        )
+
+        class _Missing:
+            headers = {}
+
+        class _Authed:
+            headers = {"authorization": "Bearer secret"}
+
+        missing = asyncio.run(studio_gateway.get_trace_sessions(_Missing()))
+        authed = asyncio.run(studio_gateway.get_trace_sessions(_Authed()))
+
+        assert missing.status_code == 401
+        assert authed["ok"] is True
+
+
 # ── Operator-controlled nav driving (S1 "move to scene") ────────
 
 

--- a/pawai-studio/gateway/test_gateway.py
+++ b/pawai-studio/gateway/test_gateway.py
@@ -443,6 +443,119 @@ class TestTraceSessionsEndpoint:
         assert authed["ok"] is True
 
 
+def _trace_event(ts: float, decision_id: str) -> dict:
+    return {
+        "v": 1,
+        "ts": ts,
+        "decision_id": decision_id,
+        "node": "brain_node",
+        "kind": "policy_decision",
+        "verdict": "suppressed",
+        "gate": "greet_cooldown",
+        "reason": "cooldown:greet:Roy",
+        "detail": {"source_summary": "identity=Roy conf=0.9"},
+    }
+
+
+class _CaptureStreamingResponse:
+    def __init__(self, content, media_type=None, **_kwargs):
+        self.lines = list(content)
+        self.media_type = media_type
+
+
+def _captured_json_lines(resp):
+    return [json.loads(line) for line in resp.lines]
+
+
+class TestTraceExportEndpoint:
+    """Lane 2 T2-2: session-scoped trace export."""
+
+    def test_trace_export_session_returns_only_that_session(self, tmp_path, monkeypatch):
+        import asyncio
+        import studio_gateway as sg
+
+        (tmp_path / "20260612-101500.jsonl").write_text(
+            json.dumps(_trace_event(10.0, "target-1")) + "\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "20260612-101500.2.jsonl").write_text(
+            json.dumps(_trace_event(20.0, "target-2")) + "\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "20260612-102000.jsonl").write_text(
+            json.dumps(_trace_event(99.0, "other")) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+        monkeypatch.setattr(sg, "StreamingResponse", _CaptureStreamingResponse)
+
+        class _Req:
+            headers = {}
+
+        resp = asyncio.run(sg.get_trace_export(_Req(), session="20260612-101500"))
+        lines = _captured_json_lines(resp)
+
+        assert resp.media_type == "application/x-ndjson"
+        assert [ev["decision_id"] for ev in lines] == ["target-1", "target-2"]
+        assert all(ev["detail"]["source_summary"] == "[private]" for ev in lines)
+
+    def test_trace_export_malicious_session_id_returns_400(self, tmp_path, monkeypatch):
+        import asyncio
+        import studio_gateway as sg
+
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+
+        class _Req:
+            headers = {}
+
+        resp = asyncio.run(sg.get_trace_export(_Req(), session="../x"))
+
+        assert resp.status_code == 400
+        assert json.loads(resp.body.decode("utf-8")) == {"error": "invalid_session"}
+
+    def test_trace_export_redact_zero_with_session_still_403_when_auth_off(
+        self, tmp_path, monkeypatch
+    ):
+        import asyncio
+        from auth import AuthConfig
+        import studio_gateway as sg
+
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+        monkeypatch.setattr(sg, "AUTH", AuthConfig(host="0.0.0.0", token="", allowed_origins=()))
+
+        class _Req:
+            headers = {}
+
+        resp = asyncio.run(
+            sg.get_trace_export(_Req(), redact=0, session="20260612-101500")
+        )
+
+        assert resp.status_code == 403
+        assert json.loads(resp.body.decode("utf-8")) == {"error": "full_export_requires_auth"}
+
+    def test_trace_export_session_composes_with_since(self, tmp_path, monkeypatch):
+        import asyncio
+        import studio_gateway as sg
+
+        (tmp_path / "20260612-101500.jsonl").write_text(
+            json.dumps(_trace_event(10.0, "before")) + "\n"
+            + json.dumps(_trace_event(20.0, "after")) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+        monkeypatch.setattr(sg, "StreamingResponse", _CaptureStreamingResponse)
+
+        class _Req:
+            headers = {}
+
+        resp = asyncio.run(
+            sg.get_trace_export(_Req(), since=15.0, session="20260612-101500")
+        )
+        lines = _captured_json_lines(resp)
+
+        assert [ev["decision_id"] for ev in lines] == ["after"]
+
+
 # ── Operator-controlled nav driving (S1 "move to scene") ────────
 
 

--- a/pawai-studio/gateway/test_gateway.py
+++ b/pawai-studio/gateway/test_gateway.py
@@ -556,6 +556,89 @@ class TestTraceExportEndpoint:
         assert [ev["decision_id"] for ev in lines] == ["after"]
 
 
+class TestTraceReportEndpoint:
+    """Lane 2 T2-5: per-session trace report endpoint."""
+
+    def test_trace_report_session_returns_summary_json(self, tmp_path, monkeypatch):
+        import asyncio
+        import studio_gateway as sg
+
+        session_id = "20260613-123456"
+        (tmp_path / f"{session_id}.jsonl").write_text(
+            json.dumps(_trace_event(10.0, "target-1")) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+
+        class _Req:
+            headers = {}
+
+        summary = asyncio.run(sg.get_trace_report(_Req(), session=session_id))
+
+        assert summary["session_id"] == session_id
+        assert summary["event_count"] == 1
+        assert {"time_range", "verdict_distribution", "top_suppressed_gates",
+                "shadow_divergence"} <= set(summary)
+
+    def test_trace_report_markdown_format_returns_text_markdown(self, tmp_path, monkeypatch):
+        import asyncio
+        import studio_gateway as sg
+
+        session_id = "20260613-123456"
+        (tmp_path / f"{session_id}.jsonl").write_text(
+            json.dumps(_trace_event(10.0, "target-1")) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+
+        class _Req:
+            headers = {}
+
+        resp = asyncio.run(sg.get_trace_report(_Req(), session=session_id, format="md"))
+
+        assert resp.media_type == "text/markdown"
+        assert session_id in resp.body.decode("utf-8")
+
+    def test_trace_report_missing_or_invalid_session_returns_400(self, tmp_path, monkeypatch):
+        import asyncio
+        import studio_gateway as sg
+
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+
+        class _Req:
+            headers = {}
+
+        missing = asyncio.run(sg.get_trace_report(_Req()))
+        invalid = asyncio.run(sg.get_trace_report(_Req(), session="../x"))
+
+        assert missing.status_code == 400
+        assert invalid.status_code == 400
+        assert json.loads(missing.body.decode("utf-8")) == {"error": "invalid_session"}
+        assert json.loads(invalid.body.decode("utf-8")) == {"error": "invalid_session"}
+
+    def test_trace_report_uses_export_auth_posture(self, tmp_path, monkeypatch):
+        import asyncio
+        from auth import AuthConfig
+        import studio_gateway as sg
+
+        session_id = "20260613-123456"
+        (tmp_path / f"{session_id}.jsonl").write_text(
+            json.dumps(_trace_event(10.0, "target-1")) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PAWAI_TRACE_DIR", str(tmp_path))
+        monkeypatch.setattr(sg, "AUTH", AuthConfig(host="0.0.0.0", token="secret",
+                                                   allowed_origins=()))
+
+        class _Req:
+            headers = {}
+
+        resp = asyncio.run(sg.get_trace_report(_Req(), session=session_id))
+
+        assert resp.status_code == 401
+        assert json.loads(resp.body.decode("utf-8")) == {"error": "unauthorized"}
+
+
 # ── Operator-controlled nav driving (S1 "move to scene") ────────
 
 

--- a/pawai-studio/gateway/test_trace_store.py
+++ b/pawai-studio/gateway/test_trace_store.py
@@ -15,6 +15,7 @@ from trace_store import (  # noqa: E402
     PII_DETAIL_KEYS,
     TraceStore,
     iter_export_lines,
+    list_sessions,
     redact_trace_event,
     store_enabled,
     trace_dir,
@@ -202,3 +203,36 @@ def test_iter_export_lines_skips_garbage_and_missing_dir(tmp_path):
     lines = [json.loads(line) for line in iter_export_lines(tmp_path)]
     assert len(lines) == 1 and lines[0]["ts"] == 5
     assert list(iter_export_lines(tmp_path / "nope")) == []
+
+
+# ── session listing (Lane 2 T2-1) ───────────────────────────────────────────
+
+def test_list_sessions_groups_rotation_parts_and_counts_valid_events(tmp_path):
+    (tmp_path / "20260613-010000.jsonl").write_text(
+        json.dumps(_ev(ts=10.0)) + "\nnot-json\n" + json.dumps(_ev(ts=12.0)) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "20260613-010000.2.jsonl").write_text(
+        json.dumps(_ev(ts=11.0)) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "20260613-020000.jsonl").write_text(
+        json.dumps(_ev(ts=20.0)) + "\n",
+        encoding="utf-8",
+    )
+
+    sessions = list_sessions(tmp_path)
+
+    assert [s["session_id"] for s in sessions] == ["20260613-020000", "20260613-010000"]
+    older = sessions[1]
+    assert older["started_ts"] == 10.0
+    assert older["line_count"] == 3
+    assert older["file_size"] == (
+        (tmp_path / "20260613-010000.jsonl").stat().st_size
+        + (tmp_path / "20260613-010000.2.jsonl").stat().st_size
+    )
+    assert older["parts"] == ["20260613-010000.jsonl", "20260613-010000.2.jsonl"]
+
+
+def test_list_sessions_missing_dir_returns_empty(tmp_path):
+    assert list_sessions(tmp_path / "nope") == []

--- a/pawai-studio/gateway/test_trace_store.py
+++ b/pawai-studio/gateway/test_trace_store.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+import trace_store as trace_store_module  # noqa: E402
 from trace_store import (  # noqa: E402
     PII_DETAIL_KEYS,
     TraceStore,
@@ -203,6 +204,43 @@ def test_iter_export_lines_skips_garbage_and_missing_dir(tmp_path):
     lines = [json.loads(line) for line in iter_export_lines(tmp_path)]
     assert len(lines) == 1 and lines[0]["ts"] == 5
     assert list(iter_export_lines(tmp_path / "nope")) == []
+
+
+def test_iter_session_lines_parts_since_and_redact_default(tmp_path):
+    session_id = "20260612-101500"
+    (tmp_path / f"{session_id}.3.jsonl").write_text(
+        json.dumps(_ev(ts=30.0)) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / f"{session_id}.jsonl").write_text(
+        json.dumps(_ev(ts=10.0)) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / f"{session_id}.2.jsonl").write_text(
+        json.dumps(_ev(ts=20.0)) + "\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "other.jsonl").write_text(json.dumps(_ev(ts=99.0)) + "\n", encoding="utf-8")
+
+    lines = [
+        json.loads(line)
+        for line in trace_store_module.iter_session_lines(tmp_path, session_id)
+    ]
+
+    assert [ev["ts"] for ev in lines] == [10.0, 20.0, 30.0]
+    assert all(ev["detail"]["source_summary"] == "[private]" for ev in lines)
+
+    since = [
+        json.loads(line)
+        for line in trace_store_module.iter_session_lines(tmp_path, session_id, since=15.0)
+    ]
+    assert [ev["ts"] for ev in since] == [20.0, 30.0]
+
+
+def test_valid_session_id_whitelist():
+    assert trace_store_module.valid_session_id("20260612-101500") is True
+    for session_id in ("", "../x", "a/b", "a.jsonl", "a b", ".", ".."):
+        assert trace_store_module.valid_session_id(session_id) is False
 
 
 # ── session listing (Lane 2 T2-1) ───────────────────────────────────────────

--- a/pawai-studio/gateway/test_trace_store.py
+++ b/pawai-studio/gateway/test_trace_store.py
@@ -18,6 +18,8 @@ from trace_store import (  # noqa: E402
     iter_export_lines,
     list_sessions,
     redact_trace_event,
+    render_session_report_md,
+    summarize_session,
     store_enabled,
     trace_dir,
 )
@@ -274,3 +276,100 @@ def test_list_sessions_groups_rotation_parts_and_counts_valid_events(tmp_path):
 
 def test_list_sessions_missing_dir_returns_empty(tmp_path):
     assert list_sessions(tmp_path / "nope") == []
+
+
+# ── session report (Lane 2 T2-5) ────────────────────────────────────────────
+
+def test_summarize_session_counts_redacted_multipart_trace(tmp_path):
+    session_id = "20260613-123456"
+    part1 = [
+        _ev(ts=10.0, verdict="accepted", gate="wake_gate"),
+        _ev(ts=11.0, verdict="suppressed", gate="cooldown"),
+        _ev(ts=12.0, verdict="suppressed", gate="confirm_pending"),
+        _ev(ts=13.0, verdict="suppressed", gate="cooldown"),
+    ]
+    part2 = [
+        _ev(ts=14.0, verdict="blocked", gate="safety"),
+        {
+            "v": 1,
+            "ts": 15.0,
+            "decision_id": "shadow-diverge",
+            "node": "brain_node",
+            "kind": "candidate",
+            "gate": "ism_shadow",
+            "detail": {
+                "shadow": True,
+                "ism_verdict": "accept",
+                "legacy_action": "suppressed",
+                "legacy_gate": "greet_cooldown",
+                "transcript": "Roy wants water",
+            },
+        },
+        {
+            "v": 1,
+            "ts": 16.0,
+            "decision_id": "shadow-agree",
+            "node": "brain_node",
+            "kind": "candidate",
+            "gate": "ism_shadow",
+            "detail": {
+                "shadow": True,
+                "ism_verdict": "suppress",
+                "legacy_action": "suppressed",
+                "legacy_gate": "confirm_pending",
+            },
+        },
+    ]
+    (tmp_path / f"{session_id}.jsonl").write_text(
+        "\n".join(json.dumps(ev, ensure_ascii=False) for ev in part1)
+        + "\nnot-json\n",
+        encoding="utf-8",
+    )
+    (tmp_path / f"{session_id}.2.jsonl").write_text(
+        "\n".join(json.dumps(ev, ensure_ascii=False) for ev in part2) + "\n",
+        encoding="utf-8",
+    )
+
+    summary = summarize_session(tmp_path, session_id)
+
+    assert summary["session_id"] == session_id
+    assert summary["event_count"] == 7
+    assert summary["time_range"] == {"start": 10.0, "end": 16.0}
+    assert summary["verdict_distribution"] == {
+        "accepted": 1,
+        "blocked": 1,
+        "suppressed": 3,
+    }
+    assert summary["top_suppressed_gates"] == [
+        {"gate": "cooldown", "count": 2},
+        {"gate": "confirm_pending", "count": 1},
+    ]
+    assert summary["shadow_divergence"] == {
+        "total": 1,
+        "by_gate": [{"gate": "greet_cooldown", "count": 1}],
+    }
+    assert "Roy wants water" not in json.dumps(summary, ensure_ascii=False)
+
+
+def test_summarize_session_invalid_session_id_returns_empty(tmp_path):
+    assert summarize_session(tmp_path, "../x") == {
+        "session_id": "../x",
+        "event_count": 0,
+        "time_range": {"start": None, "end": None},
+        "verdict_distribution": {},
+        "top_suppressed_gates": [],
+        "shadow_divergence": {"total": 0, "by_gate": []},
+    }
+
+
+def test_render_session_report_md_contains_session_and_event_count(tmp_path):
+    session_id = "20260613-123456"
+    (tmp_path / f"{session_id}.jsonl").write_text(
+        json.dumps(_ev(ts=10.0, verdict="accepted", gate="wake_gate")) + "\n",
+        encoding="utf-8",
+    )
+    report = render_session_report_md(summarize_session(tmp_path, session_id))
+
+    assert isinstance(report, str)
+    assert session_id in report
+    assert "1" in report

--- a/pawai-studio/gateway/trace_store.py
+++ b/pawai-studio/gateway/trace_store.py
@@ -29,7 +29,7 @@ import os
 import re
 import threading
 import time
-from collections import deque
+from collections import Counter, deque
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -322,3 +322,168 @@ def iter_session_lines(directory: Path | str, session_id: str,
             if redact:
                 ev = redact_trace_event(ev)
             yield json.dumps(ev, ensure_ascii=False) + "\n"
+
+
+def _empty_session_summary(session_id: str) -> dict:
+    return {
+        "session_id": session_id,
+        "event_count": 0,
+        "time_range": {"start": None, "end": None},
+        "verdict_distribution": {},
+        "top_suppressed_gates": [],
+        "shadow_divergence": {"total": 0, "by_gate": []},
+    }
+
+
+def summarize_session(directory: Path | str, session_id: str) -> dict:
+    """Return a compact report summary for one persisted session.
+
+    The read path intentionally consumes iter_session_lines(redact=True), then
+    parses that redacted JSONL. Do not read fields from raw on-disk events here:
+    this report feeds operators and Lane 1 analysis, so it must inherit the
+    gateway redaction single source.
+    """
+    summary = _empty_session_summary(session_id)
+    if not valid_session_id(session_id):
+        return summary
+    d = Path(directory)
+    if not d.is_dir():
+        return summary
+
+    verdicts: Counter[str] = Counter()
+    suppressed_gates: Counter[str] = Counter()
+    divergence_by_gate: Counter[str] = Counter()
+    start_ts: float | None = None
+    end_ts: float | None = None
+
+    for line in iter_session_lines(d, session_id, redact=True):
+        try:
+            redacted_ev = json.loads(line)
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(redacted_ev, dict):
+            continue
+
+        summary["event_count"] += 1
+
+        ts = redacted_ev.get("ts")
+        if isinstance(ts, (int, float)) and not isinstance(ts, bool):
+            ts_f = float(ts)
+            start_ts = ts_f if start_ts is None else min(start_ts, ts_f)
+            end_ts = ts_f if end_ts is None else max(end_ts, ts_f)
+
+        verdict = redacted_ev.get("verdict")
+        if isinstance(verdict, str) and verdict:
+            verdicts[verdict] += 1
+            if verdict == "suppressed":
+                gate = redacted_ev.get("gate")
+                if isinstance(gate, str) and gate:
+                    suppressed_gates[gate] += 1
+
+        if redacted_ev.get("kind") != "candidate" or redacted_ev.get("gate") != "ism_shadow":
+            continue
+        detail = redacted_ev.get("detail")
+        if not isinstance(detail, dict) or detail.get("shadow") is not True:
+            continue
+        ism_verdict = detail.get("ism_verdict")
+        if not isinstance(ism_verdict, str) or not ism_verdict:
+            continue
+
+        would_act = ism_verdict in {"accept", "preempt"}
+        legacy_action = detail.get("legacy_action")
+        acted = isinstance(legacy_action, str) and (
+            legacy_action.startswith("emitted")
+            or legacy_action.startswith("confirm_requested")
+        )
+        if would_act == acted:
+            continue
+        legacy_gate = detail.get("legacy_gate")
+        gate_key = legacy_gate if isinstance(legacy_gate, str) and legacy_gate else "(none)"
+        divergence_by_gate[gate_key] += 1
+
+    summary["time_range"] = {"start": start_ts, "end": end_ts}
+    summary["verdict_distribution"] = dict(sorted(verdicts.items()))
+    summary["top_suppressed_gates"] = [
+        {"gate": gate, "count": count}
+        for gate, count in sorted(suppressed_gates.items(), key=lambda item: (-item[1], item[0]))
+    ]
+    divergence_rows = [
+        {"gate": gate, "count": count}
+        for gate, count in sorted(divergence_by_gate.items(), key=lambda item: (-item[1], item[0]))
+    ]
+    summary["shadow_divergence"] = {
+        "total": sum(divergence_by_gate.values()),
+        "by_gate": divergence_rows,
+    }
+    return summary
+
+
+def render_session_report_md(summary: dict) -> str:
+    """Render summarize_session() output as compact Markdown. Pure, no I/O."""
+    session_id = summary.get("session_id") or ""
+    event_count = summary.get("event_count", 0)
+    time_range = summary.get("time_range")
+    if not isinstance(time_range, dict):
+        time_range = {}
+    start_ts = time_range.get("start")
+    end_ts = time_range.get("end")
+
+    lines = [
+        "# Trace Session Report",
+        "",
+        f"- Session: `{session_id}`",
+        f"- Event count / 事件數: {event_count}",
+        f"- Time range / 時間範圍: {start_ts if start_ts is not None else 'n/a'} "
+        f"to {end_ts if end_ts is not None else 'n/a'}",
+        "",
+        "## Verdict Distribution",
+        "",
+        "| Verdict | Count |",
+        "|---|---:|",
+    ]
+
+    verdict_distribution = summary.get("verdict_distribution")
+    if isinstance(verdict_distribution, dict) and verdict_distribution:
+        for verdict, count in sorted(verdict_distribution.items()):
+            lines.append(f"| `{verdict}` | {count} |")
+    else:
+        lines.append("| (none) | 0 |")
+
+    lines.extend([
+        "",
+        "## Top Suppressed Gates",
+        "",
+        "| Gate | Count |",
+        "|---|---:|",
+    ])
+    top_suppressed_gates = summary.get("top_suppressed_gates")
+    if isinstance(top_suppressed_gates, list) and top_suppressed_gates:
+        for row in top_suppressed_gates:
+            if not isinstance(row, dict):
+                continue
+            lines.append(f"| `{row.get('gate', '')}` | {row.get('count', 0)} |")
+    else:
+        lines.append("| (none) | 0 |")
+
+    shadow_divergence = summary.get("shadow_divergence")
+    if not isinstance(shadow_divergence, dict):
+        shadow_divergence = {}
+    lines.extend([
+        "",
+        "## Shadow Divergence",
+        "",
+        f"- Total / 總數: {shadow_divergence.get('total', 0)}",
+        "",
+        "| Legacy gate | Count |",
+        "|---|---:|",
+    ])
+    by_gate = shadow_divergence.get("by_gate")
+    if isinstance(by_gate, list) and by_gate:
+        for row in by_gate:
+            if not isinstance(row, dict):
+                continue
+            lines.append(f"| `{row.get('gate', '')}` | {row.get('count', 0)} |")
+    else:
+        lines.append("| (none) | 0 |")
+
+    return "\n".join(lines) + "\n"

--- a/pawai-studio/gateway/trace_store.py
+++ b/pawai-studio/gateway/trace_store.py
@@ -209,6 +209,11 @@ def _session_part(path: Path) -> tuple[str, int] | None:
     return m.group("session"), part
 
 
+def valid_session_id(session_id: str) -> bool:
+    """True when session_id matches the persisted trace filename session group."""
+    return bool(session_id and _SESSION_PART_RE.fullmatch(f"{session_id}.jsonl"))
+
+
 def _file_mtime(path: Path) -> float:
     try:
         return path.stat().st_mtime
@@ -279,6 +284,36 @@ def iter_export_lines(directory: Path | str, since: float | None = None,
     if not d.is_dir():
         return
     for path in sorted(d.glob("*.jsonl"), key=lambda p: p.stat().st_mtime):
+        for ev in _iter_file_events(path):
+            if since is not None:
+                ts = ev.get("ts")
+                if not isinstance(ts, (int, float)) or ts < since:
+                    continue
+            if redact:
+                ev = redact_trace_event(ev)
+            yield json.dumps(ev, ensure_ascii=False) + "\n"
+
+
+def iter_session_lines(directory: Path | str, session_id: str,
+                       since: float | None = None,
+                       redact: bool = True) -> Iterator[str]:
+    """Yield JSONL lines for one persisted session, in rotation part order."""
+    if not valid_session_id(session_id):
+        return
+    d = Path(directory)
+    if not d.is_dir():
+        return
+
+    part_paths: list[tuple[int, Path]] = []
+    for path in d.glob("*.jsonl"):
+        parsed = _session_part(path)
+        if parsed is None:
+            continue
+        parsed_session, part = parsed
+        if parsed_session == session_id:
+            part_paths.append((part, path))
+
+    for _, path in sorted(part_paths, key=lambda item: item[0]):
         for ev in _iter_file_events(path):
             if since is not None:
                 ts = ev.get("ts")

--- a/pawai-studio/gateway/trace_store.py
+++ b/pawai-studio/gateway/trace_store.py
@@ -48,6 +48,7 @@ PII_DETAIL_KEYS = frozenset({
 # "cooldown:greet:Roy". Mask the value segment, keep the structural prefix.
 # Structural reasons ("gate:executing", "phase:s3_object:gesture") never match.
 _PII_REASON_RE = re.compile(r"((?:identity|name|greet)[:=])[^:,\s]+")
+_SESSION_PART_RE = re.compile(r"^(?P<session>[A-Za-z0-9_-]+)(?:\.(?P<part>[2-9]\d*|1\d+))?\.jsonl$")
 
 
 def store_enabled(env: dict | None = None) -> bool:
@@ -198,6 +199,72 @@ def _iter_file_events(path: Path) -> Iterator[dict]:
             continue
         if isinstance(ev, dict):
             yield ev
+
+
+def _session_part(path: Path) -> tuple[str, int] | None:
+    m = _SESSION_PART_RE.match(path.name)
+    if not m:
+        return None
+    part = int(m.group("part") or "1")
+    return m.group("session"), part
+
+
+def _file_mtime(path: Path) -> float:
+    try:
+        return path.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def list_sessions(directory: Path | str) -> list[dict]:
+    """Return redaction-free session stats for runtime/traces/*.jsonl.
+
+    This endpoint needs only non-PII metadata: session_id, earliest event ts,
+    valid event count, aggregate file size and the rotation part filenames.
+    Raw trace payloads never leave this function.
+    """
+    d = Path(directory)
+    if not d.is_dir():
+        return []
+
+    grouped: dict[str, list[tuple[int, Path]]] = {}
+    for path in d.glob("*.jsonl"):
+        parsed = _session_part(path)
+        if parsed is None:
+            continue
+        session_id, part = parsed
+        grouped.setdefault(session_id, []).append((part, path))
+
+    sessions: list[dict] = []
+    for session_id, part_paths in grouped.items():
+        part_paths.sort(key=lambda item: item[0])
+        started_ts: float | None = None
+        line_count = 0
+        file_size = 0
+        parts: list[str] = []
+        fallback_started = min((_file_mtime(path) for _, path in part_paths), default=0.0)
+
+        for _, path in part_paths:
+            parts.append(path.name)
+            try:
+                file_size += path.stat().st_size
+            except OSError:
+                continue
+            for ev in _iter_file_events(path):
+                line_count += 1
+                ts = ev.get("ts")
+                if isinstance(ts, (int, float)):
+                    started_ts = float(ts) if started_ts is None else min(started_ts, float(ts))
+
+        sessions.append({
+            "session_id": session_id,
+            "started_ts": started_ts if started_ts is not None else fallback_started,
+            "line_count": line_count,
+            "file_size": file_size,
+            "parts": parts,
+        })
+
+    return sorted(sessions, key=lambda s: (s["started_ts"], s["session_id"]), reverse=True)
 
 
 def iter_export_lines(directory: Path | str, since: float | None = None,

--- a/pawai_contracts/pawai_contracts/zh_tables.py
+++ b/pawai_contracts/pawai_contracts/zh_tables.py
@@ -8,6 +8,9 @@ actually assigns colour names). Studio TS copy guarded by parity test
 (test_zh_parity.py:test_studio_ts_copy_matches_contracts).
 
 Consumers: interaction_executive.brain_node, pawai_brain.conversation_graph_node.
+
+Evidence Center display tables below are additive and best-effort. Consumers
+should fall back to the raw code when a display key is absent.
 """
 
 # Mirror of object_perception/coco_classes.py:COCO_CLASSES_ZH (whitelist subset).
@@ -36,4 +39,71 @@ OBJECT_TTS_SPECIAL_SUFFIX: dict[str, str] = {
     "cup": "，你要喝水嗎？今天天氣很熱，要記得補充水分。",
     "bottle": "，喝點水吧",
     "book": "，在看書啊",
+}
+
+# Evidence Center trace gate labels. Keep in sync with the trace gate strings
+# emitted by interaction_executive and pawai_brain.
+TRACE_GATE_ZH: dict[str, str] = {
+    "active_plan": "已有行動計畫",
+    "alert_active": "警戒中",
+    "attention_engaged": "注意力已佔用",
+    "capability_health": "能力健康檢查",
+    "confirm_pending": "等待確認",
+    "conversation_gate": "對話閘門",
+    "dedup": "重複事件",
+    "demo_phase": "demo 場景遮罩",
+    "depth_clear": "深度安全",
+    "emergency": "緊急狀態",
+    "executing": "正在執行",
+    "gesture_enabled": "手勢啟用",
+    "greet_cooldown": "問候冷卻",
+    "greet_gate": "問候閘門",
+    "greet_sitting_window": "坐姿問候視窗",
+    "ism_shadow": "ISM 影子判斷",
+    "llm_allowlist": "LLM 白名單",
+    "nav_paused": "導航暫停",
+    "nav_ready": "導航就緒",
+    "object_remark_dedup": "物件評論重複",
+    "pending_confirm": "等待確認",
+    "safety": "安全限制",
+    "safety_hold": "安全暫停",
+    "skill_cooldown": "技能冷卻",
+    "speaking": "正在說話",
+    "stranger_alert_enabled": "陌生人警戒啟用",
+    "tts_playing": "語音播放中",
+}
+
+TRACE_REASON_PREFIX_ZH: dict[str, str] = {
+    "cooldown": "冷卻中",
+    "phase": "demo 場景遮罩",
+    "watchdog_timeout": "逾時自癒",
+    "banned_api": "禁用指令",
+    "gate": "被閘門擋下",
+    "identity": "身份",
+}
+
+ISM_VERDICT_ZH: dict[str, str] = {
+    "accept": "接受",
+    "suppress": "抑制",
+    "queue": "排隊",
+    "preempt": "搶佔",
+}
+
+ISM_TRIGGER_ZH: dict[str, str] = {
+    "skill_result": "技能結果",
+    "confirm_result": "確認結果",
+    "tts_ack": "語音確認",
+    "operator": "操作者",
+    "safety": "安全",
+}
+
+ISM_STATE_ZH: dict[str, str] = {
+    "idle": "閒置",
+    "listening": "聆聽中",
+    "speaking": "說話中",
+    "confirm_pending": "等待確認",
+    "executing": "執行中",
+    "alert_active": "警戒中",
+    "safety_hold": "安全暫停",
+    "error_recovery": "錯誤復原",
 }

--- a/pawai_contracts/test/test_zh_tables.py
+++ b/pawai_contracts/test/test_zh_tables.py
@@ -1,0 +1,96 @@
+"""Evidence Center zh table coverage locks."""
+
+import re
+
+from pawai_contracts.zh_tables import (
+    ISM_STATE_ZH,
+    ISM_TRIGGER_ZH,
+    ISM_VERDICT_ZH,
+    TRACE_GATE_ZH,
+    TRACE_REASON_PREFIX_ZH,
+)
+
+
+EXPECTED_TRACE_GATES = frozenset(
+    {
+        "active_plan",
+        "alert_active",
+        "attention_engaged",
+        "capability_health",
+        "confirm_pending",
+        "conversation_gate",
+        "dedup",
+        "demo_phase",
+        "depth_clear",
+        "emergency",
+        "executing",
+        "gesture_enabled",
+        "greet_cooldown",
+        "greet_gate",
+        "greet_sitting_window",
+        "ism_shadow",
+        "llm_allowlist",
+        "nav_paused",
+        "nav_ready",
+        "object_remark_dedup",
+        "pending_confirm",
+        "safety",
+        "safety_hold",
+        "skill_cooldown",
+        "speaking",
+        "stranger_alert_enabled",
+        "tts_playing",
+    }
+)
+
+EXPECTED_REASON_PREFIXES = frozenset(
+    {"cooldown", "phase", "watchdog_timeout", "banned_api", "gate", "identity"}
+)
+
+CJK = re.compile(r"[\u4e00-\u9fff]")
+
+
+def test_trace_gate_zh_has_exact_brain_gate_coverage():
+    assert set(TRACE_GATE_ZH) == EXPECTED_TRACE_GATES
+
+
+def test_ism_zh_tables_cover_all_interaction_state_machine_codes():
+    assert set(ISM_VERDICT_ZH) == {"accept", "suppress", "queue", "preempt"}
+    assert set(ISM_TRIGGER_ZH) == {
+        "skill_result",
+        "confirm_result",
+        "tts_ack",
+        "operator",
+        "safety",
+    }
+    assert set(ISM_STATE_ZH) == {
+        "idle",
+        "listening",
+        "speaking",
+        "confirm_pending",
+        "executing",
+        "alert_active",
+        "safety_hold",
+        "error_recovery",
+    }
+
+
+def test_reason_prefix_zh_contains_required_trace_reason_prefixes():
+    assert set(TRACE_REASON_PREFIX_ZH) >= EXPECTED_REASON_PREFIXES
+
+
+def test_evidence_center_zh_values_are_non_empty_chinese_strings():
+    tables = [
+        TRACE_GATE_ZH,
+        TRACE_REASON_PREFIX_ZH,
+        ISM_VERDICT_ZH,
+        ISM_TRIGGER_ZH,
+        ISM_STATE_ZH,
+    ]
+    placeholders = [
+        f"{key}={value!r}"
+        for table in tables
+        for key, value in table.items()
+        if not isinstance(value, str) or not value.strip() or not CJK.search(value)
+    ]
+    assert not placeholders


### PR DESCRIPTION
系統重構 Lane 2：trace 變可看可匯出可回答「為什麼沒反應」。

- T2-1 session list API / T2-2 export session 參數（路徑穿越消毒）
- T2-3 /studio/evidence + decision timeline / T2-4 zh 表（27 gate+ISM）
- T2-5 session report（含 shadow 分歧統計，餵 Lane 1）/ T2-6 下載鈕 / T2-7 mock stub

全 additive、消費 redact_trace_event()、403 規則不放寬。
親驗：gateway 110 passed + contracts 15 + 前端 tsc 乾淨 + vitest 27。
Plan: docs/superpowers/plans/2026-06-13-lane2-studio-evidence-center-v2-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)