### PR TITLE
docs(nav): Lane 6 — capability ladder + 三研究 spec + claim + HITL queue

### DIFF
--- a/docs/navigation/2026-06-13-nav-618-claim-wording.md
+++ b/docs/navigation/2026-06-13-nav-618-claim-wording.md
@@ -1,0 +1,99 @@
+# Nav 6/18 Claim Wording（對外措辭鎖定）
+
+> **日期**：2026-06-13　**狀態**：DOC — Lane 6 T6-10（純文件；**Roy 過目鎖定**前為草案）
+> **上游**：[Lane 6 plan §13 presentation impact](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)、[capability ladder](2026-06-13-nav-capability-ladder.md)
+> **這份是什麼**：6/18 發表 nav 段的**台詞真相層**——每一句可講的話綁一個 [ladder](2026-06-13-nav-capability-ladder.md) 能力 + current label + 證據；不可講清單；fallback 三層；safe-stop≠繞障的標準說法。
+> **權威關係**：對外宣稱以本檔 + [demo snapshot forbidden claims](../mission/2026-06-18-demo-north-star.md) 為準；台詞與 [convergence audit §B nav 行](../pawai-brain/research/2026-06-05-618-demo-convergence-audit-and-model-tournament.md) 逐條對過、無放水。**未過 HITL 的能力一律取保守措辭**（[ladder §5](2026-06-13-nav-capability-ladder.md)：對外取 ladder 與 6/4 snapshot 較保守者）。
+
+---
+
+## 1. 一句話定位（開場用，最安全）
+
+> **「PawAI 的移動能力是『在已知地圖上、由操作員下令、短距自主走、遇障安全停』——我們用能力階梯誠實管理每一項宣稱，不把單次成功講成可靠、不把停障講成繞障。」**
+
+這句話本身不宣稱任何未驗證能力，且把「能力階梯 + 誠實」當作敘事主軸（呼應 [aggressive master §1 誠實的完成定義](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)：nav 是高風險項，必須用 capability ladder 管理，不承諾一次變成完整自主巡邏）。
+
+---
+
+## 2. 可講句（每句綁 ladder 能力 + label + 證據 + 前提）
+
+> 規則：① 帶 `[需 N 過]` 的句子**必須對應 HITL 項 PASS 並回填 ladder 才能講**；② 每句的限制詞（單點/窄版/操作員監督/短距）**不可省略**。
+
+| # | 可講句 | ladder 能力 | current label | 證據 | 講的前提 |
+|---|---|---|---|---|---|
+| S1 | 「室內已知地圖、操作員下令的短距自主移動（0.3-0.5m）」 | [C1/C2](2026-06-13-nav-capability-ladder.md) | C1 `HARDWARE_PROVEN_LOW_SAMPLE` / C2 `NEEDS_RETEST` | [trackB §1](research/2026-06-08-trackB-hitl-results.md) | 標「單點」；**n=3 重驗（N3）後才可加「可靠」二字** |
+| S2 | 「正前方障礙物會安全停下、不碰撞——偵測到障礙會停下等待，不會繞行」 | [C4](2026-06-13-nav-capability-ladder.md) | `HARDWARE_PROVEN_WITH_LIMIT` | [trackB §1 NAV-2 / 6/9 §1.5](research/2026-06-08-trackB-hitl-results.md) | **明講 safe-stop 不是繞障**（§3 標準說法）；不講側向覆蓋 |
+| S3 | 「停下後由操作員確認再續走」 | [C5](2026-06-13-nav-capability-ladder.md) | `NEEDS_FIX_OR_OPERATOR_CONFIRM` | [6/9 §1.6](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) | operator-confirm；**禁講 auto-resume**（§4） |
+| S4 | 「居家窄場用收窄安全錐（±18°）避免家具誤擋」 | [C6](2026-06-13-nav-capability-ladder.md) | `HARDWARE_PROVEN_WITH_LIMIT` | [trackB §4 / 6/9 §1.3](research/2026-06-08-trackB-hitl-results.md) | 標「窄錐綁低速 ≤0.2 m/s」 |
+| S5 | 「client/SSH 掛掉約 10 秒內自動恢復、不需重啟」 | [C8](2026-06-13-nav-capability-ladder.md) | `HARDWARE_PROVEN_WITH_LIMIT` | [trackB §5-6 / 6/9 §orphan](research/2026-06-08-trackB-hitl-results.md) | **禁講「即時恢復」**（[6/9 §36](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)） |
+| S6 | 「每次導航拒絕都有可讀理由（如定位不夠準、已有任務在跑、超出黃帶限距）」 | rejection reason | T6-5 後 | [Lane 6 T6-5](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md) | **T6-5 merged 後才講**；message-only、不改判定邏輯 |
+| S7 | 「固定路線單圈巡邏 prototype（操作員監督）」 | [C9](2026-06-13-nav-capability-ladder.md) | `PROTOTYPE` | [6/9 Phase 1.5](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) | `[需 N5 過]` **僅在 run_route 單圈跑通後**；與「自由巡邏」嚴格區分 |
+| S8 | 「D435+LiDAR 融合 / 自主找人：研究路線已有 spec，屬 research prototype」 | [C12](2026-06-13-nav-capability-ladder.md) | `DO_NOT_CLAIM`（spec only） | [fusion spec](research/2026-06-13-spec-d435-lidar-fusion.md) / [approach spec](research/2026-06-13-spec-approach-person.md) | 只講「有 spec、是研究」；**不可講已具備** |
+
+> S1 的「可靠」與 S7 整句都是**條件句**：N3 / N5 未過則退保守版（S1 去掉「可靠」、S7 整句不講走影片 fallback）。
+
+---
+
+## 3. safe-stop ≠ 繞障（標準說法，最容易被戳的點）
+
+這是 nav 段**最關鍵的誠實邊界**——觀眾/教授會問「會不會自己繞過去」。標準回答固定為：
+
+> **「我們做的是 safe-stop：偵測到正前方障礙會在安全距離停下等待，由操作員確認後再重新下達或遙控輔助。它不會自己轉向繞過障礙——繞障需要轉向控制，而我們的反應式停障在設計上只停不轉（`angular.z=0`），這是刻意的安全選擇（硬轉曾導致四足失衡）。」**
+
+- **技術依據**：reactive_stop `angular.z=0` 只停不轉（[ladder C4 限制](2026-06-13-nav-capability-ladder.md)）；硬轉摔狗（5/2，[trackB §7](research/2026-06-08-trackB-hitl-results.md)）。
+- **為什麼這樣講站得住**：[trackB §7](research/2026-06-08-trackB-hitl-results.md) 把「遇障在安全距離前安全停下、不撞」列為能講項，把「動態繞障」列為不能講項——本說法精確落在能講側。
+- **絕不**把 safe-stop 包裝成「智能避障」「自動繞開」——那是 [ladder C11 `DO_NOT_CLAIM`](2026-06-13-nav-capability-ladder.md)。
+
+---
+
+## 4. 不可講清單（forbidden claims，延續 demo snapshot + 更新）
+
+> 任一條被講出 = 誠信破口；與 [north-star §7](../mission/2026-06-18-demo-north-star.md) + [convergence audit §B nav 行](../pawai-brain/research/2026-06-05-618-demo-convergence-audit-and-model-tournament.md) 一致。
+
+| # | 不可講 | 為什麼 | 對應 ladder |
+|---|---|---|---|
+| F1 | 自由巡邏 / 自主巡檢 | 只有固定預錄 route（且 N5 未跑前連單圈都沒有） | [C9/C11](2026-06-13-nav-capability-ladder.md) |
+| F2 | 動態繞障 / 繞行 / 自動繞開 | reactive_stop 只停不轉；硬轉摔狗 | [C11](2026-06-13-nav-capability-ladder.md) |
+| F3 | D435 已融合進 costmap | 現在只有 `depth_clear` fail-closed gate，D435 未進 Nav2 costmap | [C12](2026-06-13-nav-capability-ladder.md) |
+| F4 | 自動續走 / auto-resume / 「障礙移開會自己繼續」 | auto-resume 會 lunge 貼牆 0.21m，tight space 禁用 | [C5](2026-06-13-nav-capability-ladder.md) |
+| F5 | 「停了不會再走」 | 實際現行為**會** auto-resume（只是不安全被禁），講「不會再走」是反向不實 | [C5](2026-06-13-nav-capability-ladder.md) |
+| F6 | 「聽懂過來就走到 Roy 身邊」 | 感知與 nav goal 零連接、approach 需 4 層新開發 | [C12 / approach spec](research/2026-06-13-spec-approach-person.md) |
+| F7 | 未經 n=3 重驗前的「可靠導航」 | C1/C2 仍 low-sample；單次 ≠ 可靠 | [C1/C2](2026-06-13-nav-capability-ladder.md) |
+| F8 | 1.0m+ 乾淨連續導航 | AMCL 黃帶卡死、從未成功；「乾淨 0.5m+ 連續導航」trackB §7 明列不能講 | [C3](2026-06-13-nav-capability-ladder.md) |
+| F9 | 三鏡頭/三陣攝影機參與導航 | 只有 2D RPLIDAR 進迴路 | [trackB §2](research/2026-06-08-trackB-hitl-results.md) |
+| F10 | 即時恢復（orphan） | 是 ~10s 自癒、非即時 | [C8](2026-06-13-nav-capability-ladder.md) |
+
+---
+
+## 5. Fallback 三層（發表日 nav 段用哪層 = B-10 決策，依 B-9 結果）
+
+> 與 [Lane 6 §13 fallback 三層](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md) + [Lane 6 §10 rollback](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md) 一致。nav stack 與 brain demo stack **8GB 互斥**——nav 段是獨立鏡頭（[6/9 §499](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)）。
+
+| 層 | 內容 | 上場條件 | 可講句 |
+|---|---|---|---|
+| **① live 短距 / 短 route** | 現場 live 跑 goto 0.3-0.5m，或 run_route 單圈 | **B-9 場測 N3（短距）/ N5（route）驗過** | S1（+「可靠」若 N3 過）、S2、S3、S7（若 N5 過） |
+| **② 遙控輔助 + Studio 證據** | 遙控/Studio 輔助定位，Studio map / LiDAR 點雲 / 狀態作為「邊緣端即時感知」操作證據 | live 不穩或場地不允許 | S2、S4、S6 + 「nav 在 Studio/Foxglove 顯示即時感知環境（非寫死）」 |
+| **③ 純影片** | S1（nav 鏡）已錄影片（[demo-2026-06-snapshot tag](../mission/2026-06-18-demo-north-star.md)） | live + 遙控都不上 | 影片旁白用 S1-S5 的保守版；明標「錄影」 |
+
+**鐵則**：① demo snapshot 影片是發表保底，任何 lane 不得使其失效（[master 附錄 A](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）；② 三層任一層都能交付 nav 段——不存在「nav 整段開天窗」的情況（[Lane 6 §10](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+
+---
+
+## 6. OPEN 書記（鎖定前待補）
+
+| 書記 | 內容 | 閉合條件 |
+|---|---|---|
+| **A-1（S1 簿記）** | 6/9 鎖過一版台詞，S1 錄成的方式待補記；poses 隨後遺失 → 本版需重鎖（[ladder §4](2026-06-13-nav-capability-ladder.md)、[Lane 6 §3 問題 7](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)） | Roy 過目本檔 + 確認 S1 影片內容對得上 S1-S5 措辭 |
+| **B-9 結果回填** | N3/N5 PASS/FAIL → S1「可靠」、S7 整句的最終可講性 | B-9 場測後回填 ladder + 本表 §2 |
+| **B-10 fallback 層** | 發表日用 §5 哪一層 | 6/17 回穩日依 B-9 結果定 |
+
+---
+
+## 7. 與簡報對齊的一頁（給 Roy 過目）
+
+- **開場**：§1 一句話定位（能力階梯 + 誠實當主軸）。
+- **能講**：S1（短距，標單點/視 N3 加可靠）→ S2（safe-stop，配 §3 標準說法）→ S3（operator-confirm）→ S4（窄場安全錐）→ S6（拒絕有理由，視 T6-5）→ S7（單圈 patrol prototype，視 N5）→ S8（fusion/approach 是研究 spec）。
+- **絕口不提**：§4 F1-F10 全部。
+- **被追問繞障**：固定用 §3 標準說法。
+- **被追問「會不會自己找人/過來」**：S8 + F6——「研究路線有 spec，目前感知與移動還沒接起來，不在這次展示範圍」。
+- **發表日形態**：§5 三層擇一（B-10 定），影片保底。

--- a/docs/navigation/2026-06-13-nav-capability-ladder.md
+++ b/docs/navigation/2026-06-13-nav-capability-ladder.md
@@ -1,0 +1,172 @@
+# Navigation Capability Ladder + Proven Table（2026-06-13）
+
+> **日期**：2026-06-13　**狀態**：DOC — Lane 6 T6-1（純文件，無實作碼）
+> **上游**：[Lane 6 plan §2 evidence table](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)、[aggressive master §1 北極星](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)
+> **這份是什麼**：把 Lane 6 plan §2 的 evidence table 擴寫成**正式能力階梯**——每個 nav 能力一節，含證據文件路徑、current label、升級條件（對應 §8 HITL matrix 的 N 項）、6/18 可否講。
+> **這份不是什麼**：① 不是「現在能跑什麼」的 runtime 真相（runtime 行為以 code / topic schema 為準）；② 不是對外 claim 措辭（→ [`2026-06-13-nav-618-claim-wording.md`](2026-06-13-nav-618-claim-wording.md)）；③ 不是操作手冊（最安全 operator 流程 = [`docs/runbook/2026-06-18-hitl-oneshot-runbook.md`](../runbook/2026-06-18-hitl-oneshot-runbook.md) nav DRY-RUN 段 + [`docs/runbook/2026-06-13-roy-hitl-queue.md`](../runbook/2026-06-13-roy-hitl-queue.md) nav 場測段）。
+> **權威關係**：本表的 current label **只能透過 §8 HITL matrix 結果升級**；任何升級都要回填本檔 + claim wording。與 6/4 trusted snapshot（[`baseline-evidence/2026-06-04-hitl/`](../runbook/baseline-evidence/)）的關係見 §5。
+
+---
+
+## 1. 四級階梯定義（標籤詞彙）
+
+Lane 6 T6-1 定義四個**階梯級別**，作為「這個能力成熟到哪」的粗粒度框架；每個能力另有一個**細粒度 current label**（沿用 Lane 6 §2 與 [capability-baseline-spec](../pawai-brain/specs/2026-06-18-capability-baseline-spec.md) 的詞彙），兩者對應關係見每節。
+
+| 階梯級別 | 定義 | 升級進入的條件 | 6/18 對外措辭 |
+|---|---|---|---|
+| **`wired_only`** | code / topic / action chain 接好，dry-run 證明鏈路通，但**從未有真實 motion 證據**或資料已遺失 | 任一次 HITL 真機 motion 證據 → `hardware_proven` | 只能講「鏈路已接、fail-closed 正確」，**不可講能力本身可用** |
+| **`hardware_proven`** | 至少一次真機 HITL 證明該能力**做到過**，但樣本不足（n<3）或有明確限制（margin 薄 / 需操作員 / 窄場限定） | n=3 重複過 + 限制可接受 → `demo_ready` | 可講「做到過（單點/窄版）」，必須**連帶講出限制與樣本數** |
+| **`demo_ready`** | n=3 重複可靠 + 6/18 場地（客廳 indoor_tight）可現場展示 + 有現場中止手段 | — | 可現場 live 展示；仍綁安全前提（e-stop ready） |
+| **`research_prototype`** | 只有設計 spec、無任何實作碼 / 無可展示物 | 實作 + HITL（post-6/18） | 只能講「研究路線已有 spec、屬 research prototype」，**絕不可講已具備** |
+
+**鐵則**：① 不把 `insufficient_data` / 資料遺失洗成更高級別；② 單情境最多講 CLAIM_WITH_CAVEAT（沿用 [convergence audit §B 硬規則](../pawai-brain/research/2026-06-05-618-demo-convergence-audit-and-model-tournament.md)）；③ 任何 motion 能力的升級都必須有 §8 對應 N 項 PASS 才能改 label。
+
+---
+
+## 2. Proven Table 總覽（升級的唯一依據）
+
+> current label 直接繼承 Lane 6 plan §2；本檔在每節展開證據路徑與升級路徑。**任何一格沒有「日期 + 文件路徑級證據」就不准比現在更高的 label。**
+
+| # | 能力 | 階梯級別 | Current label | 主證據 | 升級 HITL 項 |
+|---|---|---|---|---|---|
+| C1 | 0.3m short goto | hardware_proven | `HARDWARE_PROVEN_LOW_SAMPLE` | [trackB §1](research/2026-06-08-trackB-hitl-results.md) | N3 |
+| C2 | 0.5m short goto | wired_only→hardware_proven | `NEEDS_RETEST` | [6/9 HITL §1.4-1.5](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) | N3 |
+| C3 | 1.0m goto | wired_only | `NOT_DEMO_READY` | [fusion spec §AMCL gate](specs/2026-05-03-d435-rplidar-fusion-detour.md) ※ | N2→N3 |
+| C4 | safe stop（正前停障） | hardware_proven | `HARDWARE_PROVEN_WITH_LIMIT` | [trackB §1 / 6/9 §1.5](research/2026-06-08-trackB-hitl-results.md) | N8（+N3 護航） |
+| C5 | stop-resume | wired_only | `NEEDS_FIX_OR_OPERATOR_CONFIRM` | [6/9 §1.6](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) | N6 |
+| C6 | indoor_tight profile（±18° 誤擋修正） | hardware_proven | `HARDWARE_PROVEN_WITH_LIMIT` | [trackB §4 / 6/9 §1.3](research/2026-06-08-trackB-hitl-results.md) | N8 |
+| C7 | AMCL initialpose 重定位 | hardware_proven | `HARDWARE_PROVEN_LOW_SAMPLE` | [6/10 S1 區段](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) | N2 |
+| C8 | orphan goal 自癒 | hardware_proven（client 側 wired_only） | `HARDWARE_PROVEN_WITH_LIMIT` | [trackB §5-6 / 6/9 §orphan](research/2026-06-08-trackB-hitl-results.md) | N7 |
+| C9 | patrol（固定 route 單圈） | research_prototype | `PROTOTYPE` | [6/9 Phase 1.5](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) | N1→N5 |
+| C10 | goto_named / run_route | wired_only | `NOT_DEMO_READY` | code 在、資料遺失（[master §2](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)） | N1 |
+| C11 | free roam / dynamic detour | — | `DO_NOT_CLAIM` | [trackB §7](research/2026-06-08-trackB-hitl-results.md) | 無（不在 6/18 範圍） |
+| C12 | D435+LiDAR fusion / approach person | research_prototype | `DO_NOT_CLAIM`（spec only） | 本 lane T6-8 三 spec | 無（post-6/18） |
+
+※ C3 主證據是「**為什麼到不了**」的證據（AMCL yellow gate 卡死），非「做到過」的證據——這正是它停在 `wired_only` 的理由。
+
+---
+
+## 3. 逐能力階梯（每節：證據 / current label / 升級條件 / 6/18 可否講）
+
+### C1 — 0.3m short goto
+
+- **階梯級別**：`hardware_proven`（current label `HARDWARE_PROVEN_LOW_SAMPLE`）。
+- **證據**：[`research/2026-06-08-trackB-hitl-results.md`](research/2026-06-08-trackB-hitl-results.md) §1：6/7 首發 goto 0.3m → `success=reached, actual=0.270m`，無 no_progress abort，Roy 目視 Go2 真的往前走（NAV-1 / F7 RESOLVED）。特性是 discrete-step：0.3m→0.27m，~3.45s `reached`（Go2 sport-mode 一步幅後 goal close）。
+- **為何不更高**：只有單次成功，無重複性數據（n<3）。
+- **升級條件**：§8 **N3** 短距可靠性——0.3m × n=3 全 `reached`，每發記 covariance/actual_distance → 升 `demo_ready` 候選。
+- **6/18 可否講**：✅ 可講「室內已知地圖、操作員下令的短距自主移動」，**但須標單點/窄版**；n=3 過後才可加「可靠」。
+
+### C2 — 0.5m short goto
+
+- **階梯級別**：`wired_only`→候選 `hardware_proven`（current label `NEEDS_RETEST`）。
+- **證據**：[`2026-06-09-nav-vision-hitl-execution.md`](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) §1.4-1.5：indoor_tight 走過一次（safe-stop 場景中），樣本不足；trackB §1 另記 0.5m→0.27m discrete-step（一步幅內就達標）。
+- **為何不更高**：只在 safe-stop 護航下走過、未獨立重驗。
+- **升級條件**：§8 **N3**——0.5m × n=3，三連過 = `demo_ready` 候選（Lane 6 §6 T6-4）。
+- **6/18 可否講**：⚠️ 與 C1 合併講「0.3-0.5m 短距」；0.5m 在 N3 過之前**不單獨宣稱可靠**，且**禁講「乾淨 0.5m+ 連續導航」**（trackB §7 forbidden）。
+
+### C3 — 1.0m goto
+
+- **階梯級別**：`wired_only`（current label `NOT_DEMO_READY`）。
+- **證據**：[`navigation/specs/2026-05-03-d435-rplidar-fusion-detour.md`](specs/2026-05-03-d435-rplidar-fusion-detour.md) §「AMCL cov 又卡 YELLOW」：Goal >0.5m 被 `nav_action_server` YELLOW gate 拒（covariance ≤0.30 才允許 >0.5m goal）；[`research/2026-05-01-amcl-180-degree-diagnosis.md`](research/2026-05-01-amcl-180-degree-diagnosis.md) 記 AMCL 靜止不收斂根因。6/10 S1：covariance 0.45 黃帶抖、nav 閘 yellow 只准 ≤0.5m → 被拒且 Studio 靜默回 idle（[master §2](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）。
+- **為何不更高**：**從未成功**——黃帶卡死、無 covariance 收斂 SOP。
+- **升級條件**：§8 **N2**（covariance SOP：probe 收斂曲線 + 黃帶決策表，設準 initialpose 等收斂進 green）→ **N3**（1.0m × n=3，每發先用 N2 SOP 進 green 再發）。⚠️ 不放寬 covariance 門檻值（0.3/0.5 hardcoded，Lane 6 §5 禁止）——靠診斷 SOP + 設準 pose 解。
+- **6/18 可否講**：❌ **不可講 1.0m 自主移動**，除非 N2+N3 都過並回填本表；在那之前 1.0m 不進 demo 主線。
+
+### C4 — safe stop（正前停障）
+
+- **階梯級別**：`hardware_proven`（current label `HARDWARE_PROVEN_WITH_LIMIT`）。
+- **證據**：[`research/2026-06-08-trackB-hitl-results.md`](research/2026-06-08-trackB-hitl-results.md) §1 NAV-2：接近牆 1.03m → reactive_stop danger → nav_paused → Go2 停、0 撞 0 暴衝（多次）；[`2026-06-09-nav-vision-hitl-execution.md`](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) §1.5：goto 0.5m → danger 停 @0.78m、0 撞 0 暴衝。
+- **限制（label 帶 WITH_LIMIT 的原因）**：① **stop-based 不繞行**（reactive_stop `angular.z=0` 只停不轉）；② margin 薄（機鼻 ~0.4m）；③ 側向 ±18-30° 不覆蓋（窄錐換來的）。
+- **升級條件**：§8 **N8**（indoor_tight danger 停 / clear 放行 / 無誤擋各一輪重跑），由 **N3** 短距護航。**注意**：safe-stop 永遠不會升成「繞障」——繞障是 C11，明確 `DO_NOT_CLAIM`。
+- **6/18 可否講**：✅ 可講「正前方障礙物安全停下、不碰撞」，**必須明講是 safe-stop 不是繞障**（標準說法見 claim wording §3）。
+
+### C5 — stop-resume
+
+- **階梯級別**：`wired_only`（current label `NEEDS_FIX_OR_OPERATOR_CONFIRM`）。
+- **證據**：[`2026-06-09-nav-vision-hitl-execution.md`](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) §1.6 + §275：auto-resume 會動，但以 Go2 MIN_X ~0.5 m/s lunge、短 goal 貼牆 0.21m（機鼻幾乎貼牆）→ **tight space 禁 demo auto-resume**；operator-confirm 流程 gateway 已實作（6/10 S1）未完整驗。
+- **為何不更高**：auto-resume 不安全（lunge）；operator-confirm 流程只在 gateway，台詞退路有但**無 param 防呆**。
+- **升級條件**：§8 **N6**（route/goto 中置障 → danger 停 → Studio 按「繼續」→ 續走）驗 operator-confirm 一輪；Lane 6 T6-7 加 `resume_policy` param 防呆（`operator_confirm` 預設 / `auto` 僅大場地，tight×auto 單測被拒）。auto-resume 終局（A-9）post-6/18。
+- **6/18 可否講**：✅ 可講「停下後由操作員確認再續走」（operator-confirm）；❌ **禁講** auto-resume / 「障礙移開後會自己繼續」「停了不會再走」（[6/9 §1.6 Acceptance](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)：實際會 auto-resume 但不安全）。
+
+### C6 — indoor_tight profile（±18° 誤擋修正）
+
+- **階梯級別**：`hardware_proven`（current label `HARDWARE_PROVEN_WITH_LIMIT`）。
+- **證據**：[`research/2026-06-08-trackB-hitl-results.md`](research/2026-06-08-trackB-hitl-results.md) §4：±30° 寬錐把右前角家具（0.84m）算進前方危險 → nav_paused 鎖死；收窄 ±15° + danger 1.0 + 低速 0.2 → obstacle 1.16-2.12m、zone slow/clear、nav_paused false。[`2026-06-09-nav-vision-hitl-execution.md`](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) §1.3：front 0.97→1.22m、zone danger→slow（±18° 實證）。
+- **限制**：窄錐**必綁低速 ≤0.2 m/s**（側向覆蓋變少靠低速補反應時間）；`front_arc_deg`/`danger_distance_m` 只在 `__init__` 讀，`ros2 param set` 改無效 → **必須 kill 重啟帶參數**。
+- **升級條件**：§8 **N8**；profile 驗收矩陣文件化見 Lane 6 T6-9。一鍵 profile 已在 [`scripts/start_nav_capability_demo_tmux.sh`](../../scripts/start_nav_capability_demo_tmux.sh)（`REACTIVE_PROFILE=open_space|indoor_tight`）。
+- **6/18 可否講**：✅ 可講「居家窄場用收窄安全錐避免誤擋」（trackB §7 能講項）；現場標準診斷工具 = [`scripts/lidar_front_sector.py`](../../scripts/lidar_front_sector.py)。
+
+### C7 — AMCL initialpose 重定位
+
+- **階梯級別**：`hardware_proven`（current label `HARDWARE_PROVEN_LOW_SAMPLE`）。
+- **證據**：6/10 S1 段（[`2026-06-09-nav-vision-hitl-execution.md`](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)）：`/api/nav/initialpose` 實測 amcl_pose 跳到設定點；Studio nav panel 有 initialpose 按鈕。
+- **為何不更高**：跳點可行但 **covariance 收斂無 SOP**（黃帶要等多久 / 該推 / 該重設沒有決策表）。
+- **升級條件**：§8 **N2** covariance SOP（probe 腳本量靜置 vs 0.3m warmup 兩模式收斂曲線 → 填黃帶決策表，Lane 6 T6-5②③）。
+- **6/18 可否講**：⚠️ 可作為「定位重設」操作展示；但不講「可靠收斂」——收斂時間不確定（[fusion spec §238](specs/2026-05-03-d435-rplidar-fusion-detour.md)：60-90s 偶爾過）。
+
+### C8 — orphan goal 自癒
+
+- **階梯級別**：`hardware_proven`（client 側 `wired_only`，current label `HARDWARE_PROVEN_WITH_LIMIT`）。
+- **證據**：[`research/2026-06-08-trackB-hitl-results.md`](research/2026-06-08-trackB-hitl-results.md) §5-6：被擋 goto 撐 278s 無 abort、client 被殺後 server 端 goal 仍 active → 後續全被 `rejecting goto_* — another goto still active` 擋；[`2026-06-09-nav-vision-hitl-execution.md`](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) §orphan：`no_progress_timeout`(~10s) + `goto_max_duration_s=120` backstop 可自癒、不需重啟。
+- **限制**：server 側自癒成立（~10s），但 **client cancel 仍沒送出**（rclpy SIGINT 先關 context → RCLError，非 KeyboardInterrupt）；`send_relative_goal.py` 另有 double-shutdown bug（trackB §6 backlog 1）。
+- **升級條件**：§8 **N7**（goto 中 Ctrl-C → cancel 送達 → 立刻可接下一筆）；Lane 6 T6-6 client 根治（`rclpy.init(signal_handler_options=NO)` + 自管 SIGINT）。
+- **6/18 可否講**：✅ 可講「client/SSH 掛掉約 10 秒內自動恢復、不需重啟」；❌ **不可講「即時恢復」**（[6/9 §36](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)）。
+
+### C9 — patrol（固定 route 單圈）
+
+- **階梯級別**：`research_prototype`→候選展示（current label `PROTOTYPE`）。
+- **證據**：`run_route` action 存在（[`nav_capability/nav_capability/route_runner_node.py`](../../nav_capability/nav_capability/route_runner_node.py)、[`go2_interfaces/action/RunRoute.action`](../../go2_interfaces/action/RunRoute.action)）；[`2026-06-09-nav-vision-hitl-execution.md`](../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md) Phase 1.5 設計 reactive patrol v0；**routes 資料已遺失、從未跑過完整單圈**。
+- **為何不更高**：無資料、無單圈證據。
+- **升級條件**：§8 **N1**（poses/routes 重錄）→ **N5**（run_route 單圈，indoor_tight 護航 + 操作員監督 + emergency_stop 待命，錄 Studio 三層同框）。N5 跑通 = 「固定路線單圈巡邏 prototype（操作員監督）」有證據，可講可展示（Lane 6 §13）。
+- **6/18 可否講**：⚠️ **僅在 N5 跑通後**才可講「固定路線單圈巡邏 prototype（操作員監督）」，與「自由巡邏」嚴格區分；N5 未跑 → 退影片 fallback。
+
+### C10 — goto_named / run_route
+
+- **階梯級別**：`wired_only`（current label `NOT_DEMO_READY`，N1 恢復後 `NEEDS_RETEST`）。
+- **證據**：code 在（[`nav_capability/nav_capability/nav_action_server_node.py`](../../nav_capability/nav_capability/nav_action_server_node.py)、[`go2_interfaces/action/GotoNamed.action`](../../go2_interfaces/action/GotoNamed.action) / [`RunRoute.action`](../../go2_interfaces/action/RunRoute.action)）；**poses/routes 被歷次 deploy `--delete` 清掉**（#166 已修 excludes、`runtime/` 不再被刪，但資料已失，[master §2](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）→ 目前全部空轉。
+- **為何不更高**：資料遺失 → 能力空轉。這是 Lane 6 的第一刀（T6-2）。
+- **升級條件**：§8 **N1**（`/log_pose` × 2-3 點 + 組 1 條短 route + `evidence pull` 驗備份）→ 恢復後 `NEEDS_RETEST`。備份迴路：`pawai evidence pull` 納入 `runtime/nav_capability/{named_poses,routes}`（拉回即異地備份，Lane 6 T6-2②）。
+- **6/18 可否講**：❌ N1 未做前**不可講** goto_named / run_route；goto_named 真正有意義需更大空間（學校場地，trackB §6）。
+
+### C11 — free roam / dynamic detour（自由巡邏 / 動態繞障）
+
+- **階梯級別**：— （current label `DO_NOT_CLAIM`）。
+- **證據**：不存在——reactive_stop `angular.z=0` 只停不轉；硬轉曾摔狗（5/2，[trackB §7](research/2026-06-08-trackB-hitl-results.md) + Lane 6 §2）。
+- **升級條件**：**無**——不在 6/18 範圍；Lane 6 §5 Forbidden scope 1/2 明禁（不做動態繞障、reactive_stop 維持 stop-based）。
+- **6/18 可否講**：❌ **永遠 forbidden claim**：自由巡邏、動態繞障/繞行（[north-star §7](../mission/2026-06-18-demo-north-star.md) + [convergence audit §B nav 行](../pawai-brain/research/2026-06-05-618-demo-convergence-audit-and-model-tournament.md)）。
+
+### C12 — D435+LiDAR fusion / approach person
+
+- **階梯級別**：`research_prototype`（current label `DO_NOT_CLAIM`，spec only）。
+- **證據**：現在**只有** `depth_clear` fail-closed gate（`/capability/depth_clear`，IE SafetyLayer 消費，擋 MOTION skill）——**D435 沒有融入 Nav2 costmap**；fusion 歷史見 [`navigation/specs/2026-05-03-d435-rplidar-fusion-detour.md`](specs/2026-05-03-d435-rplidar-fusion-detour.md)（5/3 詳測，根因 = `nav_action_server` max_speed 不 enforce + AMCL plateau）；approach 未開發。
+- **升級條件**：本 lane **T6-8 三條研究 spec**（[fusion](research/2026-06-13-spec-d435-lidar-fusion.md) / [patrol v1](research/2026-06-13-spec-patrol-v1.md) / [approach person](research/2026-06-13-spec-approach-person.md)）落檔可審 → 實作 + HITL（post-6/18）。spec 未過 Roy 審不開工。
+- **6/18 可否講**：⚠️ 最多講「D435+LiDAR 融合 / 自主找人：研究路線已有 spec，屬 research prototype」；❌ **不可講** D435 已融合進 costmap、已具備自主找人。
+
+---
+
+## 4. OPEN 項與待補書記
+
+> 沿用 Lane 6 §2 / §3 的誠實盤點；以下是 label 旁帶星號或尚未閉合的書記項。
+
+| 書記 | 內容 | 狀態 |
+|---|---|---|
+| **A-1（S1 簿記）** | 6/9 鎖過一版 nav 台詞，之後 S1 錄成的**方式待補記**；poses 隨後遺失 → 6/18 版台詞需重鎖（Lane 6 §3 問題 7） | OPEN（claim wording 鎖定時補） |
+| **歪斜診斷** | 0.3/0.5m discrete-step 有微幅歪斜，根因排序 H1 步態 yaw drift（~60%）＞H2 DWB 短距修正不足（~30%）＞H3 LiDAR TF（~10%），因 orphaned-goal 未錄到完整波形（[trackB §3](research/2026-06-08-trackB-hitl-results.md)） | OPEN（需較大空間 goto_named >1m 錄 angular.z + yaw） |
+| **C3 covariance 收斂** | 黃帶等待時間不確定（60-90s 偶爾過），無決策表 | 待 N2 SOP 閉合 |
+
+---
+
+## 5. 與 6/4 trusted snapshot 的關係（不矛盾聲明）
+
+[`baseline-evidence/2026-06-04-hitl/`](../runbook/baseline-evidence/) 的 nav 四能力（`nav.short_move` / `nav.safe_stop` / `nav.no_auto_resume` / `nav.dynamic_avoidance`）在 6/4 trusted snapshot 全 **`insufficient_data`**（n=0，dry-run 在 AMCL gate `amcl_lost` abort、Go2 零 motion，[convergence audit §B nav 行](../pawai-brain/research/2026-06-05-618-demo-convergence-audit-and-model-tournament.md)）。
+
+**本 ladder 與 6/4 snapshot 不矛盾**：6/4 snapshot 是「在 fresh stack 自動採集流程下、無 trusted motion record」的正確 fail-closed 結論；本 ladder 記的 C1/C4 等 `hardware_proven` 是 **6/7-6/10 後續 HITL 的人工觀測證據**（trackB / 6/9 HITL log），尚未回灌進 scoreboard 的自動 trusted 流程。兩者的橋接 = §8 HITL matrix（N3 短距、N8 safe-stop）跑出可溯源數字後回填 scoreboard——在那之前，**對外 claim 一律取兩者中較保守者**，且 nav 在 scoreboard 層維持 `insufficient_data`。
+
+---
+
+## 6. 維護規則
+
+1. **label 升級**：只能透過 §8 HITL matrix 對應 N 項 PASS；每次升級回填本檔 §2/§3 + [claim wording](2026-06-13-nav-618-claim-wording.md) 對應句。
+2. **label 降級**：任一 HITL 項 FAIL → 對應格照實標、claim wording 對應降級（FAIL 不連坐其他格，Lane 6 §10）。
+3. **資料項**（poses/routes）：是 runtime 資料非 code，錄壞重錄即可；`evidence pull` 備份讓「再被清掉」變成可還原事件。
+4. **本檔不是 runtime 真相**：能力是否能跑以 code / topic schema / `pawai smoke nav --static` 為準；本檔是「成熟度敘事 + 升級路徑」。

--- a/docs/navigation/research/2026-06-13-spec-approach-person.md
+++ b/docs/navigation/research/2026-06-13-spec-approach-person.md
@@ -1,0 +1,72 @@
+# Spec：Approach Person（自主走向人，research prototype）
+
+> **日期**：2026-06-13　**狀態**：SPEC ONLY — Lane 6 T6-8③（**零實作碼**；spec 未過 Roy 審不開工）
+> **上游**：[Lane 6 plan §6 T6-8](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)、[capability ladder C12](../2026-06-13-nav-capability-ladder.md)
+> **current label**：`DO_NOT_CLAIM`（spec only）——對外最多講「研究路線已有 spec、屬 research prototype」。
+> **這是最遠的一條**：approach person 是「看到/聽到人 → 走到人身邊」，需要把感知（face/depth）與移動（nav）第一次真正接起來——目前**零連接**。
+
+---
+
+## 0. 根因前置：approach 為何現在連起點都沒有
+
+1. **感知與 nav goal 零連接**：[trackB §2](2026-06-08-trackB-hitl-results.md) 明證——只有 2D RPLIDAR 進導航迴路；**RGB / 物體 / 人臉 / 語音與 nav goal 零連接**。approach person 要的「人在哪 → 算出 goal 座標 → 走過去」這條鏈**整條不存在**。
+2. **短距移動本身還在 low-sample**：approach 的「走過去」底層就是短距 goto，而短距可靠性還停在 [ladder C1/C2](../2026-06-13-nav-capability-ladder.md)（n<3、discrete-step）；底層不穩，approach 無從談起。
+3. **fusion 兩根因連帶**：approach 走向人時會遇到障礙，需要 safe-stop（甚至 fusion）可靠——而 fusion 卡在 [B1 max_speed 不 enforce + B2 AMCL plateau](2026-06-13-spec-d435-lidar-fusion.md)。
+4. **「聽懂過來就走到身邊」是明文 forbidden claim**：[Lane 6 §13](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md) 不可講清單已列「聽懂過來就走到 Roy 身邊」——這條 spec 存在的目的是把它**規劃成可開工的 research**，不是讓它變成 6/18 可講。
+
+> **硬閘**：短距 n=3（[N3](../2026-06-13-nav-capability-ladder.md)）+ fusion B1/B2 解 + face/depth→map 座標鏈設計過審，三者全缺一不開工。estimate ~4-5 天新開發（[trackB §6 backlog 6](2026-06-08-trackB-hitl-results.md)），明確超出 6/18。
+
+---
+
+## 1. Goal（spec 範圍）
+
+把「偵測到目標人 → 估算人的地圖座標 → 規劃並走到人身邊一個安全距離 → 停下」拆成可獨立驗證的開發階段。**目標距離留安全裕度**（停在人前 ~0.8-1.0m，不貼人）；**全程 safe-stop 兜底**；**不做跟隨**（follow 是持續追蹤，更遠，明確不在此 spec）。
+
+## 2. 四層開發拆解（~4-5 天，沿 trackB §6 backlog 6 的「物體導向導航需 4 層」框架套用到人）
+
+| 層 | 內容 | 接口 | 依賴 |
+|---|---|---|---|
+| **L1 目標偵測** | face/person 偵測產生「目標存在 + 影像 bbox」（face_perception 既有 `/state/perception/face`；person 走 object_perception COCO person） | 訂閱 face/object event | 既有感知（不改 node，只訂閱） |
+| **L2 像素 → 地圖座標** | bbox + D435 depth → 相機座標 → TF 轉 base_link → 轉 map 座標（需 AMCL 定位準 = B2 解 + [N2 covariance SOP](../2026-06-13-nav-capability-ladder.md)） | depth + TF + `/amcl_pose` | B2 AMCL plateau 解；D435 depth 對齊 |
+| **L3 規劃走過去** | 算出「人前 ~0.8-1.0m 的 goal」→ 發 `/nav/goto_relative` 或 named-pose 式 goal → 短距移動（底層 = [ladder C1/C2](../2026-06-13-nav-capability-ladder.md)） | nav_capability action | 短距 n=3 過（N3）；B1 max_speed enforce |
+| **L4 接近時 safe-stop / 繞障** | 走向人途中遇障 → safe-stop 兜底（stop-based）；**繞障不在此 spec**（繞障 = [ladder C11](../2026-06-13-nav-capability-ladder.md) `DO_NOT_CLAIM`） | reactive_stop（不改本體） | safe-stop [ladder C4](../2026-06-13-nav-capability-ladder.md) |
+
+> L1→L4 嚴格分階段、前一層沒過不進下一層（沿 [5/3 spec 的 gate 分明紀律](../specs/2026-05-03-d435-rplidar-fusion-detour.md)）。
+
+## 3. 與 face / depth 的接口（不改既有 node）
+
+- **face**：訂閱 `/state/perception/face`（人臉狀態 10Hz JSON）/ `/event/face_identity`（identity_stable 事件）——approach 只**消費**，不改 face_identity_node。known-face gate 可沿用 [Brain 6/8 greet gate 邏輯](../../../CLAUDE.md)（known + stable）。
+- **depth**：用 D435 `aligned_depth_to_color`（[5/3 spec 用同一 topic 做 depth→scan](../specs/2026-05-03-d435-rplidar-fusion-detour.md)）取 bbox 中心深度；既有 `/capability/depth_clear` fail-closed gate **維持**（approach 不繞過它）。
+- **Brain 接口**：「誰觸發 approach、走到後說什麼台詞」**不在本 lane**（Lane 6 = nav 能力；Brain 接線歸 IE / Lane 1 範疇）。本 spec 只定義 nav 側的 goal 估算與移動。
+
+## 4. Safety gate（approach 開後的安全約束）
+
+1. **目標距離留裕度**：goal = 人前 ~0.8-1.0m，**絕不**算出貼人/穿過人的 goal；L2 座標估算錯誤（depth 雜訊/人移動）必須 fail-closed（估不出可靠座標就不發 goal）。
+2. **人會動**：人是動態目標，approach 過程人若移動，goal 過期——需重估或放棄，**不得追著移動目標連續發 goal**（那是 follow，不在 scope，且易失控）。
+3. **safe-stop 不可繞過**：approach 的「走過去」全程 reactive_stop 兜底；遇障停下 = operator-confirm（[ladder C5](../2026-06-13-nav-capability-ladder.md)），不 auto-resume。
+4. **短距邊界繼承**：單次 goal 距離承襲短距可靠性（[ladder C1/C2](../2026-06-13-nav-capability-ladder.md)）；長距離 approach = 多次短 goal，每次重估 + covariance 重檢。
+5. **operator + emergency_stop 全程待命**：approach motion 全程操作員監督、e-stop 就位；非預期加速/朝人衝 → 立即 abort（[Lane 6 §8 abort criteria 條 1/5](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+
+## 5. HITL 升級條件（從 `research_prototype` 往上）
+
+| 階段 | 條件 | 升到 |
+|---|---|---|
+| spec 過審 | Roy 審本 spec + §0 三硬閘（短距 n=3 / fusion B1B2 / 座標鏈設計）全達 | 可開工（仍 `research_prototype`） |
+| L1+L2 | 偵測到人 + 算出穩定的 map 座標（**Go2 不動**，純座標驗證，n≥3 不同位置） | 座標鏈 proven |
+| L3 | 發 goal 走到人前 ~0.8-1.0m 停（單次、操作員監督、n≥3） | `hardware_proven`（approach 單次、操作員監督） |
+| L4 + 整合 | 途中遇障 safe-stop 兜底；多次短 goal 重估接近 | post-6/18 |
+
+## 6. 禁 claim（forbidden，與 demo snapshot 一致）
+
+- ❌ **「聽懂過來就走到 Roy 身邊」**——[Lane 6 §13](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md) 明文 forbidden；除非 L1-L4 全過並回填 [ladder C12](../2026-06-13-nav-capability-ladder.md)。
+- ❌ **「自主找人 / 自動走向使用者」**——6/18 前最多講「研究路線已有 spec、屬 research prototype」。
+- ❌ **「跟隨 / follow」**——follow 是持續追動態目標，不在本 spec（[CLAUDE.md](../../../CLAUDE.md)：跟隨是文件級 future work）。
+- ❌ **「看到物體/人走過去」當已具備能力**（[trackB §6](2026-06-08-trackB-hitl-results.md)：需 4 層新開發 ~4-5 天，超出 6/18）。
+
+## 7. 不做（scope 邊界）
+
+- 不寫任何 approach 實作碼（spec only）。
+- 不改 face_identity_node / object_perception_node / reactive_stop 本體——approach 是上層消費者。
+- 不做 follow（持續追蹤）；不做繞障（[ladder C11](../2026-06-13-nav-capability-ladder.md)）。
+- Brain 觸發/台詞接線不在本 lane。
+- 不買新感測器、不重建 map。

--- a/docs/navigation/research/2026-06-13-spec-d435-lidar-fusion.md
+++ b/docs/navigation/research/2026-06-13-spec-d435-lidar-fusion.md
@@ -1,0 +1,76 @@
+# Spec：D435 + LiDAR Fusion（近距盲區補償，research prototype）
+
+> **日期**：2026-06-13　**狀態**：SPEC ONLY — Lane 6 T6-8①（**零實作碼**；spec 未過 Roy 審不開工，系統 [Phase 4 T4B-5](../../superpowers/plans/2026-06-11-phase4-robot-control-nav-hardening.md) 紀律）
+> **上游**：[Lane 6 plan §6 T6-8](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)、[capability ladder C12](../2026-06-13-nav-capability-ladder.md)
+> **歷史 spec**：[`specs/2026-05-03-d435-rplidar-fusion-detour.md`](../specs/2026-05-03-d435-rplidar-fusion-detour.md)（5/3 evening 漸進三段式設計，本 spec 是其在「先解兩根因」前提下的重寫）
+> **current label**：`DO_NOT_CLAIM`（spec only）——對外最多講「研究路線已有 spec、屬 research prototype」。
+
+---
+
+## 0. 為什麼這份 spec 開頭就是「根因前置」
+
+5/3 一整天的 detour demo（自動繞開靜態障礙）**沒拿到**，且 [`specs/2026-05-03-d435-rplidar-fusion-detour.md`](../specs/2026-05-03-d435-rplidar-fusion-detour.md) 的漸進三段式設計**卡在 Phase 3**。後續拆解（[`README.md` §42](../README.md)、[`plans/2026-05-04-phase2-dev-order-spec.md` §14](../plans/2026-05-04-phase2-dev-order-spec.md)）確認 detour 反覆失敗的根因**不是 D435 沒融合、不是 DWB 設計、不是場地、不是感測器**，而是兩個 nav 基礎 bug 串連。因此 **fusion 開工前必須先把這兩個根因解掉**，否則加再多感測器都會被同樣的 bug 擋住。
+
+### 根因 B1 — `nav_action_server` 不 enforce max_speed
+
+- **症狀**：0.5m goal 實際走 1.04m（[`README.md` §42](../README.md)、[`plans/2026-05-04-phase2-dev-order-spec.md` §14](../plans/2026-05-04-phase2-dev-order-spec.md)）。
+- **後果**：goal 距離不可信 → 任何「停在障礙前 X m」的 fusion 邏輯都失準（停障點會超衝）。
+- **fusion 前置條件**：max_speed 必須在 `nav_action_server` 層 enforce，goal 距離與實走距離誤差收斂到可預期範圍，**才談 fusion 提早停障**。
+
+### 根因 B2 — AMCL 靜止不收斂（plateau）
+
+- **症狀**：`update_min_d=0.10` 導致 AMCL 在靜止時不更新 → covariance 卡 YELLOW 不收斂（[`README.md` §42](../README.md)、[`research/2026-05-01-amcl-180-degree-diagnosis.md`](2026-05-01-amcl-180-degree-diagnosis.md)）。
+- **後果**：costmap 對齊度差 → D435 marking 進 costmap 時，障礙的世界座標會漂 → fusion 的「在地圖上標障礙」失去意義。
+- **fusion 前置條件**：covariance 有可靠收斂 SOP（[capability ladder C7 / N2](../2026-06-13-nav-capability-ladder.md)）；AMCL plateau 不解，fusion 進 costmap 是錯上加錯。
+
+> **硬閘**：B1 + B2 任一未解 → fusion **不開工**。本 spec 後續所有路線都以「B1/B2 已解」為前提。
+
+---
+
+## 1. Goal（spec 範圍）
+
+補 RPLIDAR-A2M12 的 **2D 平面盲區**——尤其矮障礙（地面雜物）與 LiDAR 安裝平面以下/以上的物體——用 D435 depth 作為**額外的障礙 observation source**，提升「停得更準 / 停得更早」的可靠性。**本 spec 的 fusion = 讓 safe-stop 更可靠，不是動態繞障**（繞障是 [ladder C11](../2026-06-13-nav-capability-ladder.md) `DO_NOT_CLAIM`）。
+
+## 2. 兩條候選路線（比較，不預設選哪條）
+
+| | 路線 A：costmap obstacle layer | 路線 B：depth → `/scan_d435` light 版 |
+|---|---|---|
+| **作法** | D435 直接當 Nav2 `local_costmap` 的 observation source（或 STVL voxel layer），3D marking + clearing | `depthimage_to_laserscan` 把 depth 壓成 2D `/scan_d435`，與 `/scan_rplidar` 一起餵 obstacle layer（[`README.md` §70 配置已設計](../README.md)） |
+| **盲區補償** | 真 3D（高/低障礙都補） | 只補單一掃描高度帶（`scan_height` 窗） |
+| **CPU/RAM** | 高（voxel layer + clearing 昂貴，Jetson 8GB 緊） | 低（單條 2D scan，[5/3 spec Phase 1 已驗工具鏈](../specs/2026-05-03-d435-rplidar-fusion-detour.md)） |
+| **TF / 高度過濾風險** | 高（需精確 camera→base_link TF + 高度過濾，5/3 風險清單列過） | 中（`output_frame=camera_depth_optical_frame`，需對齊） |
+| **與 RPLIDAR 衝突** | 兩 source 同層需 clearing 協調 | 兩條 scan 進 obstacle layer，clearing 各自 |
+| **6/8 backlog 對應** | trackB §6 backlog 5「D435→local costmap 融合」 | trackB §6 backlog 5「depth→/scan_d435 進 obstacle layer + DenoiseLayer」 |
+| **建議起點** | — | **B（light 版）優先 spike**：CPU 安全、工具鏈已驗、最小變更面；A 留作 B 不足時的升級 |
+
+> 路線選定本身是 spike 的產出，不在 spec 預判。**6/9 Roy 已給 D435 fusion 的進度序**（[`2026-06-09-nav-vision-hitl-execution.md` §65](../../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)）：① D435 shadow test（**不動狗**，錄 `/scan_d435_shadow` vs `/scan_rplidar` 比 D435 補到哪些 RPLIDAR 漏障）→ ② 接 Nav2 local costmap（observation source 或 STVL voxel layer）→ ③ 靜態障礙 3/5 能否繞/更準停 → ④ reactive patrol。**今天不做、不准宣稱已融合。**
+
+## 3. Safety gate（fusion 開後的安全約束）
+
+1. **fail-closed 繼承**：D435 既有 `/capability/depth_clear` fail-closed gate（IE SafetyLayer 消費，擋 MOTION skill）**維持不動**；fusion 是「額外 observation」非「取代 depth_clear」。
+2. **fusion 不得放寬 reactive_stop**：reactive_stop 仍是 stop-based、`angular.z=0`；fusion 只能讓 danger 觸發**更早/更準**，不能讓 Go2「停下後轉向」（[Lane 6 §5 Forbidden 1/2](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+3. **誤偵防呆**：D435 depth 雜訊（地面反光/玻璃）不得造成「幽靈障礙永久停車」——需 clearing + DenoiseLayer，且 D435 source 必須可一鍵關（env/param），出問題退回純 RPLIDAR。
+4. **emergency_stop 待命**：任何 fusion HITL motion 全程 `emergency_stop.py` engage 終端就位（[Lane 6 §8 abort 條 6](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+5. **8GB 互斥**：fusion 增加感知負載，必須先量 RAM（路線 A 風險高）；nav stack 與 brain demo stack 互斥的鐵則不變。
+
+## 4. HITL 升級條件（從 `research_prototype` 往上）
+
+| 階段 | 條件 | 升到 |
+|---|---|---|
+| spec 過審 | Roy 審本 spec + B1/B2 已解 | 可開工（仍 `research_prototype`） |
+| shadow 證據 | D435 shadow test：`/scan_d435_shadow` 補到 RPLIDAR 漏的障礙、無大量幽靈點（**Go2 不動**） | spec 路線選定 |
+| costmap 接入 | D435 進 local costmap，靜態障礙停障點比純 RPLIDAR **更準/更早**（量化，n≥3） | `hardware_proven`（fusion-assisted safe-stop） |
+| 繞障 | **不在本 spec 範圍**——繞障是 [ladder C11](../2026-06-13-nav-capability-ladder.md) `DO_NOT_CLAIM`，需另案（Nav2 Collision Monitor polygon footprint，trackB §6 backlog 4，demo 後 ~7/2） | — |
+
+## 5. 禁 claim（forbidden，與 demo snapshot 一致）
+
+- ❌ **「D435 已融合進 costmap」**——除非路線過 §4 costmap 接入並回填 [ladder C12](../2026-06-13-nav-capability-ladder.md)。
+- ❌ **「融合後能動態繞障/繞行」**——fusion ≠ 繞障；繞障是 stop-based reactive_stop 做不到的（`angular.z=0`），且硬轉摔過狗（5/2）。
+- ❌ **「三陣攝影機/三鏡頭參與導航」**——只有 2D RPLIDAR 進迴路；D435 是 fusion 才會加（[trackB §2](2026-06-08-trackB-hitl-results.md)：RGB/物體/人臉/語音與 nav goal 零連接）。
+- ❌ 在 B1/B2 未解時宣稱任何 fusion 進度。
+
+## 6. 不做（scope 邊界）
+
+- 不寫任何 fusion 實作碼（spec only）。
+- 不改 reactive_stop 4-mode 本體、不改 `nav_action_server` single-goal 模型（B1 的 max_speed enforce 修補歸 nav 基礎 bug fix，不在 fusion spec）。
+- 不買新感測器、不重建 map。

--- a/docs/navigation/research/2026-06-13-spec-patrol-v1.md
+++ b/docs/navigation/research/2026-06-13-spec-patrol-v1.md
@@ -1,0 +1,63 @@
+# Spec：Patrol v1（固定路線多圈巡邏，research prototype）
+
+> **日期**：2026-06-13　**狀態**：SPEC ONLY — Lane 6 T6-8②（**零實作碼**；spec 未過 Roy 審不開工）
+> **上游**：[Lane 6 plan §6 T6-8](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)、[capability ladder C9](../2026-06-13-nav-capability-ladder.md)、[6/9 Phase 1.5 reactive patrol v0](../../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)
+> **current label**：`PROTOTYPE`（patrol v0 = T6-3 的 run_route 單圈；本 spec 是其**之上的 v1**）——對外最多講「固定路線單圈巡邏 prototype（操作員監督）」，且**僅在 N5 跑通後**。
+
+---
+
+## 0. 根因前置：patrol v0 沒跑成的兩個前置缺口
+
+patrol v1 建立在 **v0（run_route 單圈）跑通**之上；v0 自己還沒跑成，原因有二，spec 開頭先記，避免 v1 跳過 v0 直接設計多圈：
+
+1. **routes 資料遺失**：`run_route` action 存在（[`nav_capability/nav_capability/route_runner_node.py`](../../nav_capability/nav_capability/route_runner_node.py)、[`go2_interfaces/action/RunRoute.action`](../../go2_interfaces/action/RunRoute.action)），但 routes 被歷次 deploy `--delete` 清掉（[master §2](../../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）→ 從未跑過完整單圈。**v1 前置 = N1 重錄 + evidence pull 備份迴路**（[Lane 6 T6-2](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+2. **居家空間太小 + orphaned-goal**：[trackB §5](2026-06-08-trackB-hitl-results.md) 記「最後沒拍到 Go2 走給你看」不是 nav 壞，是 orphaned-goal 累積（single-goal server + client double-shutdown）；route 是連續多 goal，orphan 問題會放大。**v1 前置 = N7 orphan 根治**（[Lane 6 T6-6](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+
+> **硬閘**：N1（routes 恢復）+ N5（v0 單圈跑通）未達 → patrol v1 **不開工**。
+
+---
+
+## 1. Goal（spec 範圍）
+
+在 T6-3 的「固定 route 單圈（操作員監督）」之上，把 patrol 擴成：**多圈 / 排程 / 中途暫停與恢復**——一條已錄的 route 能連續跑 N 圈、能由操作員暫停再續、能在 danger 停障後 operator-confirm 續走。**仍是固定路線**（route 是預錄的 named poses 序列），**不是自由巡邏、不是動態繞障**。
+
+## 2. 三個能力增量（在 v0 之上）
+
+| 增量 | 內容 | 依賴 v0 之外的前置 |
+|---|---|---|
+| **多圈** | 同一 route 連續跑 N 圈（`run_route` 加 `loops` 參數或外層排程）；每圈間 covariance 重檢（[ladder C7 / N2 SOP](../2026-06-13-nav-capability-ladder.md)） | 需較大空間才有意義（居家窄場一圈就到頭，[trackB §6 backlog 6](2026-06-08-trackB-hitl-results.md)：學校場地） |
+| **排程** | 定時/事件觸發 patrol（非操作員每次手動發）——⚠️ **守護 30% 範疇，與互動主線分時**；觸發源與 Brain 的接口需另定 | Brain 接口（誰下令、台詞）不在本 lane（[Lane 6 §5](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)） |
+| **暫停恢復** | patrol 中操作員暫停 → 續走；danger 停障 → operator-confirm 續走（**禁 auto-resume**，[ladder C5](../2026-06-13-nav-capability-ladder.md)） | N6 operator-confirm 流程驗過 |
+
+> **明標需大場地的部分**：多圈與排程在居家客廳（淨空 ~1.1-1.5m，[trackB 頁首](2026-06-08-trackB-hitl-results.md)）幾乎無法展示——這兩項的 HITL 必須標「需學校/較大場地」，6/18 居家場景下**不承諾**。
+
+## 3. Safety gate（patrol 開後的安全約束）
+
+1. **每圈 covariance 重檢**：多圈累積會放大定位漂移；每圈起點重檢 covariance，YELLOW 不續圈（走 [N2 SOP](../2026-06-13-nav-capability-ladder.md)）。
+2. **danger 停障 = operator-confirm，不 auto-resume**：patrol 遇障一律停、等操作員確認；tight space 下 `resume_policy=auto` 被 param 防呆拒絕（[Lane 6 T6-7](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。auto-resume 會 lunge 貼牆 0.21m（[6/9 §275](../../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)）。
+3. **route 內每段限短距 + 低速**：route 的 named poses 間距承襲短距可靠性邊界（[ladder C1/C2](../2026-06-13-nav-capability-ladder.md)）；indoor_tight profile 必綁低速 ≤0.2 m/s（[ladder C6](../2026-06-13-nav-capability-ladder.md)）。
+4. **operator + emergency_stop 全程待命**：patrol motion 全程操作員監督、`emergency_stop.py` engage 終端就位；非預期加速/方向 → abort（[Lane 6 §8 abort criteria](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+5. **orphan 防線**：patrol 是多 goal 連續，client 必須走 N7 根治版（`signal_handler_options=NO` + 自管 cancel），否則中斷留 orphan 卡死整條 route。
+
+## 4. HITL 升級條件（從 `PROTOTYPE` 往上）
+
+| 階段 | 條件 | 升到 |
+|---|---|---|
+| v0 單圈 | [N5](../2026-06-13-nav-capability-ladder.md)：run_route 單圈跑通（indoor_tight 護航 + 操作員監督 + emergency_stop 待命）+ Studio 三層同框錄證據 | `PROTOTYPE` 有展示物（6/18 可講「單圈巡邏 prototype（操作員監督）」） |
+| v1 暫停恢復 | patrol 中暫停→續走、danger 停→operator-confirm→續走，各一輪（居家可做） | v1 暫停恢復 `hardware_proven`（操作員監督限定） |
+| v1 多圈/排程 | **需較大場地**：連續 N 圈無漂移失控、排程觸發可控 | post-6/18，需學校場地 HITL |
+
+## 5. 禁 claim（forbidden，與 demo snapshot 一致）
+
+- ❌ **「自由巡邏」「自主巡檢」**——patrol 是固定預錄 route，與自由巡邏嚴格區分（[ladder C9/C11](../2026-06-13-nav-capability-ladder.md)、[north-star §7](../../mission/2026-06-18-demo-north-star.md)）。
+- ❌ **「巡邏中能動態繞障」**——遇障一律 stop-based 停、operator-confirm 續，不繞行。
+- ❌ **「巡邏中障礙移開會自己繼續」**——auto-resume 禁用（lunge 不安全）。
+- ❌ **v0 單圈未跑通（N5 未過）就講 patrol prototype**——[Lane 6 §13](../../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)：僅在 N5 跑通後可講。
+- ❌ 在居家場景宣稱多圈/排程已達成。
+
+## 6. 不做（scope 邊界）
+
+- 不寫任何 patrol v1 實作碼（spec only）；v0 的 run_route 單圈本身是 T6-3 HITL，不是本 spec 的 code。
+- 不改 `route_runner_node` / `run_route` action interface（多圈若做 = 加參數，屬 post-6/18 實作）。
+- 排程的 Brain 接口（觸發源、台詞）不在本 lane。
+- 不借 DimOS 整包（[6/9 §64](../../superpowers/plans/2026-06-09-nav-vision-hitl-execution.md)：DimOS 用 D435 VoxelGrid + 行為層做巡邏、非內建 LiDAR，值得借的是 VoxelGrid/FollowHuman/spatial-memory 概念，**非整包導入**，獨立 P2 研究）。

--- a/docs/runbook/2026-06-13-roy-hitl-queue.md
+++ b/docs/runbook/2026-06-13-roy-hitl-queue.md
@@ -1,0 +1,132 @@
+# Roy HITL Queue — 六 lane 全部 HITL 單一隊列（2026-06-13）
+
+> **日期**：2026-06-13　**狀態**：QUEUE — 彙整 [aggressive 套件](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md) 六份 lane plan 全部 HITL 項成單一隊列
+> **這份是什麼**：把 [Lane 1](../superpowers/plans/2026-06-13-lane1-brain-ism-staged-enable-plan.md)~[Lane 6](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md) §8 的所有「Roy 在場才能做」的 HITL 項，按 **HITL#1 demo lane / HITL#2 demo lane / nav 場測 B-9 / vision 矩陣日 B-3** 分組，每項含 lane 來源、前置 PR、指令級步驟、預估時長、abort criteria、**空白結果欄**。
+> **這份不是什麼**：① 不是逐行操作 SOP（最安全 operator runbook = [`2026-06-18-hitl-oneshot-runbook.md`](2026-06-18-hitl-oneshot-runbook.md)，nav DRY-RUN 段）；② 不是 plan 本體（各項細節以對應 lane plan §6/§8 為權威）；③ 不替代 [ladder](../navigation/2026-06-13-nav-capability-ladder.md) / [claim wording](../navigation/2026-06-13-nav-618-claim-wording.md)——結果回填那兩份。
+> **時段預算**（[master §5](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）：固定兩晚 demo-lane HITL（**#1 / #2**，各 ~2h）＋兩個可選大時段（**B-3** vision 矩陣日、**B-9** nav 場測，各半天）。四天內兩大時段建議至多選一個提前、另一個 post-6/18。
+
+---
+
+## ⚠️ 全隊列共通安全護欄（先讀，不可違反）
+
+- **8GB 互斥**：nav stack 與 brain demo stack **不能同跑**（6/7 實證）。demo-lane HITL（#1/#2 + B-3 brain 部分）走 demo stack；**B-9 nav 場測走 nav stack，需專屬時段、開場前先 `pawai demo stop`**。
+- **Go2 motion 限定**：只有標「需 Go2 motion」的項才動狗；其餘 Jetson-only（deploy/smoke/瀏覽器走查/感知流）**Go2 不動**。
+- **執行授權邊界**（[master §5 分類總表](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）：Roy 不在場一律不做本隊列任何項；不可預跑、不可「先試一下」。做完才能把 [ladder](../navigation/2026-06-13-nav-capability-ladder.md) proven table 對應格升級。
+- **誠實底線**：AFK 軟體只能說「code merged + 單測綠，待真機驗證」；**本隊列的項過了才算 HITL 通過 / 功能驗證**。
+- **e-stop 前置**：任何 Go2 motion 項，開始前口頭確認 `emergency_stop.py` engage 終端就位（見 §nav abort 條 6）。
+
+---
+
+## A. HITL #1（demo lane，6/14 晚，~2h）
+
+> 走 demo stack（brain）。涵蓋 Lane 1 2a/2b、Lane 2 Evidence 走查、Lane 3 smoke family、Lane 5 face 驗證。開場：deploy → demo lane 跑起。
+
+| # | 項 | lane 來源 | 前置 PR（merged + 單測綠） | 指令級步驟 | 需 Go2 motion | 預估 | abort / 中止手段 | 結果 |
+|---|---|---|---|---|:---:|---|---|---|
+| H1-0 | deploy + demo 起 | 共通 | — | `pawai jetson deploy --module brain`（或手動 rsync，CLI deploy 曾刪 .env 走查）→ demo lane 起 → `tmux ls` + `ros2 node list` 數 process（不只信 CLI 成功訊息，6/4 CRLF 假成功教訓） | 否 | 15 min | demo 沒起全綠 → 停，先修環境 | ☐ |
+| H1-1 | Lane 1 stage 2a（demo_phase） | Lane 1 §8 | T1-0 + T1-1 | `ros2 param set /brain_node ism_enabled true` → `ism_stage_2a_demo_phase true`；`demo_phase` 切 `s3_object` → 比手勢 → trace `phase:s3_object:gesture` suppress；切回 `all` 放行 | 否（感知流） | 15 min | 該 suppress 沒 suppress / callback 例外 → `ism_stage_2a_demo_phase false` 退；該 stage 當日標未過 | ☐ |
+| H1-2 | Lane 1 stage 2b（confirm 非黑洞） | Lane 1 §8 | T1-2pre + T1-2 | 開 `ism_stage_2b_confirm true`；thumbs_up → confirm 在飛 → 拿杯子 → cup suppress-with-trace 非黑洞 → 比 OK → wiggle 執行；第二輪不比 OK → 30s timeout 回 IDLE | **是**（wiggle） | 20 min | wiggle 非預期動作 / confirm 黑洞重現 → `ism_stage_2b_confirm false` 退；e-stop 待命 | ☐ |
+| H1-3 | Lane 2 Evidence Center 走查 | Lane 2 §8 | T2-1~T2-5 | deploy gateway+frontend → demo lane 跑一段產真 trace → 瀏覽器開 `/studio/evidence`：session 列表含今晚 session、timeline 與動作對得上、suppressed 中文理由正確、detail 無 PII（人名 `[private]`）→ 下載 redacted JSONL + 報告 → 歷史模式選 6/12 舊 session | 否 | 20 min | 頁面炸/PII 洩漏 → 退回既有 Suppressed viewer；`PAWAI_TRACE_STORE_ENABLED=0` 可關落盤 | ☐ |
+| H1-4 | Lane 3 smoke family + status | Lane 3 §8 | T3-1/2/4/6 | demo lane 跑著：`pawai smoke vision`（static 綠）、`pawai smoke object`（static 綠）、`pawai smoke full`（綠）、`pawai status` brain 區塊值正確（shadow/demo_phase/ism stage） | 否 | 15 min | smoke 誤判（只讀不傷系統）→ 修判定條件 | ☐ |
+| H1-5 | Lane 3 face delete 一輪 | Lane 3 §8 | T3-5 | 對測試身份：`pawai face delete <test>` → rebuild → 重啟 face node 重訓 → `pawai face list` 確認幽靈警示 | 否 | 10 min | 刪錯人 → 重新 enroll（rm 路徑經消毒、不可能 face_db 外） | ☐ |
+| H1-6 | Lane 5 face pickle→npz 驗證 | Lane 5 §8 | T5S-5 | rebuild 重訓（寫 npz）→ roy sim 分數不退化（對照 6/8 的 0.73-0.81 帶）→ list/delete 流程正常 | 否 | 10 min | sim 退化 → 不 rebuild 即回原狀（pickle fallback 在、舊 pkl 永遠可讀） | ☐ |
+| H1-7 | evidence pull 收尾 | Lane 1/3 §8 | T3 evidence pull（已有） | `pawai evidence pull` 拉 trace + nav runtime（備份）→ 摘要 events/suppressed/shadow | 否 | 5 min | — | ☐ |
+| H1-收尾 | stage flag 保持 | Lane 1 §8 | — | 過的 stage 保持 on 跑 10 min demo 動線，觀察無 callback 例外 / 無延遲回退才算過 | 否 | 10 min | 任何「該回應沒回應」且 trace 無法解釋 → 該 stage flag-off | ☐ |
+
+**合計 ~2h**（H1-2 是唯一 Go2 motion 項，wiggle 小幅）。
+
+---
+
+## B. HITL #2（demo lane，6/15 晚，~2h）
+
+> 走 demo stack。涵蓋 Lane 1 2c/2d、Lane 5 auth-on 彩排。
+
+| # | 項 | lane 來源 | 前置 PR | 指令級步驟 | 需 Go2 motion | 預估 | abort / 中止手段 | 結果 |
+|---|---|---|---|---|:---:|---|---|---|
+| H2-1 | Lane 1 stage 2c（executing watchdog） | Lane 1 §8 | T1-3pre + T1-3 | `ism_enabled true` + `ism_stage_2c_executing true`；短暫開 `stranger_alert_enabled` 重演 6/9 卡死（或發不回終態的 mock skill_request）→ timeout_s 後 trace `watchdog_timeout` + cup/greet 恢復回應 | 建議是 | 20 min | 正常 skill 被誤殺 / watchdog 沒觸發 → `ism_stage_2c_executing false` 退 | ☐ |
+| H2-2 | Lane 1 stage 2d（speaking chokepoint） | Lane 1 §8 | T1-4 | 開 `ism_stage_2d_speaking true`；觸發長 TTS（chat 長句）→ TTS 中拿杯子 → suppress `gate:speaking`；講完再拿 → 放行 | 否 | 15 min | tts 期間誤放/誤擋 → `ism_stage_2d_speaking false` 退 | ☐ |
+| H2-3 | Lane 5 auth-on 彩排（六步第⑤步） | Lane 5 §8 | T5S-3（token wiring） | Jetson 開 auth-on（env）→ 跑 Studio 全流程（按鈕/push-to-talk/video/nav panel/Evidence 頁）+ `pawai status`/smoke + `security_smoke.sh`（無 token 401 / 偽 Origin 拒 / `redact=0` 無 token 403）→ 全綠 = B-6 可選發表日 on | 否（Go2 低度） | 30 min | 任何紅 → 記錄、發表日維持 default-off（翻回 default-off 一個 env，S0-2 已驗 byte-identical） | ☐ |
+| H2-4 | Lane 5 whitelist-on 動作回歸 | Lane 5 §8 | T5S-1 | param 切 `webrtc_api_filter_mode=whitelist` → demo 動作全流程（wiggle/hello/sit/TTS Megaphone）不誤殺 → security smoke 的 banned 拒絕項過 → 切回 `off`（或 Roy 點頭留 `blacklist` 進發表） | **是** | 20 min | 動作被誤殺 → 切 `blacklist`（現狀+拒 3 條 banned）或 `off`（秒級 byte-identical）；e-stop 待命 | ☐ |
+| H2-收尾 | stage flag 保持 | Lane 1 §8 | — | 過的 stage 保持 on 跑 demo 動線觀察 | 否 | 10 min | 同 H1-收尾 | ☐ |
+
+**合計 ~1.5-2h**（H2-1/H2-4 涉 Go2 motion）。
+
+---
+
+## C. Nav 場測（B-9，nav stack，~半天 2.5-3h，與 demo lane 互斥）
+
+> **走 nav stack**——開場前先 `pawai demo stop`（8GB 互斥）。場地：客廳 indoor_tight。開場儀式：`pawai smoke nav --static`（[Lane 3 T3-3](../superpowers/plans/2026-06-13-lane3-cli-v2-completion-plan.md)）→ goto 0.3m 一發暖身。**Go2 全程需要（motion）**；abort criteria（§nav abort 六條）全程生效、逐條勾。
+
+### C-abort：nav 場測硬性 abort criteria（[Lane 6 §8 六條](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)，任一觸發 = 當場中止該項，整段重新評估後才續）
+
+1. **Go2 非預期加速 / 非命令方向移動 → abort**（`emergency_stop.py` engage，當日該能力標 FAIL）。
+2. **reactive_stop 該觸發沒觸發**（障礙進 danger 區未停）→ **abort 全部後續 motion 項**，先用 [`lidar_front_sector.py`](../../scripts/lidar_front_sector.py) 診斷。
+3. **AMCL covariance 在黃/紅區（>0.3）卻要送 >0.5m goal → 禁送**（先走 N2 covariance SOP 收斂進 green；黃區只准 ≤0.5m）。
+4. **stop-resume 放開後衝速明顯過快（lunge 重現）→ abort**，resume 項當日不再試、退 operator-confirm only。
+5. **狗與障礙/牆距離小於安全距離（機鼻 <0.3m）仍在動 → abort**。
+6. **operator 的 e-stop（`emergency_stop.py` engage 終端）未就位 → 不開始任何 motion 項**；每項開始前口頭確認「e-stop ready」。
+
+### C 隊列（依賴序：N1→N2→N3→N4→(stretch)N5→N6→N7→N8→還原）
+
+| # | 項 | lane 來源 | 前置（PR / N 依賴） | 指令級步驟 | 預估 | 對應 ladder 升級 | 結果 |
+|---|---|---|---|---|---|---|---|
+| 開場 | smoke nav static + 暖身 | Lane 3 / Lane 6 §8 | T3-3 merged | `pawai demo stop` → 起 nav stack（`bash scripts/start_nav_capability_demo_tmux.sh`，`REACTIVE_PROFILE=indoor_tight`）→ 等 ~50s → Foxglove 設 `/initialpose` → `pawai smoke nav --static` 綠 → goto 0.3m 一發暖身 | 15 min | — | ☐ |
+| N1 | poses/routes 重錄 | Lane 6 §8 | T6-2 | `ros2 action send_goal /log_pose go2_interfaces/action/LogPose "{name: alpha, log_target: named_poses}"` × 2-3 點 → 組 1 條短 route → `pawai evidence pull` 驗備份（拉回 `runtime/nav_capability/`） | 20 min | [C10](../navigation/2026-06-13-nav-capability-ladder.md) `NOT_DEMO_READY`→`NEEDS_RETEST` | ☐ |
+| N2 | covariance SOP 實測 | Lane 6 §8 | T6-5 軟體 | `python3 scripts/nav_covariance_probe.py`（新）跑收斂曲線（靜置 vs 0.3m warmup 兩模式）→ 填黃帶決策表（該等 / 該推 0.3m / 該重設 pose） | 20 min | [C3/C7](../navigation/2026-06-13-nav-capability-ladder.md) covariance SOP 閉合 | ☐ |
+| N3 | 短距可靠性 | Lane 6 §8 | N2 | `scripts/send_relative_goal.py` 0.3 / 0.5 / 1.0m × **n=3**（1.0m 先用 N2 SOP 進 green）；每發記 covariance/actual_distance/結果 → 填 ladder proven table | 30 min | [C1/C2](../navigation/2026-06-13-nav-capability-ladder.md)→`demo_ready` 候選；[C3](../navigation/2026-06-13-nav-capability-ladder.md) 視結果 | ☐ |
+| N4 | rejection reason 驗證 | Lane 6 §8 | T6-5① | 故意黃帶發 1.0m → `ros2 action send_goal /nav/goto_relative ...` 回讀結構化 reason（`nav_not_ready:covariance=` / `yellow_band_limit:0.5m` 等） | 10 min | [claim wording S6](../navigation/2026-06-13-nav-618-claim-wording.md) 可講 | ☐ |
+| N5 | demo route + patrol v0（stretch） | Lane 6 §8 | N1 | `ros2 action send_goal /nav/run_route go2_interfaces/action/RunRoute "{route_id: '<錄的>'}"` 單圈（操作員監督 + e-stop 待命）+ Studio 三層同框錄證據 | 30 min | [C9](../navigation/2026-06-13-nav-capability-ladder.md) `PROTOTYPE` 有展示物；[claim wording S7](../navigation/2026-06-13-nav-618-claim-wording.md) 解鎖 | ☐ |
+| N6 | stop-resume operator-confirm（stretch） | Lane 6 §8 | N1 | route/goto 中置障 → danger 停 → Studio 按「繼續」→ 續走（**禁 auto-resume**） | 15 min | [C5](../navigation/2026-06-13-nav-capability-ladder.md) operator-confirm 驗 | ☐ |
+| N7 | orphan 根治驗證 | Lane 6 §8 | T6-6 軟體 | goto 進行中 Ctrl-C → server log 有 cancel → 立刻可接下一筆 | 10 min | [C8](../navigation/2026-06-13-nav-capability-ladder.md) client 側升級 | ☐ |
+| N8 | profile 矩陣重跑 | Lane 6 §8 | — | indoor_tight：danger 停 / clear 放行 / 無誤擋各一輪（`lidar_front_sector.py` 佐證） | 15 min | [C4/C6](../navigation/2026-06-13-nav-capability-ladder.md) 重驗 | ☐ |
+| 收尾 | 還原 | Lane 6 §8 | — | nav stack 停 → `pawai demo start` + `pawai smoke full` 確認 brain lane 無恙 | 15 min | — | ☐ |
+
+**合計 ~2.5-3h**（N5/N6 是 stretch，時間不夠先砍——[Lane 6 §8](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。結果回填 [ladder proven table](../navigation/2026-06-13-nav-capability-ladder.md) + [claim wording §2/§6](../navigation/2026-06-13-nav-618-claim-wording.md)；任一項 FAIL 不連坐（[Lane 6 §10](../superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md)）。
+
+---
+
+## D. Vision 矩陣日（B-3，~半天到全天，與發表準備搶時間故為可選）
+
+> [Lane 4 §8](../superpowers/plans/2026-06-13-lane4-vision-benchmark-model-ab-plan.md)。**建議與 B-9 至多選一個提前**（[master §5](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）。細部步驟/門檻以 [系統 Phase 3 plan](../superpowers/plans/2026-06-11-phase3-vision-evidence-model-benchmark.md) 為權威。**runtime 6/18 前不換模型/參數**（B-4 預設不換）。
+
+### D-abort：vision 矩陣日中止/還原 gate
+
+- **RAM 違反先量再跑**：T4 RAM 先量（tegrastats），餘 <0.8GB 即棄該配置（不硬跑）。
+- **TRT 預燒禁同跑 demo stack**（W6 前夜，否則互搶）。
+- **當日結束必須還原 demo 現役配置**（`OBJECT_MODEL`/`OBJECT_INPUT_SIZE` env 切回 n@640、conf 0.35）+ 跑 `pawai smoke full` 綠；TRT cache 分目錄保證現役 engine 不被覆蓋。
+
+| # | 項 | lane 來源 | 前置 | 指令級步驟 | 需 Go2 | 預估 | 結果 |
+|---|---|---|---|---|:---:|---|---|
+| D-0 | W1 末端 rsync 模型 | Lane 4 §8 | W1 spike 完 | rsync `yolo26s_640 / yolo26n_960 / yolo26s_960` ONNX → `/home/jetson/models/`（audited deploy，純檔案 additive） | Jetson（純檔案） | 5 min | ☐ |
+| D-1 | W6 前夜 TRT 預燒 | Lane 4 §8 | D-0 | TRT engine 預燒（**不開 demo stack**）；現役 engine 分目錄不覆蓋 | Jetson | 30-75 min | ☐ |
+| D-2 | 矩陣 T0 power mode 鎖定 | Lane 4 §8 | D-1 | `sudo bash benchmarks/scripts/prepare_env.sh`（nvpmodel + jetson_clocks） | Jetson | 10 min | ☐ |
+| D-3 | 矩陣 T1-T5（A-E 配置） | Lane 4 §8 | D-2 | `pawai object matrix`（或 `scripts/obj_matrix_cap.py`）跑 cup recall@1.0/1.5/2.0m + Hz + RAM tegrastats + 溫度；**conf 改動必 kill 重啟**；四門檻（cup@1.5m ≥80% / ≥3Hz / RAM 餘 ≥0.8GB / 7 類 sanity） | **Go2（D435 機上視角）** + 場地 + 三光照 | 核心 ~3h | ☐ |
+| D-4 | 矩陣 T6 色彩 54 格（必備 36） | Lane 4 §8 | D-3 | 9 件色彩物件 bag 錄製（Lab-LUT vs HSV12） | Go2 + 9 色彩物件 | ~1h | ☐ |
+| D-5 | T7 收尾 + 還原 | Lane 4 §8 | D-4 | 還原現役配置（env 切回）+ `pawai smoke full` 綠 + TRT 分目錄斷言 | Jetson | 15 min | ☐ |
+
+**合計**：核心 4.5-5h；含 T6 選配 ≈6h（排全天或砍 T6 選配排半天——[Lane 4 §8 三選一](../superpowers/plans/2026-06-13-lane4-vision-benchmark-model-ab-plan.md)）。數據回填 research docs + scoreboard（有上機數據才更新 recall@distance）。
+
+---
+
+## E. 6/17 回穩日（硬 checkpoint，非 HITL motion）
+
+> [master §5 回穩日鐵則](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)：不開新刀。
+
+| 項 | 內容 | 工具 | 結果 |
+|---|---|---|---|
+| E-1 | 全 flag 設「發表日狀態」寫入 checklist（shadow on / ism stages 視驗證 / auth 視 B-6 / nav profile） | `ros2 param set` + checklist | ☐ |
+| E-2 | `pawai smoke full` 全綠（回穩主工具） | Lane 3 T3-4 | ☐ |
+| E-3 | demo 全流程 smoke + 彩排一輪 | demo lane | ☐ |
+| E-4 | tag `pre-618-checkpoint` | git | ☐ |
+| E-5 | 未過驗證的刀 flag-off 或 revert（shadow 照常收數據） | runtime param / revert | ☐ |
+
+**鐵則**：6/17 18:00 起 main 凍結至發表結束；任何 stage 在 6/17 尚未通過 HITL → 該 flag 維持 False 進發表，不硬上。
+
+---
+
+## F. 依賴與排程備忘
+
+- **時段稀缺**：#1/#2 固定；**B-3 與 B-9 至多選一個提前 6/15-16**，另一個 post-6/18（[master §5](../superpowers/plans/2026-06-13-aggressive-pre618-master-plan.md)）。**B-9 對 6/18 直接價值較高**（poses 不重錄則 route/goto_named 全空轉、nav 段只能影片 fallback）。
+- **跨 lane 依賴**：Lane 3 T3-3（smoke nav --static）是 B-9 開場儀式；Lane 5 T5S-3（token wiring）是 H2-3 auth 彩排前置；Lane 1 各 stage 嚴格串行（前一 stage HITL 未過不開下一個 flag，但實作可先行）。
+- **結果回填路徑**：nav 項 → [ladder](../navigation/2026-06-13-nav-capability-ladder.md) + [claim wording](../navigation/2026-06-13-nav-618-claim-wording.md)；brain stage → Lane 1 §11 done criteria；vision → research docs + scoreboard；security → Lane 5 §11（B-5/B-6 決策記錄）。
+- **發表日 nav 形態 = B-10**（依 B-9 結果，6/17 定，[claim wording §5](../navigation/2026-06-13-nav-618-claim-wording.md)）。


### PR DESCRIPTION
系統重構 Lane 6：導航能力誠實化（純文件，零碼）。

- nav-capability-ladder（四級標籤 + proven table + 升級條件）
- 三研究 spec（fusion 引 5/3 兩根因 / patrol v1 / approach person，spec only）
- 6/18 claim wording（safe-stop≠繞障）
- roy-hitl-queue（六 lane 全 HITL 集中隊列）

Plan: docs/superpowers/plans/2026-06-13-lane6-navigation-obstacle-avoidance-v2-plan.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)