### PR TITLE
docs+test(nav): plan6 no-motion S1 fallback/diagnostics SOPs + NS-V1 route_id case

### DIFF
--- a/docs/navigation/2026-06-13-initialpose-yaw-calibration-sop.md
+++ b/docs/navigation/2026-06-13-initialpose-yaw-calibration-sop.md
@@ -1,0 +1,99 @@
+# initialpose 朝向校正 + scan-overlay SOP（no-motion）
+
+> **日期**：2026-06-13　**狀態**：SOP（操作員流程，**零 Go2 motion**）
+> **task**：plan6 NS-5（[`docs/superpowers/plans/2026-06-13-plan6-navigation-safety-s1-fallback.md`](../superpowers/plans/2026-06-13-plan6-navigation-safety-s1-fallback.md) §6 NS-5）
+> **上游**：根因計畫 [`2026-06-13-nav-motion-incident-root-cause-plan.md`](2026-06-13-nav-motion-incident-root-cause-plan.md)、措辭 [`2026-06-13-nav-618-claim-wording.md`](2026-06-13-nav-618-claim-wording.md)、診斷集 [`2026-06-13-no-motion-diagnostics-sop.md`](2026-06-13-no-motion-diagnostics-sop.md)
+> **這份是什麼**：設 `/initialpose` 後，**人工**確認 Go2 在地圖上的朝向（yaw）對不對的 no-motion 操作流程。這是 [`nav-618-claim-wording.md`](2026-06-13-nav-618-claim-wording.md) §5 **fallback②（遙控 + Foxglove LiDAR 證據）** 的操作依據，也是任何未來 motion HITL（plan6 §8）的硬前置（θ_error<5°）。
+
+---
+
+## 0. 鐵則
+
+1. **本 SOP 全程零 Go2 motion**：設 initialpose、讀 TF、讀 covariance、Foxglove overlay 都是「定位 / 讀數」動作，**不發任何 goal / cmd_vel / Move / goto / DriveOnHeading**。Go2 站立不動。
+2. **θ_error 是 sanity hint，不是 auto-gate**：本流程算出的 θ_error 是給操作員人工判斷用，**不修改任何 covariance 門檻值**（0.30 / 0.50 / 0.20 硬鎖，不放寬）。靜態安全閘目前 yaw-blind（c[35] 不查），所以 yaw 對不對**只能靠這個人工流程**把關。
+3. **「設了 initialpose 且 nav_ready=true ≠ 朝向對 ≠ 可安全移動」**：position covariance 收斂不代表 yaw 收斂。任何 motion 仍需 Roy 明確授權 + e-stop + plan6 §8 HITL gate。
+4. e-stop 終端就位（`nav_capability/scripts/emergency_stop.py engage` 待命，不按）。
+
+---
+
+## S5-1 讀外參（確認 LiDAR 前向軸）
+
+```bash
+# base_link → laser 外參（v8 反裝 mount，期望 yaw≈π=3.14159）
+ros2 run tf2_ros tf2_echo base_link laser
+
+# reactive_stop 的前向補正（須 == π，且與上面 TF 一致）
+ros2 param get /reactive_stop_node front_offset_rad
+```
+
+- 期望：兩處 yaw 都 ≈ π。**`front_offset_rad` 與 TF yaw 是兩處獨立補正、必須一致**——不一致先停、修外參，不要繼續設 initialpose。
+
+---
+
+## S5-2 物理錨定（5/1 黃金標準；移動的是人，不是 Go2）
+
+```bash
+python3 scripts/lidar_front_sector.py --once
+```
+
+- **操作員站到 Go2 機鼻正前方約 0.5m**（移動的是操作員，Go2 不動）。
+- 讀 `nearest(±30°) @ 角度`：人在正前方 → 角度應落 **±180° bin**（反裝 mount，front_offset=π）。
+- **不對則停**：先修外參 / 反裝補正，**不准**進 S5-3。
+- 此工具對齊 reactive_stop_node 同款幾何（`compute_front_min_distance` + `front_offset_rad`），**直接用 `scripts/lidar_front_sector.py`，勿重建**。
+
+---
+
+## S5-3 Foxglove fixed frame 設定（scan-overlay 基礎）
+
+- **讀 scan（點雲 / LaserScan `/scan_rplidar`）→ fixed frame 用 `base_link`**（看相對機身的障礙幾何）。
+- **讀定位（map / amcl_pose / 路徑）→ fixed frame 用 `map`**（看 Go2 在地圖上的位置與朝向）。
+- scan-overlay 判讀：在 Foxglove 把 `/scan_rplidar` 疊在 `map` 上看點雲是否「貼合牆面」——點雲與地圖牆面有明顯角度偏移 = yaw 沒對齊（與 S5-4 的 θ_error 互為佐證）。**這是目視 sanity，不是自動 gate**。
+
+> scan-overlay 在 plan6 NS-1 是一個**預設 off 的可選軟體閘**（`enable_scan_overlay_gate=false`）；本 SOP 只描述**目視判讀**，不啟用任何自動閘。
+
+---
+
+## S5-4 設 initialpose 後讀朝向（核心校正）
+
+1. 在 Foxglove / RViz 用 **2D Pose Estimate** 設 `/initialpose`：對準 Go2 **真實位置 + 真實朝向**（朝向錯一截，goto「前方」就走歪——這是事件根因 R1）。
+2. 讀完整 covariance（**人工讀 c[35]**）：
+
+```bash
+ros2 topic echo /amcl_pose --once
+#   c[0]=σ²x  c[7]=σ²y（position）  c[35]=σ²yaw（朝向不確定度）
+#   c[35] 大 = 朝向沒收斂 → 不准發 goal。
+```
+
+3. 比現場真值算 `θ_error`：
+
+```bash
+ros2 run tf2_ros tf2_echo map base_link
+#   讀 rotation → 換算 AMCL 估的 yaw，跟現場 Go2 實際朝向（用地面標記/牆面為基準）比，得 θ_error。
+```
+
+---
+
+## S5-5 判定（人工 sanity，非 auto-gate）
+
+| θ_error | c[35] | 判定 | 動作 |
+|---|---|---|---|
+| `≤5°` | 收斂 | 朝向 OK | 可進 fallback②（遙控+Foxglove 證據）；motion HITL 仍需 Roy+e-stop |
+| `5–10°` | 任意 | 邊界 | **重設 initialpose**，重跑 S5-4；**不准發 goal** |
+| `>10°` | 任意 | 不合格 | **重設 initialpose**；先回 [診斷集 D2/D3](2026-06-13-no-motion-diagnostics-sop.md) 查外參；**不准發 goal** |
+
+- **`|θ_error|>5–10°` → 重設、不准發 goal**。這是 sanity hint（human-readable），**不是 auto-gate**——靜態閘目前不查 yaw（R5），所以這層人工把關是 yaw 唯一防線。
+- 本判定**不改任何 param / 門檻值**；只決定「操作員要不要重設 initialpose」。
+
+---
+
+## 對外措辭綁定（fallback② 用）
+
+- 本 SOP 校正完成後，S1 對外只講 [`nav-618-claim-wording.md`](2026-06-13-nav-618-claim-wording.md) §5 **fallback② 可講句**：S2（safe-stop，配 §3 標準說法）、S4（窄場安全錐）、S6（拒絕有理由）、加「nav 在 Studio/Foxglove 顯示即時感知環境（非寫死）」。
+- **禁講**（§4 F1-F10）：自主導航（F1 巡邏 / 整段）、動態繞障（F2）、D435 已融合（F3）、auto-resume（F4）、即時恢復（F10）、「聽懂過來就走到 Roy 身邊」（F6）。**「設了 initialpose、靜態檢查過」不可包裝成「可安全自主移動」**。
+
+---
+
+## 收尾
+
+- 本 SOP **不改任何 runtime / param / 門檻值 / URDF**——純操作流程，刪檔即回退。
+- 判讀結果（θ_error、c[35]、scan-overlay 目視）回填 plan6 Required Evidence。

