### PR TITLE
feat(profiling): plan1 T1 co-run profiling harness (NO-MOTION, pure-additive)

### DIFF
--- a/.github/workflows/ros_build.yaml
+++ b/.github/workflows/ros_build.yaml
@@ -158,6 +158,9 @@ jobs:
           PYTHONPATH=pawai-studio/gateway pytest pawai-studio/gateway/test_auth.py \
             pawai-studio/gateway/test_trace_store.py \
             -v --tb=short
+          # Invocation 9 (plan1 T1, Tier 1): co-run profiling parser — stdlib-only,
+          # ROS-free; self-bootstraps sys.path to its own scripts/ dir.
+          pytest scripts/test_corun_profile_parse.py -v --tb=short
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v4

--- a/docs/navigation/2026-06-13-corun-profiling-procedure.md
+++ b/docs/navigation/2026-06-13-corun-profiling-procedure.md
@@ -1,0 +1,139 @@
+# Co-run Profiling 程序文件（plan1 T1 骨幹）
+
+> 日期：2026-06-13　狀態：T1 骨幹（pure-software，已單測綠）；T5/T6 數據待 Roy 真機回填
+> 權威計畫：[2026-06-13-plan1-runtime-layout-corun-profiling.md](../superpowers/plans/2026-06-13-plan1-runtime-layout-corun-profiling.md)
+> 全程 **NO-MOTION**：本程序只量資源 + topic 健康，不發 `goto_relative` / `cmd_vel` / 任何 motion。
+
+本文件配合三支腳本使用：
+
+- `scripts/corun_topics.txt` — 每配置要 watch 的 topic 清單（§9.1）。
+- `scripts/corun_profile.sh` — profiling orchestrator（每 interval 抓資源 snapshot + `ros2 topic hz`）。
+- `scripts/corun_profile_parse.py` — log → CSV + PASS/WARNING/FAIL 判定（§9.2）。
+
+執行範例（Jetson，唯讀 attach，另開 ssh session 跑，不動既有 demo 腳本）：
+
+```bash
+# 配置 A：brain-full baseline（等 ASR warmup ~60s 後）
+bash scripts/corun_profile.sh --config A --duration 300 --interval 15
+python3 scripts/corun_profile_parse.py --config A
+```
+
+> ⚠️ T2–T6（真機跑 + cold-start）需 Roy 在場、Jetson 真機，**T1 不代跑、不假裝跑過**。
+> 本文件的決策表 / 8GB 互斥表 / cold-start 表目前為**空白模板**，待真機 CSV 出來後由 T5/T6 回填。
+
+---
+
+## §9 — 量測規格
+
+### §9.1 Watch-topic 清單
+
+對映 `scripts/corun_topics.txt`（格式 `topic,expected_hz,configs`）。「期望 Hz」是中心值，判定一律走 §9.2 的單一頻帶（不另立容差數字）。`evt` = event-driven / on-demand，判定看「有沒有量到」而非速率帶。
+
+| Topic | 期望 Hz | 出現於配置 | 來源 |
+|-------|:------:|:----------:|------|
+| `/state/perception/face` | ~10 | A,B,C | CLAUDE.md 人臉主線 |
+| `/face_identity/debug_image` | ~7 | A,B,C | MEMORY 3/18 smoke |
+| `/perception/object/debug_image` | ~7 | A,B,C | CLAUDE.md object §驗證 |
+| `/event/object_detected` | evt | A,B,C | CLAUDE.md object |
+| `/tts` | evt | A,B,C | CLAUDE.md 快速驗證 TTS |
+| `/capability/depth_clear` | 5 | A,B,C | `depth_safety_node` |
+| `/vision_perception/status_image` | 8 | A,B,C | CLAUDE.md 視覺儀表板 |
+| `/scan_rplidar` | ~10 | B,C | nav 腳本 `:78` |
+| `/state/nav/heartbeat` | 1 | C | nav monitor block |
+| `/state/nav/status` | 10 | C | nav monitor block |
+| `/state/nav/safety` | 10 | C | nav monitor block |
+| `/capability/nav_ready` | ~1 | C | nav monitor block |
+
+> `ros2 topic hz` 跑法：每 sample interval 對清單每個 config-match topic 跑 `timeout 6 ros2 topic hz <topic>` 取平均（6s 視窗）。`/tts` 延遲量法另記（發 `ros2 topic pub --once /tts ...` 記到喇叭出聲牆鐘），不影響量資源。
+
+### §9.2 Pass thresholds（parser 判定）
+
+對映 `corun_profile_parse.py` 的 band 函式（`judge_ram` / `judge_headroom` / `judge_gpu` / `judge_temp` / `judge_topic_hz` / `judge_node_crash` / `oom_verdict`）。
+
+| 指標 | PASS | WARNING | FAIL | 來源 |
+|------|:----:|:-------:|:----:|------|
+| RAM used（of 7.4 GB） | < 5.5 GB | 5.5–6.5 GB | > 6.5 GB（OOM-risk） | jetson-status budget |
+| RAM headroom | ≥ 1.9 GB | 0.9–1.9 GB | < 0.8 GB | jetson-status budget + 記憶體預算 §≥0.8GB |
+| GPU load | < 95% | 95–99% | 100%（throttle） | jetson-status budget |
+| 溫度（max zone） | < 65°C | 65–80°C | > 80°C | jetson-status budget |
+| 功耗 | < 12W | 12–15W | > 15W（MAXN limit） | jetson-status budget |
+| topic Hz（每 watch topic） | 期望 ±20% | ±20–40% | 偏離 > 40% 或 0 | §9.1 期望值 |
+| node crash | `ros2 node list` 與 baseline 一致 | — | 少任一 node | crash 偵測 |
+| `/tts` 延遲 | 與 A baseline 比 ≤ +30% | +30–60% | > +60% 或無聲 | 相對 baseline |
+| gateway(8080) | curl `/health` 200 | — | 連線 refused / 逾時 | Foxglove 不壓垮 gateway |
+
+> **配置 pass = 全列 PASS 或最多 WARNING 且無 FAIL**。任一 FAIL ⟹ 該配置判 unstable。
+>
+> **OOM-risk abort（現場安全煞車，非配置自動判 FAIL）**：`corun_profile.sh` 維持 10s 滑動視窗，**只有 RAM used 連續 > 6.5GB 達 ≥10s** 才 emit `OOM-RISK ABORT` 並停止 sample loop（**不殺 stack**，由 Roy 決定清場）。瞬時觸頂（touch 6.6GB 一次後回落 < 6.5GB）只記 WARNING、不 abort。parser `oom_verdict` 以同一 sustained 規則重判：spike → WARNING、sustained → ABORT、全清 → OK。
+
+---
+
+## §11.1 — 4-branch 決策樹（Q2 鎖定，本計畫核心交付）
+
+> **stable / unstable 精確定義**：一個配置 `stable` = §9.2 每一指標都是 PASS，或最多 WARNING 且零 FAIL；`unstable` = 任一指標 FAIL。FAIL 門檻直接引 §9.2，判讀者不得自行加減門檻。
+
+```
+量完 A/B/C（NO-MOTION）後，自上而下取第一個 match 的 branch：
+
+┌─ branch 4 "BRAIN-FIRST"：A（brain baseline）unstable
+│     觸發 = A 配置任一 §9.2 指標 FAIL（RAM used >6.5GB / 溫度 >80°C /
+│            brain topic（face/object/tts）任一 crash 或 Hz 偏離 >40%）。
+│     → 先修 brain demo，nav 完全不談。S1 退第三人稱 + Studio brain only，
+│       map/LiDAR 走影片/截圖。（A unstable 時 B/C 不必再判，直接此 branch。）
+│
+├─ branch 1 "C-CORESIDENT"：A stable 且 C（brain + full-nav-stack）stable
+│     觸發 = C 配置全指標 PASS。
+│     → S1 可避免換 stack（brain + nav 同跑）。
+│       ★ 仍不發 goto_relative ★ — map/LiDAR/pose 只當「視覺證據」。
+│       S1 形態交 plan6 決定 live 證據呈現。
+│
+├─ branch 2 "B-RESIDENT-LIDAR"：A stable、C unstable、B stable
+│     觸發 = C 任一指標 FAIL，但 B 全指標 PASS。
+│     → brain 駐留 + raw LiDAR/Foxglove 當視覺證據 + operator-assisted。
+│       不跑 nav2/amcl（省 RAM）。
+│
+└─ branch 3 "A-ONLY-VIDEO"：A stable、B 也 unstable
+      觸發 = B 任一指標 FAIL，但 A 全指標 PASS（或最多 WARNING）。
+      → S1 live = 第三人稱 + Studio brain only；map/LiDAR 走影片/截圖。
+```
+
+> **無論落哪個 branch，S1 都不啟 `goto_relative` 當主線**（nav NOT_DEMO_READY）。live-motion 選項（若有）= plan6 的 DriveOnHeading，且須 T0 fix + D1–D5 + θ_error<5° + e-stop + n=3，**不在本計畫**。
+
+---
+
+## S1 runtime layout 決策表（空白模板 — 待 T5 回填）
+
+> 待 T2–T4 真機 CSV 出來後填；每格話術須過 [claim-wording](2026-06-13-nav-618-claim-wording.md) S1–S8 / F1–F10 掃描（不得出現 autonomous navigation / 即時 SLAM / 動態繞障 / D435 已融合 / fallen / 2m 物體 / 可靠顏色 / 19 色）。數字須等於 CSV，不得自編。
+
+| 項目 | 內容（待填） |
+|------|--------------|
+| Branch 落點（1/2/3/4） | _（待 T5 + Roy 6/17 拍板）_ |
+| S1 runtime layout | _（待填）_ |
+| 對外可講話術（過 claim-wording） | _（待填）_ |
+| 引用的 CSV 數字（RAM / 溫度 / Hz） | _（待填，須 = CSV）_ |
+| Roy 6/17 彩排簽註 | _（待填）_ |
+
+---
+
+## 8GB 互斥事實表（空白模板 — 待 T4/T6 回填）
+
+> master plan §2.2「nav stack 與 brain demo stack 8GB 互斥（不能同跑）」由 C 配置量化驗證。下表待真機數據回填。
+
+| 配置 | RAM used 峰值 | headroom | 溫度峰值 | OOM verdict | D435 在線 | 判定 |
+|------|:------------:|:--------:|:--------:|:-----------:|:--------:|:----:|
+| A（brain-full） | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ |
+| B（brain + raw-LiDAR + Foxglove） | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ |
+| C（brain + full-nav-stack 同跑） | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ | _（待填）_ |
+
+---
+
+## Cold-start 成本 + 交接時間表（空白模板 — 待 T6 回填）
+
+> 量 `clean_full_demo.sh` → `start_full_demo_tmux.sh` 到 `/tts` 可發 / face 出圖 / ASR warmup done 的牆鐘時間；同量 nav stack stop→start 到 `/state/nav/heartbeat` 1Hz 的時間。推出 S1(nav)→S2(brain) 8GB 交接最短間隔（master open question：1 分鐘 gap 是否需旁白）。數字寫入 `runtime/profiling/2026-06-13-coldstart.csv`。
+
+| 量測項 | 牆鐘時間（待填） |
+|--------|:----------------:|
+| brain cold-start（clean → `/tts` 可發 + face 出圖 + ASR warmup done） | _（待填，s）_ |
+| nav cold-start（stop → `/state/nav/heartbeat` 1Hz） | _（待填，s）_ |
+| S1(nav) → S2(brain) 8GB 交接最短間隔 | _（待填，s）_ |
+| 交接是否需旁白解釋（master open question） | _（待填）_ |

