### PR TITLE
feat(cli/studio): 批次2-C — evidence pull nav / token wiring / CLI-01 消毒

### DIFF
--- a/pawai-studio/frontend/app/(studio)/studio/evidence/page.tsx
+++ b/pawai-studio/frontend/app/(studio)/studio/evidence/page.tsx
@@ -485,7 +485,9 @@ export default function EvidencePage() {
     setSessionsLoading(true);
     setError(null);
     try {
-      const response = await fetch(`${getGatewayHttpUrl()}/api/trace/sessions`);
+      const response = await fetch(`${getGatewayHttpUrl()}/api/trace/sessions`, {
+        headers: { ...authHeaders() },
+      });
       if (!response.ok) {
         throw new Error(`sessions ${response.status}`);
       }
@@ -521,7 +523,10 @@ export default function EvidencePage() {
         const url = `${getGatewayHttpUrl()}/api/trace/export?session=${encodeURIComponent(
           selectedSession
         )}`;
-        const response = await fetch(url, { signal: controller.signal });
+        const response = await fetch(url, {
+          signal: controller.signal,
+          headers: { ...authHeaders() },
+        });
         if (!response.ok) {
           throw new Error(`export ${response.status}`);
         }

--- a/pawai-studio/frontend/components/chat/brain/skill-buttons.tsx
+++ b/pawai-studio/frontend/components/chat/brain/skill-buttons.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { AlertTriangle, Hand, Lock, Octagon, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 import type { SkillRegistryEntry, SkillRegistryResponse } from "@/contracts/types";
 
@@ -39,7 +40,7 @@ const DEFAULT_ARGS: Record<string, Record<string, unknown>> = {
 async function postSkill(skill: string, args: Record<string, unknown> = {}) {
   await fetch(`${getGatewayHttpUrl()}/api/skill_request`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...authHeaders() },
     body: JSON.stringify({ skill, args, request_id: `btn-${Date.now()}` }),
   });
 }
@@ -57,7 +58,9 @@ export function SkillButtons() {
 
   useEffect(() => {
     let cancelled = false;
-    fetch(`${getGatewayHttpUrl()}/api/skill_registry`)
+    fetch(`${getGatewayHttpUrl()}/api/skill_registry`, {
+      headers: { ...authHeaders() },
+    })
       .then((r) => r.json())
       .then((data: SkillRegistryResponse) => {
         if (!cancelled) setRegistry(data);

--- a/pawai-studio/frontend/components/chat/chat-panel.tsx
+++ b/pawai-studio/frontend/components/chat/chat-panel.tsx
@@ -9,6 +9,7 @@ import { Composer } from "@/components/chat/composer";
 import { GestureToggle } from "@/components/chat/gesture-toggle";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 import { cn } from "@/lib/utils";
 
@@ -252,7 +253,10 @@ export function ChatPanel() {
       "將清除目前所有對話記憶，包括其他開啟的 Studio 視窗。確定？"
     );
     if (!ok) return;
-    await fetch(`${getGatewayHttpUrl()}/api/reset`, { method: "POST" });
+    await fetch(`${getGatewayHttpUrl()}/api/reset`, {
+      method: "POST",
+      headers: { ...authHeaders() },
+    });
     setMessages([]);
     useStateStore.setState({ ttsMessages: [] });
     lastSeenTtsIdRef.current = null;
@@ -311,7 +315,7 @@ export function ChatPanel() {
     try {
       const response = await fetch(`${getGatewayHttpUrl()}/api/text_input`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ text, request_id: requestId }),
       });
       if (!response.ok) throw new Error(`HTTP ${response.status}`);

--- a/pawai-studio/frontend/components/chat/gesture-toggle.tsx
+++ b/pawai-studio/frontend/components/chat/gesture-toggle.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Hand } from "lucide-react";
 import { useStateStore } from "@/stores/state-store";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 import { cn } from "@/lib/utils";
 
@@ -25,7 +26,9 @@ export function GestureToggle() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`${getGatewayHttpUrl()}/api/gesture_enabled`);
+        const res = await fetch(`${getGatewayHttpUrl()}/api/gesture_enabled`, {
+          headers: { ...authHeaders() },
+        });
         if (!res.ok) return;
         const data = (await res.json().catch(() => null)) as
           | { enabled?: boolean | null }
@@ -50,7 +53,7 @@ export function GestureToggle() {
     try {
       const res = await fetch(`${getGatewayHttpUrl()}/api/gesture_enabled`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ enabled: next }),
       });
       if (!res.ok) return;

--- a/pawai-studio/frontend/components/navigation/nav-control.tsx
+++ b/pawai-studio/frontend/components/navigation/nav-control.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Play, Pause, Square } from "lucide-react";
 import { useStateStore } from "@/stores/state-store";
 import type { NavControl, NavControlState } from "@/stores/state-store";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 
 /**
@@ -49,7 +50,9 @@ export function NavControl() {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`${getGatewayHttpUrl()}/api/nav/control`);
+        const res = await fetch(`${getGatewayHttpUrl()}/api/nav/control`, {
+          headers: { ...authHeaders() },
+        });
         if (!res.ok) return;
         const data = (await res.json().catch(() => null)) as
           | Partial<NavControl>
@@ -81,7 +84,7 @@ export function NavControl() {
     try {
       await fetch(`${getGatewayHttpUrl()}${path}`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: body != null ? JSON.stringify(body) : undefined,
       });
       // 不做 optimistic state — 一律等 gateway 的 nav_control WS 廣播更新。

--- a/pawai-studio/frontend/components/navigation/nav-map-canvas.tsx
+++ b/pawai-studio/frontend/components/navigation/nav-map-canvas.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useStateStore } from "@/stores/state-store";
 import type { NavPose, NavReactiveStop, NavZone } from "@/stores/state-store";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 
 /**
@@ -210,7 +211,7 @@ export function NavMapCanvas() {
     try {
       const res = await fetch(`${getGatewayHttpUrl()}/api/nav/initialpose`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ x, y, yaw }),
       });
       if (!res.ok) return false;

--- a/pawai-studio/frontend/hooks/use-scoreboard.ts
+++ b/pawai-studio/frontend/hooks/use-scoreboard.ts
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 
 import type { ScoreboardResponse } from "@/contracts/types";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 
 interface UseScoreboardResult {
@@ -21,7 +22,9 @@ export function useScoreboard(): UseScoreboardResult {
 
     async function fetchScoreboard() {
       try {
-        const response = await fetch(`${getGatewayHttpUrl()}/api/scoreboard`);
+        const response = await fetch(`${getGatewayHttpUrl()}/api/scoreboard`, {
+          headers: { ...authHeaders() },
+        });
 
         if (!response.ok) {
           throw new Error(`Scoreboard request failed: ${response.status}`);

--- a/pawai-studio/frontend/hooks/use-toggle-plan-mode.ts
+++ b/pawai-studio/frontend/hooks/use-toggle-plan-mode.ts
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react";
 import { useStateStore } from "@/stores/state-store";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl } from "@/lib/gateway-url";
 import type { PlanMode } from "@/contracts/types";
 
@@ -24,7 +25,9 @@ export function useTogglePlanMode(): UseTogglePlanModeResult {
   // Hydrate from gateway once.
   useEffect(() => {
     let cancelled = false;
-    fetch(`${getGatewayHttpUrl()}/api/plan_mode`)
+    fetch(`${getGatewayHttpUrl()}/api/plan_mode`, {
+      headers: { ...authHeaders() },
+    })
       .then((r) => r.json())
       .then((d) => {
         if (!cancelled && d?.mode) setPlanMode(d.mode as PlanMode);
@@ -43,7 +46,7 @@ export function useTogglePlanMode(): UseTogglePlanModeResult {
     try {
       await fetch(`${getGatewayHttpUrl()}/api/plan_mode`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...authHeaders() },
         body: JSON.stringify({ mode: next }),
       });
     } catch {

--- a/pawai-studio/frontend/hooks/use-websocket.ts
+++ b/pawai-studio/frontend/hooks/use-websocket.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { PawAIEvent } from "@/contracts/types";
+import { authHeaders } from "@/lib/gateway-auth";
 import { getGatewayHttpUrl, getGatewayWsUrl } from "@/lib/gateway-url";
 
 // Runtime fallback: env → same-origin hostname:8080 → localhost:8080
@@ -57,7 +58,10 @@ export function useWebSocket({ onMessage }: UseWebSocketOptions): UseWebSocketRe
       if (process.env.NEXT_PUBLIC_AUTO_RESET_ON_REFRESH === "true") {
         const refreshAt = sessionStorage.getItem("paw_refresh_at");
         if (refreshAt && Date.now() - parseInt(refreshAt) < 5000) {
-          fetch(`${getGatewayHttpUrl()}/api/reset`, { method: "POST" }).catch(() => {
+          fetch(`${getGatewayHttpUrl()}/api/reset`, {
+            method: "POST",
+            headers: { ...authHeaders() },
+          }).catch(() => {
             // Best-effort — ignore errors (gateway may not be ready yet)
           });
           sessionStorage.removeItem("paw_refresh_at");

--- a/pawai-studio/frontend/lib/__tests__/gateway-auth-wiring.test.ts
+++ b/pawai-studio/frontend/lib/__tests__/gateway-auth-wiring.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("react", async () => {
+  const actual = await vi.importActual<typeof import("react")>("react");
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      effect();
+    },
+    useState: <T>(initial: T) => [initial, vi.fn()],
+  };
+});
+
+import { useScoreboard } from "@/hooks/use-scoreboard";
+
+const originalGatewayToken = process.env.NEXT_PUBLIC_GATEWAY_TOKEN;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (originalGatewayToken === undefined) {
+    delete process.env.NEXT_PUBLIC_GATEWAY_TOKEN;
+  } else {
+    process.env.NEXT_PUBLIC_GATEWAY_TOKEN = originalGatewayToken;
+  }
+});
+
+function stubScoreboardFetch() {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ score: 0 }),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("gateway auth wiring", () => {
+  it("sends Authorization on gateway fetches when a token is configured", () => {
+    process.env.NEXT_PUBLIC_GATEWAY_TOKEN = "secret-token";
+    const fetchMock = stubScoreboardFetch();
+
+    useScoreboard();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8080/api/scoreboard",
+      { headers: { Authorization: "Bearer secret-token" } },
+    );
+  });
+
+  it("does not send Authorization when the gateway token is unset", () => {
+    delete process.env.NEXT_PUBLIC_GATEWAY_TOKEN;
+    const fetchMock = stubScoreboardFetch();
+
+    useScoreboard();
+
+    const options = fetchMock.mock.calls[0]?.[1] as RequestInit | undefined;
+    const headers = options?.headers as Record<string, string> | undefined;
+    expect(headers?.Authorization).toBeUndefined();
+  });
+});

--- a/tools/pawai_cli/pawai_cli/evidence.py
+++ b/tools/pawai_cli/pawai_cli/evidence.py
@@ -17,6 +17,34 @@ from . import shell
 from .errors import structured_error
 
 EVIDENCE_DEST_REL = Path("artifacts/evidence/traces")
+NAV_CAPABILITY_DEST_NAME = "nav_capability"
+
+
+def _remote_runtime_dir(name: str) -> str:
+    return f"{shell.jetson_host()}:{shell.jetson_repo().rstrip('/')}/runtime/{name}/"
+
+
+def _pull_read_only(src: str, dest: Path) -> None:
+    # Read-only pull: -az, NO --delete (local extras stay; remote untouched).
+    argv = ["rsync", "-az", src, f"{dest}/"]
+    code = shell.stream(argv)
+    if code == 127:
+        raise structured_error(
+            "rsync not found on this machine",
+            ["install rsync: sudo apt install rsync (Linux/WSL) / "
+             "brew install rsync (Mac)"],
+        )
+    if code != 0:
+        raise structured_error(
+            f"evidence pull failed (rsync exit {code})",
+            [
+                "SSH 不通？跑 `pawai doctor` 看 Network topology / Tailscale 區塊",
+                f"確認 Jetson 端有 trace：ssh {shell.jetson_host()} "
+                f"'ls {shell.jetson_repo()}/runtime/traces/'",
+                "gateway 沒跑、或 store 被 PAWAI_TRACE_STORE_ENABLED=0 關掉時，"
+                "Jetson 端不會有檔案",
+            ],
+        )
 
 
 def summarize_jsonl_dir(directory: Path) -> dict:
@@ -58,28 +86,11 @@ def pull(dest_str: str | None) -> None:
     """Pull runtime/traces/*.jsonl from the Jetson gateway trace store."""
     root = shell.repo_root()
     dest = Path(dest_str).expanduser() if dest_str else root / EVIDENCE_DEST_REL
+    nav_dest = dest.parent / NAV_CAPABILITY_DEST_NAME
+    nav_dest.mkdir(parents=True, exist_ok=True)
     dest.mkdir(parents=True, exist_ok=True)
-    src = f"{shell.jetson_host()}:{shell.jetson_repo().rstrip('/')}/runtime/traces/"
-    # Read-only pull: -az, NO --delete (local extras stay; remote untouched).
-    argv = ["rsync", "-az", src, f"{dest}/"]
-    code = shell.stream(argv)
-    if code == 127:
-        raise structured_error(
-            "rsync not found on this machine",
-            ["install rsync: sudo apt install rsync (Linux/WSL) / "
-             "brew install rsync (Mac)"],
-        )
-    if code != 0:
-        raise structured_error(
-            f"evidence pull failed (rsync exit {code})",
-            [
-                "SSH 不通？跑 `pawai doctor` 看 Network topology / Tailscale 區塊",
-                f"確認 Jetson 端有 trace：ssh {shell.jetson_host()} "
-                f"'ls {shell.jetson_repo()}/runtime/traces/'",
-                "gateway 沒跑、或 store 被 PAWAI_TRACE_STORE_ENABLED=0 關掉時，"
-                "Jetson 端不會有檔案",
-            ],
-        )
+    _pull_read_only(_remote_runtime_dir("nav_capability"), nav_dest)
+    _pull_read_only(_remote_runtime_dir("traces"), dest)
     summary = summarize_jsonl_dir(dest)
     click.echo(
         f"✓ pulled {summary['files']} file(s), {summary['events']} event(s), "

--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -785,7 +785,7 @@ def deploy(module_name: str, yes: bool, no_build: bool, no_sync: bool, all_modul
     payload["ts"] = payload["when"]
     remote_json = json.dumps(payload, ensure_ascii=False)
     shell.run_remote(
-        f"cd {shell.jetson_repo()} && printf '%s\\n' {json.dumps(remote_json)} > .pawai-last-deploy",
+        f"cd {shell.jetson_repo()} && printf '%s\\n' {shlex.quote(remote_json)} > .pawai-last-deploy",
         timeout=8,
     )
     print("Deploy complete.")

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -335,6 +335,45 @@ def test_last_deploy_payload_has_new_fields(monkeypatch, tmp_path):
     assert isinstance(payload["dirty"], bool)
 
 
+def test_deploy_last_deploy_write_quotes_malicious_branch(monkeypatch):
+    dangerous_branch = "$(touch /tmp/pwn)"
+    captured_commands = []
+
+    def fake_git(argv, timeout=None):
+        if argv[-2:] == ["--abbrev-ref", "HEAD"]:
+            return shell.Result(0, f"{dangerous_branch}\n", "")
+        if argv[-2:] == ["rev-parse", "HEAD"]:
+            return shell.Result(0, "abcdef1234567890\n", "")
+        if argv[-2:] == ["status", "--porcelain"]:
+            return shell.Result(0, "", "")
+        return shell.Result(1, "", "unexpected command")
+
+    def fake_run_remote(command, timeout=None):
+        captured_commands.append(command)
+        return shell.Result(0, "", "")
+
+    with patch("pawai_cli.lock.Lock.read", return_value=None), \
+         patch("pawai_cli.main.print_status", return_value=SimpleNamespace(has_demo=False)), \
+         patch("pawai_cli.main._do_rsync_and_build", return_value=(0, "none")), \
+         patch("pawai_cli.main.shell.run", side_effect=fake_git), \
+         patch("pawai_cli.main.shell.run_remote", side_effect=fake_run_remote), \
+         patch("pawai_cli.main.shell.local_identity", return_value="tester@workstation"):
+        result = CliRunner().invoke(
+            cli,
+            ["jetson", "deploy", "--module", "brain", "--no-sync", "--no-build", "-y"],
+        )
+
+    assert result.exit_code == 0, result.output
+    command = next(cmd for cmd in captured_commands if ".pawai-last-deploy" in cmd)
+    prefix = "printf '%s\\n' "
+    start = command.index(prefix) + len(prefix)
+    end = command.index(" > .pawai-last-deploy", start)
+    payload_arg = command[start:end]
+    assert dangerous_branch in payload_arg
+    assert payload_arg.startswith("'")
+    assert payload_arg.endswith("'")
+
+
 def test_doctor_fix_requires_prompt(monkeypatch, tmp_path):
     env_path = tmp_path / ".env.local"
     env_path.write_text("JETSON_TAILSCALE_IP=100.99.99.99\n")

--- a/tools/pawai_cli/tests/test_smoke_evidence.py
+++ b/tools/pawai_cli/tests/test_smoke_evidence.py
@@ -396,6 +396,22 @@ def test_evidence_pull_rsync_argv_read_only():
     assert argv[-1].endswith("artifacts/evidence/traces/")
 
 
+def test_evidence_pull_also_backs_up_nav_capability():
+    calls = []
+
+    def fake_stream(argv, cwd=None, env=None):
+        calls.append(list(argv))
+        return 0
+
+    with patch("pawai_cli.evidence.shell.stream", side_effect=fake_stream):
+        result = _invoke(["evidence", "pull"])
+
+    assert result.exit_code == 0, result.output
+    sources = [argv[-2] for argv in calls]
+    assert any(source.endswith("runtime/traces/") for source in sources)
+    assert any(source.endswith("runtime/nav_capability/") for source in sources)
+
+
 def test_evidence_pull_prints_summary():
     calls, fake = _fake_rsync_writing({
         "s1.jsonl": '{"ts": 1, "verdict": "suppressed"}\n{"ts": 2, "verdict": "accepted"}\n',


### PR DESCRIPTION
系統重構批次2 Route C（pawai_cli + frontend，純軟體，全 default-off）。

- T6-2② evidence pull 一併備份 runtime/nav_capability（named_poses/routes 異地備份迴路）
- T5S-3 gateway token wiring（前端 fetch 全接 authHeaders、CLI probe 支援 GATEWAY_TOKEN env；無 token 時 header 完全不帶＝byte-identical；WS header auth 屬 post-6/18 interface 級）
- CLI-01 deploy branch 名 shlex.quote 防 SSH 注入

親驗：CLI **213 passed**、前端 tsc rc=0 + vitest **29 passed**、樹乾淨。
⚠️ HITL pending：T6-2② 備份迴路需 N1 重錄 poses 後實測；T5S-3 auth-on 需彩排。

🤖 Generated with [Claude Code](https://claude.com/claude-code)