--- a/docs/navigation/2026-06-13-no-motion-diagnostics-sop.md
+++ b/docs/navigation/2026-06-13-no-motion-diagnostics-sop.md
@@ -1,0 +1,165 @@
+# No-Motion 導航診斷 SOP（D2–D5）
+
+> **日期**：2026-06-13　**狀態**：SOP（READ-ONLY 診斷集，**零 Go2 motion**）
+> **task**：plan6 NS-D2（[`docs/superpowers/plans/2026-06-13-plan6-navigation-safety-s1-fallback.md`](../superpowers/plans/2026-06-13-plan6-navigation-safety-s1-fallback.md) §7）
+> **上游**：根因計畫 [`2026-06-13-nav-motion-incident-root-cause-plan.md`](2026-06-13-nav-motion-incident-root-cause-plan.md)、runbook [`2026-06-13-nav-incident-runbook.md`](2026-06-13-nav-incident-runbook.md)、措辭 [`2026-06-13-nav-618-claim-wording.md`](2026-06-13-nav-618-claim-wording.md)
+> **這份是什麼**：把 goto 撞牆事件的 no-motion 根因診斷（D2 AMCL yaw / D3 LiDAR 前向軸 / D4 reactive 側向幾何 / D5 靜態 smoke + covariance）寫成**可直接貼上終端**的唯讀指令集。**每一條都是讀取 / echo / param get，不發任何 cmd_vel / Move / goto / 任何 Go2 motion。**
+
+---
+
+## 0. 鐵則（先讀，違反即停）
+
+1. **本 SOP 全程零 motion**：只允許 `echo` / `tf2_echo` / `param get` / `topic hz` / 移動「障礙物」（不是移動 Go2）。**不准** `ros2 topic pub /goal_pose`、`ros2 action send_goal /nav/goto_relative`、`ros2 action send_goal /nav/drive_on_heading`、`cmd_vel`、`Move(1008)`、`DriveOnHeading`。
+2. Go2 全程**站立不動、e-stop 終端就位**（`nav_capability/scripts/emergency_stop.py engage` 待命）。
+3. `front_arc_deg` / `danger_distance_m` / `slow_distance_m` / `front_offset_rad` 只在 `reactive_stop_node.__init__` 讀一次 → **`ros2 param set` 改了無效**，要改 profile 必 **kill 重啟帶參數**（這是讀數會「對不上你以為的設定」的常見坑）。本 SOP 只 **`param get`** 不 set。
+4. **「靜態 smoke 8/8 通過 ≠ 朝向對 ≠ 可安全移動」**——D5 過了不代表 goto 安全（這正是事件根因之一：靜態閘 yaw-blind，見 D2 c[35] 段）。任何 motion 仍需 Roy 明確授權 + e-stop + plan6 §8 HITL gate。
+5. Jetson 用 zsh：`source` 用 `setup.zsh`；陣列參數加單引號（zsh glob 會炸）。所有指令在 `ros2 node list` 看得到 nav stack 在跑的前提下執行。
+
+---
+
+## 前置：確認環境（唯讀）
+
+```bash
+# 確認 nav stack 在跑、e-stop 待命
+ros2 node list                                    # 應見 amcl / nav_action_server / reactive_stop_node / go2_driver
+ros2 topic list | grep -E "amcl_pose|scan_rplidar|reactive_stop|nav_ready|depth_clear"
+# e-stop 終端另開一個（不要按 engage，只是就位）
+#   python3 nav_capability/scripts/emergency_stop.py engage   # ← 只在出事時才執行
+```
+
+---
+
+## D2 — AMCL yaw / covariance（治 R1 走歪 + R5 yaw-blind 閘）
+
+> 目的：證明 ① goto「前方」吃的是 AMCL map-frame yaw（yaw 錯 → 走歪）；② 靜態安全閘 `nav_ready` 只看 position covariance（c[0]+c[7]），**從不看 c[35]（σ²yaw）** → yaw 大錯時 `nav_ready` 仍可能 true（R5）。
+
+```bash
+# D2-1 讀完整 AMCL covariance（6x6 row-major 攤平成 36 個值）
+ros2 topic echo /amcl_pose --once
+#   讀法（唯讀，人工對照）：
+#     c[0]  = σ²x          ← position
+#     c[7]  = σ²y          ← position（nav_ready 只用 c[0]+c[7]）
+#     c[35] = σ²yaw        ← 朝向不確定度（靜態閘從不查 → R5 的證據）
+#   c[0]/c[7] 小但 c[35] 大 = 位置收斂、朝向沒收斂 → 仍可能被判 nav_ready=true。
+
+# D2-2 AMCL 估的朝向 vs 現場真值
+ros2 run tf2_ros tf2_echo map base_link
+#   讀 rotation → 換算 yaw，跟現場 Go2 實際朝向比，估 θ_error。
+
+# D2-3 yaw 大錯時 nav_ready 是否仍 true（R5 直接實證）
+ros2 topic echo /capability/nav_ready --once
+#   若 D2-2 顯示 θ_error 很大、但這裡仍 nav_ready=true → R5 yaw-blind 閘成立。
+```
+
+**covariance 收斂曲線（含 yaw 維度）**：靜止下用 covariance probe 看 c[0]+c[7] 與 c[35] 隨時間收斂（NS-4 產出 `scripts/nav_covariance_probe.py` 後）：
+
+```bash
+python3 scripts/nav_covariance_probe.py        # 訂 /amcl_pose，輸出 CSV: time, cov_xy, cov_yaw
+```
+
+> **黃帶決策表（含 yaw；NS-4 probe 上線後回填實測門檻；門檻值零變動原則：position 0.30/0.50 硬鎖，不放寬）**：
+>
+> | cov_xy | cov_yaw (c[35]) | 判讀 | 動作（皆 no-motion 或 needs_roy） |
+> |---|---|---|---|
+> | 低（收斂） | 低（收斂） | 位置 + 朝向都穩 | 可進 motion HITL gate（仍需 Roy + e-stop，plan6 §8） |
+> | 低 | 高（未收斂） | 位置穩、**朝向沒收斂** | **不發 goal**；重設 initialpose 朝向（[initialpose SOP](2026-06-13-initialpose-yaw-calibration-sop.md)） |
+> | 高 | 任意 | 位置未收斂 | 等收斂 / 重設 initialpose；**不發 goal** |
+>
+> **覆蓋率與 AMCL warmup**：靜止 AMCL 不一定靠自己收斂；plan6 把「該推 Go2 0.3m warmup」列為 **needs_roy + e-stop 的 HITL 選項**，非本 SOP 動作。
+
+---
+
+## D3 — LiDAR 前向軸 / 反裝 yaw=π（治 R6 外參 + reactive 沉默）
+
+> 目的：確認 ① base_link→laser 外參 yaw≈π（v8 反裝 mount）；② reactive_stop 的 `front_offset_rad` 與該 TF yaw **必須一致**（兩處獨立補正）；③ 物理錨定（人站機鼻）落在預期 bin。
+
+```bash
+# D3-1 外參 TF（期望 yaw≈π = 3.14159）
+ros2 run tf2_ros tf2_echo base_link laser
+
+# D3-2 reactive_stop 的前向補正（須 == π，與 D3-1 一致）
+ros2 param get /reactive_stop_node front_offset_rad
+
+# D3-3 物理錨定（零 Go2 motion；操作員「站到」Go2 機鼻前 0.5m，移動的是人不是狗）
+python3 scripts/lidar_front_sector.py --once
+#   讀 nearest(±30°) @ 角度：人在正前方 → 角度應落 ±180°（反裝 mount，front_offset=π）。
+#   若不落 ±180° → 外參/反裝補正不一致，先修 TF/param，再做任何 motion。
+#   （此工具對齊 reactive_stop_node 同款幾何 compute_front_min_distance + front_offset_rad，
+#    --front-offset-rad 預設 π；勿重建，直接用 scripts/lidar_front_sector.py。）
+
+# D3-4 scan 健康度（頻率 / 有效點 / NaN 比例）
+python3 scripts/scan_health_check.py
+ros2 topic hz /scan_rplidar                     # 預期穩定（< 2Hz 或抖動 = scan 不健康）
+```
+
+> **`front_offset_rad=π` 與 TF yaw=π 是雙重獨立補正、必須一致**（plan6 §2.6）。任一邊改 mount 角度，兩邊都要改。
+
+---
+
+## D4 — reactive 側向幾何（治 R3 側向沉默 / 誤擋）
+
+> 目的：① 讀現用 `front_arc_deg`（窄錐 vs 寬錐）；② 移動「障礙物」（不是 Go2）驗側前家具是否被誤算進前方危險；③ 確認 progressive 模式在 slow 帶會回 None（沉默）是預期行為，不是 bug。**全程 Go2 站立不動，只移箱子。**
+
+```bash
+# D4-1 現用前錐角度（open_space=30 / indoor_tight=18；param set 無效，只能 get）
+ros2 param get /reactive_stop_node front_arc_deg
+ros2 param get /reactive_stop_node danger_distance_m
+ros2 param get /reactive_stop_node slow_distance_m
+
+# D4-2 移箱到「側前角」+25° / 1.65m（移動的是箱子，Go2 不動）
+#   → 看 reactive 是否把 off-path 家具算進前方危險
+ros2 topic echo /state/reactive_stop/status
+#   open_space(±30°)：+25° 的箱子在錐內 → 可能 slow/active（這就是 6/8「前面明明空卻被擋」）
+#   indoor_tight(±18°)：+25° 的箱子在錐外 → 預期 zone=slow/clear、active=false（窄錐修正）
+
+# D4-3 scan 頻率（reactive 反應的上游）
+ros2 topic hz /scan_rplidar
+```
+
+> **窄錐（indoor_tight ±18°）必須綁低速 ≤0.2 m/s**（側向覆蓋變少，靠低速補反應時間，6/8 HITL）。改 profile 用 `REACTIVE_PROFILE=indoor_tight bash scripts/start_nav_capability_demo_tmux.sh`（kill 重啟），**不是** `ros2 param set`。
+> **progressive 模式在 slow 帶回 None（沉默）= 設計使然**（`lidar_geometry.py` progressive 在 slow 回 None）——本 SOP 只觀測、不改判定邏輯。
+
+---
+
+## D5 — 靜態 smoke + 動作/能力存在性（基線健檢；**過了≠朝向對≠可安全移動**）
+
+```bash
+# D5-1 靜態 smoke（8 項全靜態，零 motion）
+bash scripts/smoke_test_nav_static.sh
+#   ⚠ 8/8 PASS 只代表「nav stack 起來了、靜態介面在」，
+#     不代表朝向對、不代表可安全移動（靜態閘 yaw-blind，見 D2）。
+
+# D5-2 確認可用動作（觀測；不送 goal）
+ros2 action list | grep -E "goto_relative|drive_on_heading"
+#   goto_relative = NOT_DEMO_READY（R1 AMCL-yaw / R2 超衝），不是 S1 主線。
+
+# D5-3 depth_clear gate 狀態（D435 在線時的 fail-closed gate；非 costmap fusion）
+ros2 topic echo /capability/depth_clear --once
+#   D435 目前可能 Right MIPI / Hardware Error → depth_clear 可能 false/stale。
+#   這只是 Brain 層 fail-closed gate，D435 未進 Nav2 costmap（fusion = research-only spec）。
+```
+
+---
+
+## 判讀填表（dry-run 後逐條記錄）
+
+| 診斷 | 指令 | 觀測值 | 判讀 |
+|---|---|---|---|
+| D2-1 covariance | `echo /amcl_pose --once` | c[0]=__ c[7]=__ **c[35]=__** | position vs yaw 收斂？ |
+| D2-2 θ_error | `tf2_echo map base_link` | AMCL yaw=__ vs 現場=__ | θ_error≈__° |
+| D2-3 R5 實證 | `echo /capability/nav_ready --once` | nav_ready=__ | yaw 大錯時仍 true？ |
+| D3-1 外參 | `tf2_echo base_link laser` | yaw=__ | ≈π？ |
+| D3-2 補正 | `param get ... front_offset_rad` | __ | ==π 且 == D3-1？ |
+| D3-3 錨定 | `lidar_front_sector.py --once` | nearest @ __° | 落 ±180°？ |
+| D4-1 前錐 | `param get ... front_arc_deg` | __ | open_space/indoor_tight？ |
+| D4-2 側向 | 移箱 +25°/1.65m → `echo .../status` | zone=__ active=__ | 誤擋？ |
+| D5-1 smoke | `smoke_test_nav_static.sh` | __/8 | 過≠朝向對 |
+| D5-2 動作 | `ros2 action list \| grep ...` | __ | goto/drive_on_heading 存在？ |
+
+---
+
+## 收尾
+
+- 本 SOP **不改任何 runtime / param / URDF**。
+- 判讀結果（含原始 echo log）回填上表 + plan6 Required Evidence。
+- 任何進一步 motion 走 plan6 §8 HITL（needs_roy + e-stop + plan1 profiling gate）；S1 對外措辭一律綁 [`nav-618-claim-wording.md`](2026-06-13-nav-618-claim-wording.md) S1-S8 / F1-F10。