--- a/scripts/corun_profile.sh
+++ b/scripts/corun_profile.sh
@@ -171,7 +171,7 @@ while [ "${elapsed}" -lt "${DURATION}" ]; do
   emit "SAMPLE config=${CONFIG} idx=${sample_idx} ts=${NOW_TS} ram_gb=${RAM_GB} gpu_pct=${GPU_PCT} temp_c=${TEMP_C}"
 
   # --- ps aux snapshot (count of profiled model processes, for the raw record) ---
-  PROC_COUNT="$(ps aux | grep -E '(realsense|face_identity|vision_perception|speech_processor|foxglove|object_perception|nav_capability|reactive_stop|sllidar|tts_node)' | grep -v grep | wc -l | tr -d ' ')"
+  PROC_COUNT="$( { ps aux | grep -E '(realsense|face_identity|vision_perception|speech_processor|foxglove|object_perception|nav_capability|reactive_stop|sllidar|tts_node)' | grep -v grep || true; } | wc -l | tr -d ' ')"
   emit "PROC config=${CONFIG} idx=${sample_idx} proc_count=${PROC_COUNT}"
 
   # --- Node list snapshot ---

--- a/scripts/corun_profile.sh
+++ b/scripts/corun_profile.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# corun_profile.sh — plan1 T1 co-run profiling orchestrator (NO-MOTION).
+#
+# Runs N sample intervals over --duration. Each interval captures a Jetson
+# resource snapshot (RAM via `free -h`, GPU load via /sys/devices/gpu.0/load,
+# max thermal-zone temp, `ps aux`) plus a `ros2 topic hz` window for each topic
+# in scripts/corun_topics.txt that matches the chosen config. One raw,
+# parseable line per metric is appended to runtime/profiling/2026-06-13-config<X>.log.
+#
+# This is a READ-ONLY attach: it does not start/stop/modify any demo stack.
+# It emits ZERO motion commands. Parsing + PASS/WARNING/FAIL judgement lives in
+# corun_profile_parse.py (stdlib-only).
+#
+# OOM brake: if RAM used stays > 6.5 GB sustained for >= 10s (sliding window over
+# the recent samples, NOT a single instantaneous spike), emit "OOM-RISK ABORT"
+# and break the sample loop. It does NOT kill the stack — Roy decides clean-up.
+#
+# Usage:
+#   bash scripts/corun_profile.sh --config A|B|C --duration <seconds> --interval <seconds>
+#
+# Run via `bash` (no zsh assumptions).
+set -euo pipefail
+
+# ── Resolve script + repo paths ─────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TOPICS_FILE="${SCRIPT_DIR}/corun_topics.txt"
+OUT_DIR="${REPO_ROOT}/runtime/profiling"
+
+# ── Defaults ────────────────────────────────────────────────────────────────
+CONFIG=""
+DURATION=300
+INTERVAL=15
+HZ_WINDOW=6           # seconds per `ros2 topic hz` sample window
+RAM_FAIL_GB="6.5"     # OOM-risk threshold (jetson-status: critical > 6.5 GB of 7.4)
+OOM_SUSTAIN_S=10      # sustained-over seconds required before ABORT
+
+# ── Arg parsing ─────────────────────────────────────────────────────────────
+usage() {
+  echo "Usage: bash scripts/corun_profile.sh --config A|B|C --duration <s> --interval <s>" >&2
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --config)
+      CONFIG="${2:-}"; shift 2 ;;
+    --duration)
+      DURATION="${2:-}"; shift 2 ;;
+    --interval)
+      INTERVAL="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+  esac
+done
+
+case "${CONFIG}" in
+  A|B|C) ;;
+  *) echo "ERROR: --config must be one of A|B|C (got '${CONFIG}')" >&2; usage; exit 2 ;;
+esac
+
+if ! [ -f "${TOPICS_FILE}" ]; then
+  echo "ERROR: topics file not found: ${TOPICS_FILE}" >&2; exit 1
+fi
+
+mkdir -p "${OUT_DIR}"
+LOG_FILE="${OUT_DIR}/2026-06-13-config${CONFIG}.log"
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+# Emit a raw line to both the log file and stdout (key=value, pipe-separated).
+emit() {
+  local line="$1"
+  echo "${line}" | tee -a "${LOG_FILE}"
+}
+
+# RAM used in GB (one decimal) parsed from `free` (KiB → GB).
+read_ram_used_gb() {
+  free | awk '/^Mem:/ { printf "%.1f", $3/1024/1024 }'
+}
+
+# GPU load percent: raw /10 (e.g. 910 -> 91.0). N/A if file missing.
+read_gpu_load_pct() {
+  if [ -r /sys/devices/gpu.0/load ]; then
+    awk '{ printf "%.1f", $1/10 }' /sys/devices/gpu.0/load
+  else
+    echo "NA"
+  fi
+}
+
+# Max temperature across all thermal zones in °C (raw /1000).
+read_max_temp_c() {
+  local max=""
+  local f
+  for f in /sys/devices/virtual/thermal/thermal_zone*/temp; do
+    [ -r "${f}" ] || continue
+    local raw
+    raw="$(cat "${f}" 2>/dev/null || echo "")"
+    [ -n "${raw}" ] || continue
+    if [ -z "${max}" ] || [ "${raw}" -gt "${max}" ] 2>/dev/null; then
+      max="${raw}"
+    fi
+  done
+  if [ -z "${max}" ]; then
+    echo "NA"
+  else
+    awk -v r="${max}" 'BEGIN { printf "%.1f", r/1000 }'
+  fi
+}
+
+# Parse the mean Hz out of `ros2 topic hz` output (the "average rate:" line).
+parse_hz_from_output() {
+  # reads stdin; prints a numeric mean or "NA"
+  awk '
+    /average rate:/ { val=$3 }
+    END { if (val == "") print "NA"; else print val }
+  '
+}
+
+# Capture one topic Hz sample (bounded by timeout; never blocks the loop).
+sample_topic_hz() {
+  local topic="$1"
+  local out
+  out="$(timeout "${HZ_WINDOW}" ros2 topic hz "${topic}" 2>/dev/null || true)"
+  printf '%s' "${out}" | parse_hz_from_output
+}
+
+# Snapshot the active ROS2 node list as a comma-joined single field.
+snapshot_node_list() {
+  local nodes
+  nodes="$(ros2 node list 2>/dev/null | sort | tr '\n' ',' || true)"
+  if [ -z "${nodes}" ]; then
+    echo "NA"
+  else
+    echo "${nodes%,}"
+  fi
+}
+
+# Float comparison: returns 0 (true) if $1 > $2.
+gt() {
+  awk -v a="$1" -v b="$2" 'BEGIN { exit !(a > b) }'
+}
+
+# ── Header ──────────────────────────────────────────────────────────────────
+RUN_TS="$(date +%Y-%m-%dT%H:%M:%S)"
+emit "RUN config=${CONFIG} start_ts=${RUN_TS} duration=${DURATION} interval=${INTERVAL} hz_window=${HZ_WINDOW}"
+
+# Baseline node list (snapshot 0) — parser uses this to detect later crashes.
+BASELINE_NODES="$(snapshot_node_list)"
+emit "BASELINE_NODES config=${CONFIG} nodes=${BASELINE_NODES}"
+
+# ── Sliding window for sustained-OOM detection ──────────────────────────────
+# Track recent (timestamp,ram_gb) samples; ABORT only if every sample inside the
+# last OOM_SUSTAIN_S seconds is above RAM_FAIL_GB. A lone spike that falls back
+# below the threshold breaks the streak and does NOT abort.
+declare -a OOM_TS=()
+declare -a OOM_RAM=()
+
+elapsed=0
+sample_idx=0
+
+while [ "${elapsed}" -lt "${DURATION}" ]; do
+  NOW_EPOCH="$(date +%s)"
+  NOW_TS="$(date +%H:%M:%S)"
+
+  # --- Resource snapshot ---
+  RAM_GB="$(read_ram_used_gb)"
+  GPU_PCT="$(read_gpu_load_pct)"
+  TEMP_C="$(read_max_temp_c)"
+  emit "SAMPLE config=${CONFIG} idx=${sample_idx} ts=${NOW_TS} ram_gb=${RAM_GB} gpu_pct=${GPU_PCT} temp_c=${TEMP_C}"
+
+  # --- ps aux snapshot (count of profiled model processes, for the raw record) ---
+  PROC_COUNT="$(ps aux | grep -E '(realsense|face_identity|vision_perception|speech_processor|foxglove|object_perception|nav_capability|reactive_stop|sllidar|tts_node)' | grep -v grep | wc -l | tr -d ' ')"
+  emit "PROC config=${CONFIG} idx=${sample_idx} proc_count=${PROC_COUNT}"
+
+  # --- Node list snapshot ---
+  NODE_LIST="$(snapshot_node_list)"
+  emit "NODES config=${CONFIG} idx=${sample_idx} nodes=${NODE_LIST}"
+
+  # --- Per-topic Hz (only topics whose config column contains this CONFIG) ---
+  while IFS=',' read -r topic expected_hz configs || [ -n "${topic}" ]; do
+    case "${topic}" in
+      ''|'#'*) continue ;;
+    esac
+    case "${configs}" in
+      *"${CONFIG}"*) ;;
+      *) continue ;;
+    esac
+    HZ="$(sample_topic_hz "${topic}")"
+    emit "HZ config=${CONFIG} idx=${sample_idx} topic=${topic} expected=${expected_hz} hz=${HZ}"
+  done < "${TOPICS_FILE}"
+
+  # --- Sustained-OOM sliding window ---
+  OOM_TS+=("${NOW_EPOCH}")
+  OOM_RAM+=("${RAM_GB}")
+  # Drop entries older than OOM_SUSTAIN_S seconds.
+  WINDOW_START=$(( NOW_EPOCH - OOM_SUSTAIN_S ))
+  declare -a NEW_TS=()
+  declare -a NEW_RAM=()
+  i=0
+  while [ "${i}" -lt "${#OOM_TS[@]}" ]; do
+    if [ "${OOM_TS[$i]}" -ge "${WINDOW_START}" ]; then
+      NEW_TS+=("${OOM_TS[$i]}")
+      NEW_RAM+=("${OOM_RAM[$i]}")
+    fi
+    i=$(( i + 1 ))
+  done
+  OOM_TS=("${NEW_TS[@]}")
+  OOM_RAM=("${NEW_RAM[@]}")
+
+  # ABORT only if the window truly spans >= OOM_SUSTAIN_S AND every sample in it
+  # is above RAM_FAIL_GB (so a single spike that fell back cannot trigger it).
+  WINDOW_SPAN=$(( NOW_EPOCH - OOM_TS[0] ))
+  if [ "${WINDOW_SPAN}" -ge "${OOM_SUSTAIN_S}" ] && [ "${#OOM_RAM[@]}" -ge 2 ]; then
+    all_over=1
+    j=0
+    while [ "${j}" -lt "${#OOM_RAM[@]}" ]; do
+      if ! gt "${OOM_RAM[$j]}" "${RAM_FAIL_GB}"; then
+        all_over=0
+        break
+      fi
+      j=$(( j + 1 ))
+    done
+    if [ "${all_over}" -eq 1 ]; then
+      emit "OOM-RISK ABORT config=${CONFIG} idx=${sample_idx} ram_gb=${RAM_GB} sustained_s=${WINDOW_SPAN} note=stack-NOT-killed"
+      break
+    fi
+  fi
+
+  sample_idx=$(( sample_idx + 1 ))
+  sleep "${INTERVAL}"
+  elapsed=$(( elapsed + INTERVAL ))
+done
+
+emit "RUN_END config=${CONFIG} samples=${sample_idx} end_ts=$(date +%Y-%m-%dT%H:%M:%S)"
+echo "Profiling log written to: ${LOG_FILE}"