--- a/docs/navigation/2026-06-13-s1-fallback-decision.md
+++ b/docs/navigation/2026-06-13-s1-fallback-decision.md
@@ -1,0 +1,87 @@
+# S1（nav 段）三層 Fallback 決策 + Claim Wording 鎖定
+
+> **日期**：2026-06-13　**狀態**：DOC（決策草案；**S1 台詞最終版待 Roy 簽 D-1**，本檔用 LOCKED 佔位符）
+> **task**：plan6 NS-6（[`docs/superpowers/plans/2026-06-13-plan6-navigation-safety-s1-fallback.md`](../superpowers/plans/2026-06-13-plan6-navigation-safety-s1-fallback.md) §6 NS-6）
+> **權威措辭來源**：[`2026-06-13-nav-618-claim-wording.md`](2026-06-13-nav-618-claim-wording.md)（S1-S8 可講 / F1-F10 禁講）——本檔每一句宣稱都綁回該檔的編號。
+> **相關 SOP**：[診斷集 NS-D2](2026-06-13-no-motion-diagnostics-sop.md)、[initialpose 校正 NS-5](2026-06-13-initialpose-yaw-calibration-sop.md)。
+> **這份是什麼**：6/18 發表「s1_nav 這一幕」要**演什麼、講什麼、在什麼條件下退到哪一層**的決策。三層 fallback + 每層可講句綁 S1-S8、禁句綁 F1-F10。
+
+---
+
+## 0. 硬前提（先講清楚，避免 overclaim）
+
+1. **`goto_relative` = `NOT_DEMO_READY`，且不是 S1 live 主線。** 根因：R1（goto「前方」吃 AMCL map-frame yaw，yaw 錯就走歪）、R2（不 enforce max_speed → 0.5m goal 超衝到 1.04m）、T0（URDF 把 `map→odom`/`odom→base_link` 當 fixed joint 發 `/tf_static`，與 AMCL/driver 雙 authority 衝突）。**任何 S1 layer 都不依賴 `goto_relative`。**
+2. **`DriveOnHeading` / full nav motion = Roy-returns HITL 選項，不是 6/18 live 主線。** 只有在 plan6 §8 全前置過（T0 修好 + D1-D5 全綠 + θ_error<5° + e-stop + Roy 明確授權 + NS-H3 n=3 全達）才升級到 fallback① live；否則 S1 走 fallback② 或 ③。
+3. **S1 主線預設 = fallback②（遙控 + Foxglove LiDAR 證據）**；fallback③（純影片）永遠保底。
+4. **不可宣稱**（綁 [§4 F1-F10](2026-06-13-nav-618-claim-wording.md)）：自主導航 / 自由巡邏（F1）、動態繞障（F2）、D435+LiDAR 已融合（F3）、auto-resume / 自動續走（F4/F5）、「聽懂過來就走到 Roy 身邊」（F6）、未 n=3 重驗的「可靠導航」（F7）、1.0m+ 連續乾淨導航（F8）、即時恢復（F10）。**「靜態檢查通過 = 可安全移動」也不可講**（靜態閘 yaw-blind，R5）。
+
+---
+
+## 1. 三層 Fallback 決策表
+
+> 上場條件依 plan1 profiling（nav stack 能否與 brain 共存/分時）+ NS-H1→H3 HITL 結果；6/17 回穩日由 Roy 定 B-10。三層任一層都能交付 nav 段——**不存在「nav 整段開天窗」**。
+
+| 層 | 演什麼 | 上場條件 | 可講句（綁 S 編號） |
+|---|---|---|---|
+| **① live 短距（DriveOnHeading）** | 現場 live 跑短距 0.3-0.5m（**DriveOnHeading body-frame，不用 goto_relative**） | **全部**：T0 修好 + D1-D5 全綠 + θ_error<5° + e-stop 就位 + Roy 授權 + NS-H3 n=3 全達零撞零超衝 + plan1 profiling 允許 nav stack 共存/分時 | [S1](2026-06-13-nav-618-claim-wording.md)（標「單點」；**n=3 過才可加「可靠」**）、S2、S3 |
+| **② 遙控 + Foxglove LiDAR 證據**（**預設主線**） | 遙控 / Studio 輔助移動；Studio map + `/scan_rplidar` 點雲 + reactive zone 狀態作「邊緣端即時感知」證據 | live 不穩 / 場地不允許 / 任一 ① 前提未過 | [S2](2026-06-13-nav-618-claim-wording.md)（safe-stop，配 §3 標準說法）、S4（窄場安全錐 ±18°）、S6（拒絕有理由，T6-5 merged 後）+「nav 在 Studio/Foxglove 顯示即時感知環境（非寫死）」 |
+| **③ 純影片**（保底） | S1（nav 鏡）已錄影片，旁白用保守版 | live + 遙控都不上 | 影片旁白用 [S1-S5](2026-06-13-nav-618-claim-wording.md) 的**保守版**，明標「錄影」 |
+
+**鐵則**：① demo snapshot 影片是發表保底，任何 lane 不得使其失效；② covariance 門檻值零變動（0.30/0.50/0.20 硬鎖）。
+
+---
+
+## 2. S1 台詞 LOCKED 佔位符（Roy 未簽 D-1，**禁硬寫最終句**）
+
+> ⚠ **本節全部是佔位符**。最終 15 句 canned 台詞**待 Roy 簽核**（D-1），簽核前**不得**把任何一句當定稿寫進 demo 腳本 / executive.yaml / conductor。每個佔位符標明「綁哪個 S 編號 + 限制詞」，Roy 簽核時照 [§2 可講句表](2026-06-13-nav-618-claim-wording.md) 的限制詞填。
+
+| 佔位 ID | 用途 | 綁定 | 必含限制詞（不可省） | 句子 |
+|---|---|---|---|---|
+| `<S1_OPENING_LOCKED>` | 開場一句話定位 | [§1 一句話定位](2026-06-13-nav-618-claim-wording.md) | 「已知地圖 / 操作員下令 / 短距 / 遇障安全停」+「能力階梯誠實管理」 | **【LOCKED — 待 Roy D-1】** |
+| `<S1_MOVE_LOCKED>` | 短距移動旁白 | S1（C1/C2） | 「單點」；**未過 N3 不得加「可靠」** | **【LOCKED — 待 Roy D-1】** |
+| `<S1_SAFESTOP_LOCKED>` | safe-stop 說明 | S2（C4）+ [§3 標準說法](2026-06-13-nav-618-claim-wording.md) | 「偵測到障礙停下等待，不會繞行」；**明講 safe-stop 不是繞障** | **【LOCKED — 待 Roy D-1】** |
+| `<S1_CONFIRM_LOCKED>` | 停後續走 | S3（C5） | 「由操作員確認再續走」；**禁講 auto-resume** | **【LOCKED — 待 Roy D-1】** |
+| `<S1_NARROW_LOCKED>` | 窄場安全錐 | S4（C6） | 「±18° 窄錐綁低速 ≤0.2 m/s」 | **【LOCKED — 待 Roy D-1】** |
+| `<S1_REJECT_LOCKED>` | 拒絕有理由 | S6 | 「定位不夠準 / 已有任務 / 超出黃帶限距」；**T6-5 merged 後才講** | **【LOCKED — 待 Roy D-1】** |
+| `<S1_FUSION_QA_LOCKED>` | 被問融合/找人 | S8 + F6 | 「研究路線有 spec、屬 research，目前感知與移動還沒接起來」 | **【LOCKED — 待 Roy D-1】** |
+
+> **佔位符規則**：① 簽核前 demo 腳本引用這些 ID，不引用具體句；② 簽核後由 conductor/台詞 lane（plan2/plan3）落地，**不由本 nav-static lane 寫死**；③ 任一句若加了限制詞以外的宣稱（如「自動繞開」「走到 Roy 身邊」）= overclaim，駁回。
+
+---
+
+## 3. safe-stop ≠ 繞障（最易被戳；標準說法綁 §3）
+
+對外固定用 [`nav-618-claim-wording.md` §3 標準說法](2026-06-13-nav-618-claim-wording.md)：
+
+> safe-stop = 偵測到正前方障礙在安全距離**停下等待**，操作員確認後再下達 / 遙控輔助；**它不會自己轉向繞過障礙**——reactive_stop 設計上只停不轉（`angular.z=0`），這是刻意的安全選擇（硬轉曾導致四足失衡）。
+
+- **絕不**把 safe-stop 包裝成「智能避障 / 自動繞開」（= [F2](2026-06-13-nav-618-claim-wording.md)）。
+- 被問「會不會自己繞過去」→ 上述標準說法，落在能講側（S2），不碰 F2。
+
+---
+
+## 4. 禁句速查（綁 F1-F10；任一講出 = 誠信破口）
+
+| 禁句 | 綁定 | 為什麼 |
+|---|---|---|
+| 自由巡邏 / 自主巡檢 / 自主導航 | [F1](2026-06-13-nav-618-claim-wording.md) | 只有固定預錄 route，N5 未跑前連單圈都沒有 |
+| 動態繞障 / 繞行 / 自動繞開 | F2 | reactive_stop 只停不轉；硬轉摔狗 |
+| D435 已融合進 costmap | F3 | 現在只有 `depth_clear` fail-closed gate，D435 未進 Nav2 costmap（fusion = research-only spec） |
+| 自動續走 / auto-resume / 「障礙移開會自己繼續」 | F4 | auto-resume 會 lunge 貼牆 0.21m，tight space 禁用 |
+| 「停了不會再走」 | F5 | 現行為**會** auto-resume（只是不安全被禁），反向不實 |
+| 「聽懂過來就走到 Roy 身邊」 | F6 | 感知與 nav goal 零連接、approach 需多層新開發 |
+| 未 n=3 重驗的「可靠導航」 | F7 | C1/C2 仍 low-sample；單次 ≠ 可靠 |
+| 1.0m+ 乾淨連續導航 | F8 | AMCL 黃帶卡死、從未成功 |
+| 三鏡頭/三陣攝影機參與導航 | F9 | 只有 2D RPLIDAR 進迴路 |
+| 即時恢復（orphan） | F10 | 是 ~10s 自癒、非即時 |
+| 「靜態檢查通過 = 可安全移動」 | （R5 yaw-blind） | 靜態閘只看 position covariance，不查 yaw（c[35]）；過了不代表朝向對 |
+| 「goto 0.3m 就走 0.3m」 | （R2 超衝） | goto 不 enforce max_speed，0.5m goal 實測超衝到 1.04m |
+
+---
+
+## 5. Done / 簽核狀態
+
+- **本檔交付 = 三層 fallback 決策表 + 每句綁 S1-S8/F1-F10 + LOCKED 台詞佔位符**（plan6 FLOOR 第 5 項）。
+- **未閉合**：S1 台詞最終 15 句待 Roy 簽 D-1（[`nav-618-claim-wording.md` §6 OPEN A-1](2026-06-13-nav-618-claim-wording.md)）；B-10 發表日用哪層待 6/17 回穩日定。
+- **S1 主線預設 = fallback②**，影片③ 保底就緒；nav motion 維持 `NOT_DEMO_READY`。
+- 本檔純文件，刪檔即回退，無 runtime / param / 門檻值 / URDF 變動。

--- a/nav_capability/test/test_route_validator.py
+++ b/nav_capability/test/test_route_validator.py
@@ -127,6 +127,7 @@ def test_sanitize_route_name_allows_legitimate_ids_unchanged(route_name):
         "a\\b",
         "..%2f..%2fetc",
         "%2e%2e%2froute",
+        "%2e%2e",
         "route;rm",
         "",
         ".",


### PR DESCRIPTION
**Lane:** nav-static | **Plan:** plan6 (NO-MOTION only)

3 new SOP/decision docs + **1 test line**; prod (`route_validator.py`/`go2.urdf`/nav action-server/`nav_ready_check.py`) **untouched**.
- `no-motion-diagnostics-sop.md` (D2–D5 read-only), `initialpose-yaw-calibration-sop.md`, `s1-fallback-decision.md` (claims bound to `nav-618-claim-wording` F1–F10; final S1 phrases = LOCKED placeholders pending Roy).
- NS-V1: added standalone `%2e%2e` reject case.

**Tests:** nav_capability 95 passed/1 skipped · claim-wording grep clean (forbidden phrases only as negations). S8 verified (route_id path-traversal protection; not re-implemented). NS-T0 URDF edit left DEFERRED (Jetson-gated).
**Rollback:** revert docs + the 1 test line. **Adversarial review:** PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)