--- a/scripts/corun_profile_parse.py
+++ b/scripts/corun_profile_parse.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""corun_profile_parse.py — plan1 T1 co-run profiling parser (stdlib-only).
+
+Reads a raw profiling log produced by corun_profile.sh, parses the
+RAM / temperature / GPU-load / per-topic-Hz / node-list time series, applies the
+plan1 §9.2 PASS / WARNING / FAIL thresholds, writes a per-metric CSV
+(runtime/profiling/2026-06-13-config<X>.csv) and prints a per-metric verdict plus
+the overall config stable / unstable judgement to stdout.
+
+STDLIB ONLY. Importing supervision / cv2 / torch / numpy is forbidden here — this
+keeps the parser CI-safe and off the Jetson runtime (master B-4 iron rule).
+
+The OOM-risk abort decision is a *sustained* check, mirroring corun_profile.sh:
+a single RAM spike above the threshold yields WARNING; only RAM used staying
+above the OOM threshold for >= the sustained window (default 10s) is an ABORT.
+
+NO-MOTION: this parser reads /state/nav/* topic Hz only; it never emits any
+motion command.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import re
+import sys
+
+# ── §9.2 thresholds (jetson-status budget) ──────────────────────────────────
+RAM_PASS_GB = 5.5          # used < 5.5 GB -> PASS
+RAM_WARN_GB = 6.5          # 5.5-6.5 GB -> WARNING; > 6.5 GB -> FAIL (OOM-risk)
+RAM_TOTAL_GB = 7.4         # for headroom derivation
+HEADROOM_PASS_GB = 1.9     # headroom >= 1.9 GB -> PASS
+HEADROOM_FAIL_GB = 0.8     # headroom < 0.8 GB -> FAIL (0.9-1.9 -> WARNING)
+GPU_PASS_PCT = 95.0        # < 95% PASS; 95-99% WARNING; 100% FAIL (throttle)
+GPU_FAIL_PCT = 100.0
+TEMP_PASS_C = 65.0         # < 65 PASS; 65-80 WARNING; > 80 FAIL
+TEMP_FAIL_C = 80.0
+HZ_PASS_BAND = 0.20        # within +-20% of expected -> PASS
+HZ_WARN_BAND = 0.40        # +-20-40% -> WARNING; > 40% off or 0 -> FAIL
+
+# OOM-risk abort: sustained, not instantaneous.
+OOM_THRESHOLD_GB = 6.5
+OOM_SUSTAIN_S = 10
+
+PASS = "PASS"
+WARNING = "WARNING"
+FAIL = "FAIL"
+
+# ── Log line patterns ───────────────────────────────────────────────────────
+_RE_KV = re.compile(r"(\w+)=(\S+)")
+
+
+def _parse_kv(line: str) -> dict:
+    """Parse key=value tokens out of a raw log line into a dict."""
+    return dict(_RE_KV.findall(line))
+
+
+def parse_ram_used_gb_from_free(free_text: str) -> float:
+    """Parse used RAM (GB) from a `free` block.
+
+    Accepts either `free` (KiB) or `free -h` (human, e.g. '5.0Gi') output. The
+    'Mem:' row's *used* column (3rd numeric/size field) is returned in GB.
+    """
+    for raw in free_text.splitlines():
+        line = raw.strip()
+        if not line.startswith("Mem:"):
+            continue
+        fields = line.split()[1:]  # drop the 'Mem:' label
+        if len(fields) < 2:
+            continue
+        used = fields[1]  # total, used, free, ...
+        return _size_to_gb(used)
+    raise ValueError("no 'Mem:' row found in free block")
+
+
+def _size_to_gb(token: str) -> float:
+    """Convert a `free`/`free -h` size token to GB.
+
+    Plain integers are treated as KiB (raw `free`); human suffixes
+    (Ki/Mi/Gi/Ti, with or without trailing 'B') are scaled accordingly.
+    """
+    t = token.strip()
+    m = re.match(r"^([0-9]+(?:\.[0-9]+)?)\s*([KMGTkmgt]i?)?B?$", t)
+    if not m:
+        raise ValueError(f"unparseable size token: {token!r}")
+    value = float(m.group(1))
+    unit = (m.group(2) or "").lower().rstrip("i")
+    if unit == "":
+        # bare number from raw `free` -> KiB
+        return value / 1024.0 / 1024.0
+    if unit == "k":
+        return value / 1024.0 / 1024.0
+    if unit == "m":
+        return value / 1024.0
+    if unit == "g":
+        return value
+    if unit == "t":
+        return value * 1024.0
+    raise ValueError(f"unknown size unit in token: {token!r}")
+
+
+def parse_max_temp_c(thermal_text: str) -> float:
+    """Parse the max temperature (°C) across thermal_zone*/temp values.
+
+    Accepts a block of raw milli-°C integers (one per line, as cat'd from
+    /sys/.../thermal_zone*/temp). Returns the max in °C.
+    """
+    temps = []
+    for raw in thermal_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        # tolerate "thermal_zoneN: 52000" or bare "52000"
+        m = re.search(r"(\d+)\s*$", line)
+        if not m:
+            continue
+        temps.append(int(m.group(1)) / 1000.0)
+    if not temps:
+        raise ValueError("no temperatures found in thermal block")
+    return max(temps)
+
+
+def parse_gpu_load_pct(load_text: str) -> float:
+    """Parse GPU load percent from /sys/devices/gpu.0/load (raw / 10).
+
+    e.g. '910' -> 91.0.
+    """
+    t = load_text.strip()
+    if not t:
+        raise ValueError("empty GPU load text")
+    raw = int(t.split()[0])
+    return raw / 10.0
+
+
+# ── §9.2 per-metric band judgements ─────────────────────────────────────────
+def judge_ram(used_gb: float) -> str:
+    if used_gb < RAM_PASS_GB:
+        return PASS
+    if used_gb <= RAM_WARN_GB:
+        return WARNING
+    return FAIL
+
+
+def judge_headroom(used_gb: float) -> str:
+    headroom = RAM_TOTAL_GB - used_gb
+    if headroom >= HEADROOM_PASS_GB:
+        return PASS
+    if headroom >= HEADROOM_FAIL_GB:
+        return WARNING
+    return FAIL
+
+
+def judge_gpu(load_pct: float) -> str:
+    if load_pct < GPU_PASS_PCT:
+        return PASS
+    if load_pct < GPU_FAIL_PCT:
+        return WARNING
+    return FAIL
+
+
+def judge_temp(temp_c: float) -> str:
+    if temp_c < TEMP_PASS_C:
+        return PASS
+    if temp_c <= TEMP_FAIL_C:
+        return WARNING
+    return FAIL
+
+
+def judge_topic_hz(measured_hz, expected_hz) -> str:
+    """Judge a measured topic Hz against the expected centre value (§9.2 band).
+
+    `expected_hz` may be a float, an "~N" hint, "evt", or None. Event-driven /
+    on-demand topics ("evt", "evt"/"on-demand") are not Hz-graded -> PASS when a
+    measurement exists, FAIL only when nothing was seen at all.
+    """
+    if _is_event_topic(expected_hz):
+        # event/on-demand: presence is the signal, not a rate band.
+        if measured_hz is None:
+            return FAIL
+        return PASS
+    exp = _coerce_hz(expected_hz)
+    if exp is None:
+        return WARNING  # expected unparseable -> can't grade strictly
+    if measured_hz is None or measured_hz == 0:
+        return FAIL
+    deviation = abs(measured_hz - exp) / exp
+    if deviation <= HZ_PASS_BAND:
+        return PASS
+    if deviation <= HZ_WARN_BAND:
+        return WARNING
+    return FAIL
+
+
+def _is_event_topic(expected) -> bool:
+    if expected is None:
+        return False
+    s = str(expected).strip().lower()
+    return s in ("evt", "event", "on-demand", "ondemand")
+
+
+def _coerce_hz(expected):
+    """Coerce an expected-Hz token ('10', '~10', float) to a float, else None."""
+    if expected is None:
+        return None
+    if isinstance(expected, (int, float)):
+        return float(expected)
+    s = str(expected).strip().lstrip("~")
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def judge_node_crash(baseline_nodes, observed_nodes) -> str:
+    """FAIL if any baseline node is missing from the observed set."""
+    missing = set(baseline_nodes) - set(observed_nodes)
+    if missing:
+        return FAIL
+    return PASS
+
+
+def oom_verdict(samples) -> str:
+    """Classify RAM time series for OOM-risk.
+
+    `samples` is a list of (epoch_seconds, ram_gb). Returns:
+      - "ABORT"   if RAM stayed > OOM_THRESHOLD_GB sustained for >= OOM_SUSTAIN_S
+      - "WARNING" if it touched > OOM_THRESHOLD_GB at least once (a spike) but
+                  never sustained
+      - "OK"      otherwise
+
+    A lone spike that falls back below the threshold is WARNING, not ABORT.
+    """
+    over = [(t, r) for (t, r) in samples if r > OOM_THRESHOLD_GB]
+    if not over:
+        return "OK"
+    # Find the longest run of consecutive over-threshold samples and check that
+    # the run spans >= OOM_SUSTAIN_S seconds.
+    longest_span = 0
+    run_start_t = None
+    prev_idx = None
+    for idx, (t, r) in enumerate(samples):
+        if r > OOM_THRESHOLD_GB:
+            if run_start_t is None:
+                run_start_t = t
+            span = t - run_start_t
+            if span > longest_span:
+                longest_span = span
+            prev_idx = idx
+        else:
+            run_start_t = None
+            prev_idx = idx
+    _ = prev_idx  # silence linters; index retained for clarity
+    if longest_span >= OOM_SUSTAIN_S:
+        return "ABORT"
+    return "WARNING"
+
+
+# ── Log parsing ─────────────────────────────────────────────────────────────
+def parse_log(text: str) -> dict:
+    """Parse a corun_profile.sh log into structured series.
+
+    Returns a dict with keys:
+      config, baseline_nodes (list), samples (list of dicts), oom_abort_seen.
+    Each sample dict: idx, ram_gb, gpu_pct, temp_c, nodes (list), hz (dict).
+    """
+    config = None
+    baseline_nodes = []
+    samples_by_idx = {}
+    oom_abort_seen = False
+
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        kind = line.split(None, 1)[0]
+        kv = _parse_kv(line)
+
+        if kind == "RUN":
+            config = kv.get("config", config)
+        elif kind == "BASELINE_NODES":
+            baseline_nodes = _split_nodes(kv.get("nodes", ""))
+            config = kv.get("config", config)
+        elif kind == "SAMPLE":
+            idx = int(kv["idx"])
+            s = samples_by_idx.setdefault(idx, _blank_sample(idx))
+            s["ram_gb"] = _opt_float(kv.get("ram_gb"))
+            s["gpu_pct"] = _opt_float(kv.get("gpu_pct"))
+            s["temp_c"] = _opt_float(kv.get("temp_c"))
+            s["ts"] = kv.get("ts")
+        elif kind == "NODES":
+            idx = int(kv["idx"])
+            s = samples_by_idx.setdefault(idx, _blank_sample(idx))
+            s["nodes"] = _split_nodes(kv.get("nodes", ""))
+        elif kind == "HZ":
+            idx = int(kv["idx"])
+            s = samples_by_idx.setdefault(idx, _blank_sample(idx))
+            topic = kv.get("topic", "")
+            s["hz"][topic] = {
+                "expected": kv.get("expected"),
+                "measured": _opt_float(kv.get("hz")),
+            }
+        elif kind == "OOM-RISK":
+            # line form: "OOM-RISK ABORT config=... idx=..."
+            oom_abort_seen = True
+
+    samples = [samples_by_idx[i] for i in sorted(samples_by_idx)]
+    return {
+        "config": config,
+        "baseline_nodes": baseline_nodes,
+        "samples": samples,
+        "oom_abort_seen": oom_abort_seen,
+    }
+
+
+def _blank_sample(idx: int) -> dict:
+    return {
+        "idx": idx,
+        "ts": None,
+        "ram_gb": None,
+        "gpu_pct": None,
+        "temp_c": None,
+        "nodes": [],
+        "hz": {},
+    }
+
+
+def _split_nodes(s: str):
+    if not s or s == "NA":
+        return []
+    return [n for n in s.split(",") if n]
+
+
+def _opt_float(token):
+    if token is None or token == "NA":
+        return None
+    try:
+        return float(token)
+    except (TypeError, ValueError):
+        return None
+
+
+# ── Aggregation + verdict ───────────────────────────────────────────────────
+def _worst(verdicts) -> str:
+    """Reduce a list of verdicts to the worst (FAIL > WARNING > PASS)."""
+    order = {PASS: 0, WARNING: 1, FAIL: 2}
+    worst = PASS
+    for v in verdicts:
+        if order.get(v, 0) > order[worst]:
+            worst = v
+    return worst
+
+
+def build_report(parsed: dict) -> dict:
+    """Turn parsed series into a per-metric verdict report + overall stable flag."""
+    samples = parsed["samples"]
+    baseline = parsed["baseline_nodes"]
+    rows = []
+
+    # RAM used: judge the sustained peak (max over the run).
+    ram_vals = [s["ram_gb"] for s in samples if s["ram_gb"] is not None]
+    if ram_vals:
+        peak_ram = max(ram_vals)
+        rows.append(("ram_used_gb", round(peak_ram, 2), judge_ram(peak_ram)))
+        rows.append(("ram_headroom_gb", round(RAM_TOTAL_GB - peak_ram, 2),
+                     judge_headroom(peak_ram)))
+
+    # GPU: judge the peak load.
+    gpu_vals = [s["gpu_pct"] for s in samples if s["gpu_pct"] is not None]
+    if gpu_vals:
+        peak_gpu = max(gpu_vals)
+        rows.append(("gpu_load_pct", round(peak_gpu, 1), judge_gpu(peak_gpu)))
+
+    # Temp: judge the peak temperature.
+    temp_vals = [s["temp_c"] for s in samples if s["temp_c"] is not None]
+    if temp_vals:
+        peak_temp = max(temp_vals)
+        rows.append(("temp_max_c", round(peak_temp, 1), judge_temp(peak_temp)))
+
+    # Per-topic Hz: judge the mean measured Hz against expected.
+    topic_means = _topic_means(samples)
+    for topic in sorted(topic_means):
+        info = topic_means[topic]
+        verdict = judge_topic_hz(info["mean"], info["expected"])
+        value = "evt" if _is_event_topic(info["expected"]) else (
+            round(info["mean"], 2) if info["mean"] is not None else "none")
+        rows.append((f"hz:{topic}", value, verdict))
+
+    # Node crash: any baseline node missing from any later sample -> FAIL.
+    crash_verdict = PASS
+    if baseline:
+        for s in samples:
+            if not s["nodes"]:
+                continue
+            if judge_node_crash(baseline, s["nodes"]) == FAIL:
+                crash_verdict = FAIL
+                break
+    rows.append(("node_crash", "ok" if crash_verdict == PASS else "missing-node",
+                 crash_verdict))
+
+    # OOM verdict (sustained-only). ABORT -> FAIL on the metric line.
+    ram_series = [(i, s["ram_gb"]) for i, s in enumerate(samples)
+                  if s["ram_gb"] is not None]
+    # Use epoch-like spacing of OOM_SUSTAIN_S-friendly seconds if timestamps
+    # are not available; here index*assumed-interval is not reliable, so prefer
+    # explicit (epoch, ram) when provided by oom_verdict callers in tests.
+    oom = oom_verdict([(t, r) for t, r in ram_series])
+    if parsed.get("oom_abort_seen"):
+        oom = "ABORT"
+    oom_metric_verdict = FAIL if oom == "ABORT" else (
+        WARNING if oom == "WARNING" else PASS)
+    rows.append(("oom_risk", oom, oom_metric_verdict))
+
+    overall = _worst([v for (_, _, v) in rows])
+    stable = overall != FAIL
+    return {
+        "config": parsed.get("config"),
+        "rows": rows,
+        "overall": overall,
+        "stable": stable,
+    }
+
+
+def _topic_means(samples) -> dict:
+    """Average each topic's measured Hz across samples, keeping the expected."""
+    acc = {}
+    for s in samples:
+        for topic, info in s["hz"].items():
+            entry = acc.setdefault(topic, {"vals": [], "expected": info.get("expected")})
+            if info.get("expected") is not None:
+                entry["expected"] = info.get("expected")
+            m = info.get("measured")
+            if m is not None:
+                entry["vals"].append(m)
+    out = {}
+    for topic, entry in acc.items():
+        vals = entry["vals"]
+        out[topic] = {
+            "mean": (sum(vals) / len(vals)) if vals else None,
+            "expected": entry["expected"],
+        }
+    return out
+
+
+# ── CSV + stdout ────────────────────────────────────────────────────────────
+def write_csv(report: dict, csv_path: str) -> None:
+    os.makedirs(os.path.dirname(csv_path) or ".", exist_ok=True)
+    with open(csv_path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["metric", "value", "verdict"])
+        for metric, value, verdict in report["rows"]:
+            writer.writerow([metric, value, verdict])
+        writer.writerow(["__overall__", report["overall"],
+                         "stable" if report["stable"] else "unstable"])
+
+
+def print_report(report: dict) -> None:
+    print(f"=== Co-run profiling verdict: config {report['config']} ===")
+    for metric, value, verdict in report["rows"]:
+        print(f"  [{verdict:7s}] {metric:24s} = {value}")
+    state = "stable" if report["stable"] else "unstable"
+    print(f"--- Overall: {report['overall']} -> config {report['config']} is {state} ---")
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────────
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Parse a corun_profile.sh log and apply §9.2 thresholds.")
+    parser.add_argument("--config", required=True,
+                        help="Config label (A|B|C); required to avoid mixing results.")
+    parser.add_argument("--log", help="Path to the raw profiling log "
+                        "(default: runtime/profiling/2026-06-13-config<X>.log).")
+    parser.add_argument("--csv", help="Output CSV path "
+                        "(default: runtime/profiling/2026-06-13-config<X>.csv).")
+    args = parser.parse_args(argv)
+
+    config = args.config.strip().upper()
+    if config not in ("A", "B", "C"):
+        print(f"ERROR: --config must be one of A|B|C (got {args.config!r})",
+              file=sys.stderr)
+        return 2
+
+    log_path = args.log or f"runtime/profiling/2026-06-13-config{config}.log"
+    csv_path = args.csv or f"runtime/profiling/2026-06-13-config{config}.csv"
+
+    if not os.path.isfile(log_path):
+        print(f"ERROR: log file not found: {log_path}", file=sys.stderr)
+        return 1
+
+    with open(log_path, "r") as fh:
+        text = fh.read()
+
+    parsed = parse_log(text)
+    parsed["config"] = parsed.get("config") or config
+    report = build_report(parsed)
+    report["config"] = config  # CLI label is authoritative
+    write_csv(report, csv_path)
+    print_report(report)
+    print(f"CSV written to: {csv_path}")
+    return 0 if report["stable"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/corun_topics.txt
+++ b/scripts/corun_topics.txt
@@ -1,0 +1,18 @@
+# Co-run profiling watch-topic list (plan1 T1, §9.1)
+# Format: topic,expected_hz,configs
+#   - topic       : ROS2 topic name (verbatim; verified against CLAUDE.md / nav monitor block)
+#   - expected_hz : numeric centre value, or "~N" hint, or "evt" for event-driven topics
+#   - configs     : which profiling configs watch this topic (subset of A/B/C, no separators)
+# NO-MOTION: this file lists only perception/state/health topics; zero motion topics.
+/state/perception/face,10,ABC
+/face_identity/debug_image,~7,ABC
+/perception/object/debug_image,~7,ABC
+/event/object_detected,evt,ABC
+/tts,evt,ABC
+/capability/depth_clear,5,ABC
+/vision_perception/status_image,8,ABC
+/scan_rplidar,~10,BC
+/state/nav/heartbeat,1,C
+/state/nav/status,10,C
+/state/nav/safety,10,C
+/capability/nav_ready,~1,C

--- a/scripts/test_corun_profile_parse.py
+++ b/scripts/test_corun_profile_parse.py
@@ -1,0 +1,157 @@
+"""test_corun_profile_parse.py — plan1 T1 parser unit tests (stdlib-only, ROS-free).
+
+Eight cases, all with inline fixtures; no hardware, no ROS, no heavy deps. Run:
+
+    cd /home/roy422/newLife/elder_and_dog && \
+        python3 -m pytest scripts/test_corun_profile_parse.py -v
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import corun_profile_parse as cpp  # noqa: E402
+
+
+# ── 1. RAM from free block ──────────────────────────────────────────────────
+def test_parse_ram_from_free_block():
+    # raw `free` (KiB): total, used, free, shared, buff/cache, available
+    free_text = (
+        "              total        used        free      shared  buff/cache   available\n"
+        "Mem:        7654321     5242880     1048576       12345      999999     2000000\n"
+        "Swap:             0           0           0\n"
+    )
+    used_gb = cpp.parse_ram_used_gb_from_free(free_text)
+    # 5242880 KiB / 1024 / 1024 = 5.0 GB
+    assert used_gb == pytest.approx(5.0, abs=0.01)
+
+
+# ── 2. Max temp across multiple thermal zones ───────────────────────────────
+def test_parse_temp_max():
+    thermal_text = (
+        "thermal_zone0: 48000\n"
+        "thermal_zone1: 66000\n"
+        "thermal_zone2: 52000\n"
+        "thermal_zone3: 61500\n"
+    )
+    assert cpp.parse_max_temp_c(thermal_text) == pytest.approx(66.0, abs=0.01)
+
+
+# ── 3. GPU load 910 -> 91.0 ─────────────────────────────────────────────────
+def test_parse_gpu_load():
+    assert cpp.parse_gpu_load_pct("910\n") == pytest.approx(91.0, abs=0.001)
+    assert cpp.parse_gpu_load_pct("0") == pytest.approx(0.0, abs=0.001)
+    assert cpp.parse_gpu_load_pct("1000") == pytest.approx(100.0, abs=0.001)
+
+
+# ── 4. RAM PASS/WARNING/FAIL bands ──────────────────────────────────────────
+def test_passfail_ram_headroom():
+    # 5.0 GB -> PASS (< 5.5)
+    assert cpp.judge_ram(5.0) == cpp.PASS
+    # 6.0 GB -> WARNING (5.5-6.5)
+    assert cpp.judge_ram(6.0) == cpp.WARNING
+    # 6.7 GB -> FAIL (> 6.5, OOM-risk)
+    assert cpp.judge_ram(6.7) == cpp.FAIL
+    # headroom: 7.4 - 6.7 = 0.7 GB < 0.8 -> FAIL
+    assert cpp.judge_headroom(6.7) == cpp.FAIL
+    # headroom: 7.4 - 5.0 = 2.4 GB >= 1.9 -> PASS
+    assert cpp.judge_headroom(5.0) == cpp.PASS
+
+
+# ── 5. OOM sustained-only (spike -> WARNING, sustained -> ABORT) ─────────────
+def test_oom_abort_sustained_only():
+    # A single 6.6 GB spike at t=30 that falls back -> WARNING, not ABORT.
+    spike_series = [
+        (0, 5.0), (15, 5.2), (30, 6.6), (45, 5.3), (60, 5.1),
+    ]
+    assert cpp.oom_verdict(spike_series) == "WARNING"
+
+    # Sustained > 6.5 GB across >= 10s (three consecutive 5s samples) -> ABORT.
+    sustained_series = [
+        (0, 5.0), (5, 6.6), (10, 6.7), (15, 6.8), (20, 5.0),
+    ]
+    assert cpp.oom_verdict(sustained_series) == "ABORT"
+
+    # All clear -> OK.
+    clear_series = [(0, 5.0), (15, 5.2), (30, 5.1)]
+    assert cpp.oom_verdict(clear_series) == "OK"
+
+
+# ── 6. Topic Hz band ────────────────────────────────────────────────────────
+def test_passfail_topic_hz_band():
+    # /scan_rplidar expected ~10; 9.6 is within +-20% -> PASS
+    assert cpp.judge_topic_hz(9.6, "~10") == cpp.PASS
+    # 3 Hz against ~10 is > 40% off -> FAIL
+    assert cpp.judge_topic_hz(3.0, "~10") == cpp.FAIL
+    # 7.5 against 10 is 25% off -> WARNING band
+    assert cpp.judge_topic_hz(7.5, "10") == cpp.WARNING
+    # event-driven topic: presence -> PASS, absence -> FAIL
+    assert cpp.judge_topic_hz(0.5, "evt") == cpp.PASS
+    assert cpp.judge_topic_hz(None, "evt") == cpp.FAIL
+    # zero measured on a rate topic -> FAIL
+    assert cpp.judge_topic_hz(0.0, "10") == cpp.FAIL
+
+
+# ── 7. Node crash detection ─────────────────────────────────────────────────
+def test_passfail_node_crash():
+    baseline = ["/brain_node", "/face_identity_node", "/object_perception_node",
+                "/tts_node"]
+    # all present -> PASS
+    observed_ok = ["/brain_node", "/face_identity_node",
+                   "/object_perception_node", "/tts_node", "/extra_node"]
+    assert cpp.judge_node_crash(baseline, observed_ok) == cpp.PASS
+    # object node missing -> FAIL
+    observed_crash = ["/brain_node", "/face_identity_node", "/tts_node"]
+    assert cpp.judge_node_crash(baseline, observed_crash) == cpp.FAIL
+
+
+# ── 8. Config label required ─────────────────────────────────────────────────
+def test_config_label_required():
+    # main() must reject a missing/invalid config label.
+    rc = cpp.main(["--config", "Z", "--log", "/nonexistent.log"])
+    assert rc == 2  # invalid label rejected before touching the log
+
+    # argparse enforces --config presence (SystemExit, not a clean return).
+    with pytest.raises(SystemExit):
+        cpp.main(["--log", "/nonexistent.log"])
+
+
+# ── Bonus: end-to-end parse_log + build_report on a synthetic log ────────────
+def test_parse_log_and_report_roundtrip(tmp_path):
+    log = (
+        "RUN config=A start_ts=2026-06-13T10:00:00 duration=30 interval=15 hz_window=6\n"
+        "BASELINE_NODES config=A nodes=/brain_node,/face_identity_node,/tts_node\n"
+        "SAMPLE config=A idx=0 ts=10:00:00 ram_gb=5.0 gpu_pct=42.0 temp_c=52.0\n"
+        "PROC config=A idx=0 proc_count=8\n"
+        "NODES config=A idx=0 nodes=/brain_node,/face_identity_node,/tts_node\n"
+        "HZ config=A idx=0 topic=/state/perception/face expected=10 hz=9.8\n"
+        "HZ config=A idx=0 topic=/tts expected=evt hz=NA\n"
+        "SAMPLE config=A idx=1 ts=10:00:15 ram_gb=5.1 gpu_pct=44.0 temp_c=53.0\n"
+        "NODES config=A idx=1 nodes=/brain_node,/face_identity_node,/tts_node\n"
+        "HZ config=A idx=1 topic=/state/perception/face expected=10 hz=10.1\n"
+        "HZ config=A idx=1 topic=/tts expected=evt hz=NA\n"
+        "RUN_END config=A samples=2 end_ts=2026-06-13T10:00:30\n"
+    )
+    parsed = cpp.parse_log(log)
+    assert parsed["config"] == "A"
+    assert parsed["baseline_nodes"] == [
+        "/brain_node", "/face_identity_node", "/tts_node"]
+    assert len(parsed["samples"]) == 2
+
+    report = cpp.build_report(parsed)
+    # face Hz ~10 -> PASS; tts evt without a measurement -> FAIL by presence rule
+    metrics = {m: v for (m, v, _) in report["rows"]}
+    verdicts = {m: vd for (m, _, vd) in report["rows"]}
+    assert verdicts["ram_used_gb"] == cpp.PASS
+    assert verdicts["hz:/state/perception/face"] == cpp.PASS
+    assert verdicts["hz:/tts"] == cpp.FAIL  # never observed in this fixture
+    assert "node_crash" in metrics
+
+    # CSV write works and is readable.
+    csv_path = tmp_path / "out.csv"
+    cpp.write_csv(report, str(csv_path))
+    content = csv_path.read_text()
+    assert "metric,value,verdict" in content
+    assert "__overall__" in content


### PR DESCRIPTION
**Lane:** corun-profiling | **Plan:** plan1 T1 (S1 runtime-layout profiling gate)

5 new files + 1 additive CI line; **zero edits to existing-file bodies** → byte-identical demo runtime.
- `scripts/corun_profile.sh` (bash; --config A|B|C; reads free/gpu÷10/temp÷1000/ps/ros2 topic hz; OOM brake = sustained >6.5GB ≥10s, does NOT kill stack), `corun_profile_parse.py` (stdlib-only), `corun_topics.txt`, `test_corun_profile_parse.py` (9 cases), procedure doc skeleton.
- CI: registered the parser test as Invocation 9 in `ros_build.yaml`.

**Tests:** 9 passed · `bash -n` OK · motion-grep EMPTY · YAML valid · pipefail `|| true` guard added (review nit).
**Rollback:** delete the 5 files + revert the CI line. **Adversarial review:** PASS_WITH_NITS (fixed).
**Honesty:** T1=unit-green; T2–T6 (real Jetson profiling) deferred-HITL, decision tables left empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)