### PR TITLE
feat(cli): pawai demo start --with-lidar raw LiDAR monitor (B5, default-off) + A3 plan

### DIFF
--- a/docs/navigation/plans/2026-06-14-demo-start-raw-lidar-monitor-plan.md
+++ b/docs/navigation/plans/2026-06-14-demo-start-raw-lidar-monitor-plan.md
@@ -1,0 +1,136 @@
+# Demo Start Raw LiDAR Monitor Plan（B5 + A3，6/18 前最小整合）
+
+**Goal:** 讓 `pawai demo start --with-lidar`（或 `PAWAI_DEMO_WITH_LIDAR=1`）在 brain demo healthy 之後，**額外**啟一個 raw LiDAR monitor 當「證據窗」—— 只產 `/scan_rplidar` topic 給現場觀測 / Foxglove，**不啟 nav2 / amcl / nav_action_server / 第二個 go2_driver、不發任何 motion**。預設關閉，不開時行為 byte-identical。
+
+**Status:** B5（CLI + script）已實作並通過 unit test；本文件為 A3 plan，記錄設計界線、驗收清單、與 post-6/18 full nav 整合的邊界。
+
+**Scope freeze（6/18 前）:** 只 sllidar + static TF + `/scan_rplidar`。禁止 Go2 motion / goto_relative / live SLAM / autonomous approach / D435+LiDAR fusion / 第二 driver / nav2 / amcl。
+
+---
+
+## 1. 為什麼要這個（動機）
+
+- Demo 現場想展示「狗有 LiDAR 感知環境」的證據，但 **full nav stack（nav2 + amcl + nav_action_server + reactive_stop）風險高**：6/13 撞牆事件後 nav motion 標記 `NOT_DEMO_READY`（見 MEMORY `project_nav_incident_rootcause_0613`）。
+- 折衷：只開「感知層」—— RPLIDAR 出 `/scan_rplidar`，配 `base_link→laser` static TF 讓 Foxglove 能把點雲畫在機身座標。**沒有任何節點訂閱 scan 去算 cmd_vel**，所以零 motion 風險。
+- 與 brain demo 並存：brain demo 的單一 `go2_driver`（`scripts/start_full_demo_tmux.sh` 內）不受影響，不會被起第二個。
+
+---
+
+## 2. 架構與檔案
+
+### 2.1 新增 / 改動檔案
+
+| 檔案 | 動作 | 責任 |
+|------|------|------|
+| `scripts/start_lidar_monitor_tmux.sh` | 新增 | Jetson 端 2-window tmux（session `lidarmon`）：static TF + sllidar → `/scan_rplidar` |
+| `tools/pawai_cli/pawai_cli/main.py` | 改 | `demo start --with-lidar` 旗標 + env alias + `_start_lidar_monitor` / `_stop_lidar_monitor` / `_lidar_monitor_manual_command`；`_cleanup_for_lock`（brain lane）+ no-lock stop 路徑接 teardown |
+| `tools/pawai_cli/tests/test_cli.py` | 改 | 9 個新 unit test（旗標/env alias/default-off/失敗不拆 demo/stop 路由），全 mock 不連真 Jetson |
+
+**不改：** `scripts/start_full_demo_tmux.sh` 核心（避免衝突 / 維持 byte-identical default-off）。
+
+### 2.2 拓撲（`lidarmon` session）
+
+```
+window tf       : ros2 run tf2_ros static_transform_publisher
+                    --x 0.175 --y 0 --z 0.18 --yaw 3.14159
+                    --frame-id base_link --child-frame-id laser
+window sllidar  : ros2 run sllidar_ros2 sllidar_node
+                    -p serial_port:=/dev/rplidar -p serial_baudrate:=256000
+                    -r /scan:=/scan_rplidar
+```
+
+- ROS env source 參照 `scripts/start_reactive_stop_tmux.sh`：`/opt/ros/humble` + `~/rplidar_ws` + `~/elder_and_dog install`，皆 `setup.zsh`。
+- TF 數值（x=0.175, y=0, z=0.18, yaw=π）與 reactive_stop / nav_capability 一致 —— LiDAR 安在 base_link 前 17.5cm、高 18cm、反裝（yaw=π）。
+
+### 2.3 控制流（CLI）
+
+```
+pawai demo start --with-lidar
+  → 解析旗標（--with-lidar 或 PAWAI_DEMO_WITH_LIDAR=1）
+  → （--with-lidar + --nav capability 互斥 → UsageError）
+  → 既有 brain demo start.sh + healthcheck（hard gate 不變）
+  → transition_if_owned("running") 成功
+  → _start_lidar_monitor()  ← SSH 到 Jetson 跑 start_lidar_monitor_tmux.sh
+       成功 → "✓ LiDAR monitor running"
+       失敗 → 印手動補救、exit 0（brain demo 仍在）
+
+pawai demo stop / 重啟 cleanup / force-takeover cleanup
+  → _cleanup_for_lock(lock)
+       brain lane → _stop_lidar_monitor() 先清 → _invoke_cleanup_sh()
+       nav  lane → _invoke_nav_cleanup_sh()（不碰 lidar，nav lane 自帶 sllidar）
+  → no-lock stop 路徑 → _stop_lidar_monitor() + _invoke_cleanup_sh()
+```
+
+`_stop_lidar_monitor` 只 `tmux kill-session -t lidarmon` + `pkill sllidar_node` + `pkill static_transform_publisher（child-frame-id laser）`，**絕不 pkill go2_driver**（那是 brain cleanup 的事，單一 driver 不變）。
+
+---
+
+## 3. Default-off / byte-identical 證明
+
+- 旗標 `--with-lidar` 與 env `PAWAI_DEMO_WITH_LIDAR=1` 皆預設 false/unset。
+- `demo start` 主流程在 lidar block 前完全未變動；`if with_lidar:` 為 false 時整段不執行 → 與舊版同路徑（unit test `test_demo_start_default_does_not_start_lidar` 驗 `_start_lidar_monitor` 未被呼叫）。
+- `demo stop` 多了一個 `_stop_lidar_monitor()`：當沒起過 monitor 時，`tmux kill-session` / `pkill` 都是 no-match best-effort（`2>/dev/null; true`），不改變 brain cleanup 結果、不影響 exit code。
+- 新 script `start_lidar_monitor_tmux.sh` 只有在 `--with-lidar` 時才被 SSH 觸發，平時躺著不動。
+
+---
+
+## 4. 驗收清單
+
+### 4.1 自動（已驗，CI / 本機）
+
+- [x] `bash -n scripts/start_lidar_monitor_tmux.sh` 語法 OK
+- [x] `pawai_cli` unit test 全綠（227 passed，含 9 個新 lidar test）
+  - default-off 不啟 monitor
+  - `--with-lidar` / `PAWAI_DEMO_WITH_LIDAR=1` 啟 monitor（healthy 之後）
+  - lidar 啟動失敗 → 不拆 demo、印手動補救、exit 0
+  - `--with-lidar` + `--nav capability` → UsageError exit 2
+  - `_start_lidar_monitor` SSH 命令含 script 路徑、不含 nav2/amcl
+  - `_stop_lidar_monitor` 只 kill lidarmon/sllidar/static TF、不含 go2_driver
+  - brain stop 先 lidar 再 brain；nav stop 不碰 lidar
+
+### 4.2 HITL-only（Roy 上機，真 Jetson + RPLIDAR）
+
+- [ ] `pawai demo start --with-lidar` 後 **brain stack 正常**（`pawai health brain` 綠 / `ros2 node list` 有 5 perception + brain）
+- [ ] `ros2 topic hz /scan_rplidar` ≈ **9–13 Hz**
+- [ ] `ros2 node list | grep -c go2_driver` = **1**（不變 2）
+- [ ] `ros2 node list | grep -E 'nav2|amcl|nav_action'` = **空**（無 nav stack）
+- [ ] **RAM headroom ≥ 0.8 GB**（sllidar + TF 額外開銷，8GB 統一記憶體預算內）
+- [ ] `pawai demo stop` 後：`tmux ls` 無 `lidarmon`、`pgrep -f sllidar_node` 空、`pgrep -f 'static_transform_publisher.*laser'` 空
+- [ ] 不開 `--with-lidar` 時整套 demo 行為與舊版一致（byte-identical sanity）
+
+---
+
+## 5. 已知坑 / 注意
+
+- **serial port 競爭**：`lidarmon` 與 nav_capability lane 不可同時跑（都搶 `/dev/rplidar`）→ `--with-lidar` 已與 `--nav capability` 互斥（UsageError）。手動跑 monitor 前確認 nav lane 沒在跑。
+- **TF 衝突**：本 monitor 只發 `base_link→laser` static TF，**不發** `map→odom` / `odom→base_link`（那是 AMCL / driver 的事）。不會與 brain demo 的 TF 樹打架。⚠️ 若日後 brain demo 也發 `base_link→laser`，需去重避免雙 static TF（目前 brain demo 不發）。
+- **RAM**：3 感知壓測基線 RAM 1.2GB（CLAUDE.md L3），加 brain + driver 後接近預算上限；sllidar + TF 開銷小但 HITL 必須實量 headroom。
+- **card / serial 漂移**：`/dev/rplidar` 為 udev symlink；若未設可用 `RPLIDAR_SERIAL_PORT` env override 腳本。
+- **失敗語意**：lidar monitor 是「加值證據窗」，失敗**不應**拆掉已 healthy 的 brain demo —— 故 `_start_lidar_monitor` 失敗只警告 + 手動補救命令，exit 0。
+
+---
+
+## 6. 與 post-6/18 full nav 整合的界線
+
+本計畫是 **6/18 前的最小、低風險墊腳石**，**不是** full nav。與 post-6/18 整合的分界：
+
+| 維度 | 本計畫（6/18 前，B5/A3） | post-6/18 full nav（見 `2026-06-14-unified-demo-stack-single-go2-driver-plan.md`） |
+|------|------------------------|--------------------------------------------------|
+| 啟動什麼 | sllidar + static TF（`/scan_rplidar`） | + nav2 + amcl + nav_action_server + reactive_stop + twist_mux |
+| go2_driver | brain demo 的單一 driver，不動 | 統一單一 driver 給 brain + nav 共用（unified stack 的核心議題） |
+| motion | 零 | goto / DriveOnHeading / route（需 6/13 撞牆根因全修 + HITL gate） |
+| 旗標 | `--with-lidar`（default-off） | 由 unified stack 計畫定義（lane 路由 / 單 driver 共用） |
+| 風險 | 低（純感知，無 control loop） | 高（control loop + Go2 MIN_X 慣性，需 e-stop + 場測） |
+
+**交接點：** post-6/18 unified stack 接手時，`start_lidar_monitor_tmux.sh` 的 sllidar + static TF 拓撲可被 unified stack 直接吸收/取代；屆時 `--with-lidar` 旗標應**收斂進** unified stack 的單一 driver 共用設計，避免兩套各自起 sllidar。本計畫刻意**不**碰單一 driver 共用問題（那是 unified plan 的範疇），只保證「不起第二個 driver」。
+
+> 引用：post-6/18 整合主文件 `docs/navigation/plans/2026-06-14-unified-demo-stack-single-go2-driver-plan.md`（由 Cloud 端產出 / 整合；本 worktree 不建立該檔，僅標記為前向交接目標）。
+> 6/13 撞牆根因：`docs/navigation/2026-06-13-nav-motion-incident-root-cause-plan.md` + `2026-06-13-nav-incident-runbook.md`。
+
+---
+
+## 7. Rollback
+
+- CLI：`git revert <ab7bd1f>`（移除 `--with-lidar` 旗標 + 三個 helper + stop teardown 接線）。
+- Script：`git rm scripts/start_lidar_monitor_tmux.sh`（或留著不啟用，default-off 無副作用）。
+- 兩者皆 default-off，不 revert 也不影響不帶旗標的舊行為。

--- a/docs/superpowers/issues/2026-06-14-pre618-fix-issues-draft.md
+++ b/docs/superpowers/issues/2026-06-14-pre618-fix-issues-draft.md
@@ -1,0 +1,851 @@
+# Pre-6/18 修復 Issue 草案（2026-06-14 Live HITL 後）
+
+> ⚠️ **這是草案，尚未發到 GitHub。** 等 Roy 審完才會用 `gh` / `to-issues` 真正建立 issue。本檔只負責把「確定要做」的項目拆成可發的 issue 結構，方便 Roy 逐條 review / 砍 / 改優先序。
+>
+> **本輪只做研究 + 寫計畫**：不改任何 runtime code、不發 GitHub issue。
+>
+> **6/18 前 Forbidden scope（每張 issue 都扣這份）**：
+> - Go2 motion（除非 Roy 授權 + e-stop 在手）
+> - goto_relative 當 live 主線
+> - live SLAM
+> - autonomous approach / 動態繞障
+> - D435 + LiDAR fusion runtime claim
+> - model runtime switch
+> - auto-advance 預設開
+> - full CLI v2 / Typer 大重寫
+> - secure-default full flip（gateway auth 6/18 凍結期維持 OFF）
+>
+> **設計精神（每張 issue 都遵守）**：default-off / 可 rollback / 小 PR / byte-identical floor。
+>
+> **Live HITL 2026-06-14 結果速查**：S2 ✅（~2s greet、3m OK）／S3 ⚠（cup 辨識到但講 phone、pose 沒出）／S4 ✅（peace→OK→wiggle）／S5 ✅（秒回拒絕）／Act1 導航避障 ❌（沒成功，Stage1 LiDAR 11.9Hz 活、front±15°=2.09m、+20°=1.70m）。
+
+---
+
+## grill-me 拍板對照（2026-06-14，覆寫各 issue 的 Scope）
+
+> 完整決策表見 [`../reports/2026-06-14-live-demo-iteration-findings.md`](../reports/2026-06-14-live-demo-iteration-findings.md) §6。⚠️=Roy 覆寫了原建議。
+
+| 決策 | 拍板 | 影響 issue |
+|---|---|---|
+| **D1 S3 修法** | 混合：producer whitelist 收飲水（移除 phone/laptop）+ brain `OBJECT_REMARK_PRIORITY` cup>bottle（default-off param） | P0-1（Scope 採「混合」非純 param、非純 brain） |
+| **D2 S3 attention** | `object_remark_attention_min=NOTICED`（只對 cup/bottle，default-off） | P0-2 |
+| **D3 ⚠️ S3 pose** | 保複合句「Roy 坐著拿杯子」+ **上機修 vision pose 邊緣觸發**；cup 簡單句仍為地板層不卡 S3 | 新增 issue（vision pose periodic re-emit / `/state/pose` 訂閱，需 HITL）；非「退簡單句」 |
+| **D4 S4 Studio 鈕** | 藏 GestureToggle 按鈕、偵測全程 ON、phase gate 管範圍 | P1-4（採「藏鈕保偵測」非「關偵測」） |
+| **D5 S4 peace** | 接受現行 config（零 code） | P1-3 |
+| **D6 S4 wiggle** | Go2 motion → e-stop；不穩退純語音 | P1-5 |
+| **D7 S5 指令** | 維持 backflip/翻跟斗（零 code、不換詞） | P1-7 相關 |
+| **D8 ⚠️ S5 觸發** | **語音現場喊主線** + Studio 文字補打當即時 fallback | P1-7（採語音主線，非文字主線） |
+| **D9 ⚠️ Act1** | **live 障礙停版（Go2 自走遇障停）**，motion 紅線六關 + `slow_policy=stop` profile；不穩退人推障礙(零 motion)→影片 | P0-3/P0-4/P0-5（採 A live upside 為目標、B/C 為退場，非 B 預設） |
+| **D10 ⚠️ offline** | **小 code 修** `set_parameters` 寫回（非 docs-only SOP） | P1-8（升級為 code fix + smoke） |
+| **D11 gateway auth** | 6/18 維持 OFF | 跨 issue |
+| **D12 CLI** | venv+uv（pipx post-6/18）+ 單頁 Mac checklist + start.sh Mac-compat 驗 | P0-7/P0-8/P1-11 |
+| **D13 ⚠️ object A/B** | **6/15-16 跑** n@640 矩陣 + supervision offline（需 demo MP4+JSONL 素材） | P1-10/P2-1/P2-2（提前至 6/15-16，非 post-6/18） |
+| **D14 auto-advance** | 全幕 manual FLOOR（不碰 auto-advance）+ 15 句 TTS 暖機 | P0-6 |
+
+**待 Roy 動作**：DEMO_CANNED_TABLE 15 句台詞 6/15 前簽核。
+
+**AFK 可先做（需 Roy 授權動 runtime code，每條小 PR/default-off/smoke）**：D1、D2、D4、D10。
+**Roy 在場 HITL**：D3、D6/D9（motion+e-stop）、D8、D12、D13、S2 re-enroll。
+
+---
+
+## 目錄（依 Priority 分組）
+
+### P0（6/18 demo 阻斷級，必須先解或先確認分支）
+1. [P0-1] S3：Brain 只取 objects[0] + whitelist 含 phone → 講手機不講杯子（cup 優先序）
+2. [P0-2] S3：object_remark 硬卡 attention==ENGAGED → cup 慢一拍/被吞
+3. [P0-3] Act1：先確定當天跑哪個 topology（standalone reactive_stop vs progressive nav stack）
+4. [P0-4] Act1：LiDAR 活著但前錐讀 2.09m 淨空 = 障礙物低於掃描平面（no-motion 前置門檻）
+5. [P0-5] Act1：6/18 fallback ladder 拍板（預設 B 遙控+Foxglove，A 為 e-stop upside，C 影片保底）
+6. [P0-6] demo flow：manual-floor 無 auto canned-rescue → dead-air 全靠操作員，需彩排分工
+7. [P0-7] MacBook 6/18 主操作前置 checklist（閘門過後的本機隱性依賴）
+8. [P0-8] 各平台逐指令行為矩陣（純 SSH 安全 vs 本機 bash 分水嶺）
+
+### P1（會降穩定度 / 影響展示，盡量 6/18 前處理）
+9. [P1-1] S2：confirm greet 在 live config 已 PASS，鎖定 config 不被改回
+10. [P1-2] S2：face_db sim 老化 + face_db 衛生（demo 前 re-enroll + 清 ghost dir）
+11. [P1-3] S4：只保留 peace、關其他手勢辨識（thumbs_up_demo_ack + gesture_direct_disabled）
+12. [P1-4] S4：關掉 Studio 手勢按鈕（先釐清 GestureToggle vs SkillButtons）
+13. [P1-5] S4：wiggle 是 Go2 實體 motion → SOP 強制 e-stop + 語音 fallback
+14. [P1-6] S5：拒絕 trace / BLOCKED 紅字當鏡頭證據（safety trace 落盤 + Studio 顯示）
+15. [P1-7] S5：6/18 走 Studio 文字觸發規避 ASR 誤聽（鎖定觸發詞）
+16. [P1-8] offline_mode topic↔param 驗證陷阱（行為對但 ros2 param get 撒謊）
+17. [P1-9] operator-runbook 過時契約備註修正（#1/#2/#3）+ dry-run
+18. [P1-10] object baseline 矩陣（現役 n@640 跑 cup/bottle/phone/chair × 距離）
+19. [P1-11] PawAI CLI face enroll gap（_clean_face_name 不對稱 + 無 sim 閉環）
+20. [P1-12] full rehearsal checklist（6/17 回穩日五幕彩排）
+
+### P2（6/18 後 / 加分項 / 研究記錄）
+21. [P2-1] YOLO26s 換模研究（ONNX 已 export 未上 Jetson，6/18 前不換）
+22. [P2-2] Supervision offline confusion matrix benchmark（WSL throwaway venv）
+23. [P2-3] S3 dedup 換 take SOP（producer 5s + brain 60s 疊加）
+24. [P2-4] PawAI CLI PowerShell native blocker list（明確不支援、不繞過）
+25. [P2-5] post-6/18 single Go2 driver 架構重構（LT-0~LT-6）
+26. [P2-6] reactive_stop path-corridor / footprint-aware 升級（post-6/18 opt-in）
+
+---
+
+# P0
+
+## [P0-1] S3：Brain 只取 objects[0] + whitelist 含 phone → 講手機不講杯子
+
+- **Title**: S3 物品關懷講「手機」不講「杯子」：brain objects[0]-only + whitelist 含 cell_phone，需加 cup 優先序
+- **Priority**: P0
+- **Deadline**: 6/16（需 Roy 在場 echo + 簽優先序）
+- **Scope**:
+  - 確認真兇：producer `_publish_events` 依 YOLO NMS 信心序建 `new_objects`，brain `_on_object` 只取 `objects[0]`，cell_phone(67) 在白名單且在 `OBJECT_CLASS_ZH`（「手機」）→ phone 信心高就永遠搶 `objects[0]` 被講。
+  - P0 最小外科（brain 端、default-off）：`_on_object` 對 `ev.objects` 先做 class 優先序排序再取首個。新增 `OBJECT_REMARK_PRIORITY=('cup','bottle','bowl','book',...)` param-gated，預設沿用 `objects[0]`（byte-identical）。滿足 Roy「cup 優先、bottle 也可」。
+  - 現場零 code 應急：`ros2 param set /object_perception_node class_whitelist '[41,39,45]'`（VIS-2 runtime callback 即時生效）只留 cup/bottle/bowl，踢掉 phone/laptop。
+- **Forbidden scope**:
+  - 不動 producer `_publish_events` 排序（會影響 Studio chip 順序，scope 太大）。
+  - 不引 model runtime switch（換模型不解此題，真兇在 brain）。
+  - 不大改 perception_router / zh_tables 跨 consumer 結構。
+- **Evidence**:
+  - Live HITL：杯子放面前~1m，UI 跳 cup 但 Brain 一直講 Roy 的手機。
+  - `object_perception/object_perception/object_perception_node.py:438-451`（new_objects 建構）
+  - `interaction_executive/interaction_executive/perception_router.py:128` / `brain_node.py:2245-2257`（objects[0]）
+  - `pawai_contracts/pawai_contracts/zh_tables.py:22`（cell_phone='手機'）
+  - `object_perception/config/object_perception.yaml:21`（whitelist 含 67）
+- **Acceptance criteria**:
+  - 上機 `ros2 topic echo /event/object_detected` 確認 phone 是否在 `objects[0]`、cup/phone confidence 值。
+  - 套用 P0 排序 param 後：杯子在面前時 Brain 講「看到杯子了」而非手機；phone 在 objects 內也被排到 cup 之後。
+  - 預設不開 param 時行為 byte-identical（沿用 objects[0]）。
+- **Tests**:
+  - `interaction_executive` 新增 unit test：mock objects=[phone(0.9), cup(0.6)]，開 priority param 後選 cup；不開時選 phone。
+  - `ros2-test-suite --quick`（speech+face）+ brain package tests 全綠。
+- **HITL required**: yes（需 Roy 在場 echo /event/object_detected + 確認 cup 浮現）
+- **Rollback**: param 預設關 → 直接 byte-identical；現場 param set 可即時切回原 whitelist。
+- **Suggested owner/lane**: Codex（brain-studio-lane worktree）寫 priority param + test；Roy HITL 驗證。
+
+---
+
+## [P0-2] S3：object_remark 硬卡 attention==ENGAGED → cup 慢一拍/被吞
+
+- **Title**: S3 cup 慢一拍：object_remark 要求 attention==ENGAGED，S2 greet 後進 INTERACTING 需 quiet 8s 才回 ENGAGED
+- **Priority**: P0
+- **Deadline**: 6/16
+- **Scope**:
+  - 確認 `_on_object` 要求 `_attention_state_snapshot()==ENGAGED` 才發 object_remark；S2 greet 觸發後進 INTERACTING，要 active_plan 結束 + quiet_s=8.0s 才回 ENGAGED → S3 緊接 S2 時 cup 被 `attention_engaged` gate suppress。
+  - P1 最小外科（default-off param）：新增 `object_remark_attention_min`（預設 `'ENGAGED'`=byte-identical），設 `'NOTICED'` 時對 cup/bottle 放寬到 NOTICED-or-better。符合 Roy「pose/距離不可卡住 S3」。
+  - 用 `/brain/trace`（Plan E）直接看 cup 被哪個 gate 擋（attention_engaged vs active_plan vs tts_playing vs dedup），不需加 code。
+- **Forbidden scope**:
+  - 不全域縮 `quiet_s`（影響 idle 等其他路徑）；若要縮只在 demo profile。
+  - 不移除 attention gate 本體（只加可調下限）。
+- **Evidence**:
+  - Live HITL：cup 辨識有出來但 Brain 慢一拍甚至不講。
+  - `interaction_executive/interaction_executive/brain_node.py:2277`（attention gate）/ `:2283`（active_plan）/ `:2292`（tts_playing）
+  - `interaction_executive/interaction_executive/attention_machine.py:271`（INTERACTING）/ `:35`（quiet_s=8.0）
+- **Acceptance criteria**:
+  - `/brain/trace` 過濾 `source_summary=class=cup` 找出真正 suppress gate。
+  - 設 `object_remark_attention_min='NOTICED'` 後：S2 greet 緊接 S3 時 cup 仍能在 face 穩定下講出。
+  - 預設值 byte-identical。
+- **Tests**:
+  - unit test：attention=NOTICED + param='NOTICED' → cup remark 通過；param='ENGAGED'（預設）→ 被擋。
+  - brain package tests 全綠。
+- **HITL required**: yes（需 Roy 在場看 /brain/trace 確認 gate）
+- **Rollback**: param 預設 'ENGAGED' = byte-identical。
+- **Suggested owner/lane**: Codex（brain-studio-lane）；Roy HITL 驗 trace。
+
+---
+
+## [P0-3] Act1：先確定當天跑哪個 topology
+
+- **Title**: Act1 導航避障診斷分叉根：確認 6/14 當天跑 standalone reactive_stop 還是 progressive nav stack
+- **Priority**: P0
+- **Deadline**: 6/15（收工前 evidence pull，否則 stack 重啟即遺失）
+- **Scope**:
+  - Act1 失敗候選互斥（Go2 沒動 / 走歪 / reactive 沒啟 / cmd_vel 沒到 driver），必須先確定當天啟動形態，才能分流 80% 的診斷。
+  - 純 no-motion 診斷：看當天 tmux session 名稱 + 啟動指令、`ros2 node list`（幾個 go2_driver）、`ros2 action list | grep goto`（有無殘留 active goal）、`pawai evidence pull` 找有無 `[PR1a]` goto log（有=progressive/goto；無=standalone）。
+  - 結論寫死進 operator runbook：「Act1 用哪個腳本」避免兩條路混用。
+- **Forbidden scope**:
+  - 不發任何 goto/forward/motion 指令。
+  - 不在此 issue 修 nav code（只做 topology 判定 + evidence 保全）。
+- **Evidence**:
+  - Live HITL：Act1 ❌ 沒成功；Roy 列候選含「Go2 沒動 / 走歪 / reactive 沒啟 / cmd_vel 沒到 driver」。
+  - `scripts/start_nav_capability_demo_tmux.sh:98-113` / `scripts/start_reactive_stop_tmux.sh:56-63`
+  - `docs/superpowers/plans/2026-06-13-s1-low-risk-navigation-plan.md:13`
+- **Acceptance criteria**:
+  - 明確記錄當天 topology（standalone vs progressive）+ ros2 node list driver 數 + 有無 goto log。
+  - `pawai evidence pull` 撈回當天 `runtime/traces/*.jsonl`（D0，只讀零 motion）。
+- **Tests**:
+  - 無 code 改動；驗證為 evidence pull 成功 + runbook 段落更新。
+- **HITL required**: yes（需 Roy 在 Jetson 上跑 evidence pull / node list）
+- **Rollback**: N/A（純診斷 + 文件）。
+- **Suggested owner/lane**: Roy HITL（收工前優先做 evidence pull）；nav-avoidance-lane 整理 runbook。
+
+---
+
+## [P0-4] Act1：LiDAR 活著但前錐讀 2.09m 淨空 = 障礙物低於掃描平面
+
+- **Title**: Act1 reactive_stop「沒看到障礙」no-motion 前置門檻：障礙物須高於 LiDAR ~0.50m 掃描平面
+- **Priority**: P0
+- **Deadline**: 6/17（回穩日 no-motion 驗證）
+- **Scope**:
+  - Stage1 LiDAR 11.9Hz 活、front±15°=2.09m，若障礙物放正前卻讀淨空 = LiDAR 沒偵測到（2D planar 盲區：mount z=0.18m + base_link 離地 ~0.32m → 掃描面約離地 0.50m）。矮於 ~0.50m 的障礙完全看不到。
+  - operator runbook 寫死：Act1 障礙物必須 >0.6m 高、不反光、放正前方 ≤1.0m（進 danger 1.1m 內）。最穩用「人站正前」（人高度必過掃描面，trackB 6/8 NAV-2 已驗）。
+  - 現場用 `lidar_front_sector.py --once` 先驗「障礙物確實被掃到」再開始 Act1（no-motion 前置門檻）。
+- **Forbidden scope**:
+  - 不 claim D435+LiDAR 已融合補盲區（F3，D435 現況只是 advisory 未進 costmap）。
+  - 不發 motion。
+- **Evidence**:
+  - Stage1：LiDAR 11.9Hz、front±15°=2.09m、+20°=1.70m。
+  - `docs/navigation/research/2026-04-29-mount-measurement.md:76` / `2026-04-25-rplidar-a2m12-integration-log.md:306`
+  - `go2_robot_sdk/go2_robot_sdk/lidar_geometry.py:38-51` / `scripts/lidar_front_sector.py:85-96`
+- **Acceptance criteria**:
+  - 障礙物放正前 1.0m 時 `lidar_front_sector.py --once` 讀 ~1.0m（非 2.09m）。
+  - `scan_health_check.py` 對該方向 NaN 比例正常。
+  - runbook 補入「障礙物高度/材質/放置」硬性規定。
+- **Tests**:
+  - 無 code；驗證為 lidar_front_sector 讀數正確 + scan_health 正常。
+- **HITL required**: yes（需 Jetson + 實體障礙物）
+- **Rollback**: N/A（純診斷 + 文件規定）。
+- **Suggested owner/lane**: Roy HITL（Jetson no-motion）；nav-avoidance-lane 整理 runbook。
+
+---
+
+## [P0-5] Act1：6/18 fallback ladder 拍板
+
+- **Title**: Act1 6/18 交付 fallback ladder：預設 B（遙控+Foxglove LiDAR 證據），A（standalone reactive_stop 障礙停）為 e-stop upside，C（影片）保底
+- **Priority**: P0
+- **Deadline**: 6/17（回穩日由 Roy 定 B-10 當天層）
+- **Scope**:
+  - B 層（預設主線）：遙控/手推障礙 + Foxglove 顯示 `/scan_rplidar` 點雲 + reactive zone 狀態當「邊緣端即時感知環境」證據，零 motion（Go2 站著、移動的是障礙物）。
+  - A 層（upside，需條件）：standalone reactive_stop 障礙停（trackB 6/8 NAV-2 已驗「人/箱 1.03m → danger → Go2 停、0 撞」）。前提：Roy+e-stop+障礙物高度過掃描平面+indoor_tight 窄錐重驗無誤擋+人站正前最穩。
+  - C 層（保底）：S1 影片已錄（demo snapshot tag），旁白用保守版。
+  - 不採 goto/progressive（綁 6/13 R1/R2 走歪根因）。
+- **Forbidden scope**:
+  - goto_relative / DriveOnHeading 不當 live 主線。
+  - A 層不穩立即退 B/C，不硬演。
+  - 台詞禁 F1-F10（自主導航/動態繞障/D435 已融合/auto-resume）；safe-stop≠繞障標準說法。
+- **Evidence**:
+  - Live HITL：Act1 ❌ 沒成功。
+  - `docs/navigation/2026-06-13-s1-fallback-decision.md:20`
+  - `docs/navigation/research/2026-06-08-trackB-hitl-results.md:14`
+  - `scripts/start_reactive_stop_tmux.sh:74-79`
+- **Acceptance criteria**:
+  - 6/17 Roy 拍板當天採哪層 + A 層前置門檻全列（lidar_front_sector 看得到 + param 驗 indoor_tight + e-stop 就位 + 場地淨空）。
+  - B 層 Foxglove `/scan_rplidar` 點雲可顯示 + reactive status topic 活。
+  - C 層 demo snapshot 影片 tag 存在可播。
+- **Tests**:
+  - 無 code；驗證為三層各自前置都備齊。
+- **HITL required**: yes（Roy 拍板 + A 層需 e-stop）
+- **Rollback**: 任何情況退 B/C。
+- **Suggested owner/lane**: Roy（決策）；nav-avoidance-lane（備齊 B/C 前置）。
+
+---
+
+## [P0-6] demo flow：manual-floor 無 auto canned-rescue → dead-air 靠操作員
+
+- **Title**: demo flow never-dead-air：manual-floor 模式 per-phase max_wait timer 永不 arm，需彩排分派計時+canned 觸發角色
+- **Priority**: P0
+- **Deadline**: 6/17（彩排決定每幕是否逐幕開 auto）
+- **Scope**:
+  - 確認 `auto_advance_phases=[]`（預設 OFF）→ `_arm_phase_wait_timer` 只在 `_auto_advance_on(phase)=True` 才 arm → `_on_phase_max_wait` 永不觸發 → brain 不會自動補話。manual-floor 下 never-dead-air 全靠操作員手按。
+  - 保守版（6/18 主線）：每幕不開 auto_advance；彩排分派「計時人 + canned 觸發人」，max_wait 內沒視覺觸發就 Studio skill_request(say_canned) 或文字補話。
+  - 理想版（6/17 彩排才決定）：只對 S2 開 `auto_advance_phases=['s2_greet']`（進場 greet 自動補 + max_wait rescue），S3/S4/S5 仍 manual floor，一鍵退 `[]`。
+  - 必做：tts canned 暖機（15 句各發一次 /tts 進 cache），避免首句 2.4s 延遲被當 dead air（禁 mid-session 重啟 tts_node）。
+- **Forbidden scope**:
+  - auto-advance 不預設開（forbidden scope）；若開只能單幕現場手動 + Roy 點頭。
+  - 不 mid-session 重啟 tts_node（Megaphone silent fail）。
+- **Evidence**:
+  - `interaction_executive/interaction_executive/brain_node.py:468-473`（timer arm gate）/ `:578-613`（canned rescue）/ `:1443-1470`（chat timeout）
+  - `docs/runbook/2026-06-18-operator-runbook.md:271-278`
+- **Acceptance criteria**:
+  - 彩排確認 dead-air 上限 ≤ chat_wait_ms（1.5s）對語音路徑；純視覺空檔由操作員手動補話流程驗過。
+  - 15 句 canned 暖機後首句 latency≈0。
+  - 若逐幕開 S2 auto，驗一鍵退回 `[]`。
+- **Tests**:
+  - brain package tests 全綠（auto_advance_phases 為空時不 arm timer 的既有測試）。
+- **HITL required**: yes（彩排 + Jetson）
+- **Rollback**: `auto_advance_phases:=[]` 一鍵退回 manual floor。
+- **Suggested owner/lane**: Roy HITL（彩排分工）；brain-studio-lane（暖機 SOP）。
+
+---
+
+## [P0-7] MacBook 6/18 主操作前置 checklist
+
+- **Title**: MacBook operator setup checklist：CLI 閘門過後的本機隱性依賴（ssh/rsync/bash + brain-studio-lane .sh + Tailscale）
+- **Priority**: P0
+- **Deadline**: 6/16（6/18 主操作前要驗過）
+- **Scope**:
+  - 產出單頁 MacBook checklist（docs，不改 code）：
+    1. `brew install tmux node` + `brew install --cask tailscale`，登入並接受 share
+    2. `git clone` repo 到 `~/elder_and_dog`（不要 iCloud Drive 同步目錄）
+    3. `python3 -m venv ~/.venv` + `uv pip install -e tools/pawai_cli`
+    4. `~/.ssh/config` 建 `Host jetson-nano` 指向 Tailscale IP + `ssh-copy-id`
+    5. `cp .env.local.example .env.local` 填 keys
+    6. `pawai doctor` 全綠（注意 Tailscale CLI PATH，GUI 版 binary 不一定在 PATH）
+    7. `pawai status` / `smoke brain` / `evidence pull` 走純 SSH 先驗
+    8. `pawai demo start` 最後驗（需本機 bash 跑 start.sh）
+  - 確認 flock 不是本機依賴（全在 Jetson run_remote），macOS 無 flock 也能 demo start lock。
+- **Forbidden scope**:
+  - 不加 pipx 安裝路徑（現行 218 測試/CI 假設 venv+uv，6/18 前不改安裝機制；pipx 列 post-6/18）。
+  - 不改 `shell.stream` bash 呼叫核心路徑。
+- **Evidence**:
+  - `tools/pawai_cli/pawai_cli/main.py:803/882`（demo 走本機 bash 跑 .sh）
+  - `tools/pawai_cli/pawai_cli/lock.py:18`（flock 全遠端）
+  - `docs/pawai_cli/troubleshooting.md:340`（Mac 搬家 7 步）
+- **Acceptance criteria**:
+  - MacBook 上 `pawai doctor` 全綠。
+  - `pawai status` / `smoke brain` / `evidence pull`（純 SSH）在 Mac 與 WSL 輸出等價。
+  - `bash .claude/skills/brain-studio-lane/scripts/start.sh demo` 在 Mac 無 GNU-only / zsh-only 假設（HITL 驗）。
+- **Tests**:
+  - 無 code；驗證為 Mac 上實跑各指令 exit code。
+- **HITL required**: yes（需 Roy 的 MacBook 實機）
+- **Rollback**: N/A（純文件 checklist）。
+- **Suggested owner/lane**: pawai-cli lane（寫 checklist）；Roy HITL（MacBook 實跑驗 start.sh）。
+
+---
+
+## [P0-8] 各平台逐指令行為矩陣（純 SSH vs 本機 bash 分水嶺）
+
+- **Title**: 6/18 CLI runbook 兩層：純 SSH 指令（status/smoke/evidence/logs）跨平台等價，本機 bash 指令（demo start/stop/health）是分水嶺
+- **Priority**: P0
+- **Deadline**: 6/16
+- **Scope**:
+  - 產出指令矩陣 docs：
+    - Layer A（純 SSH，Mac/WSL2 完全等價）：`status` / `smoke brain` / `evidence pull` / `logs` / `contract check --jetson`
+    - Layer B（本機 bash + repo + Studio node_modules）：`demo start` / `demo stop` / `health brain`
+  - 每指令標「誰跑 / 前提 / 失敗 hint」（demo start 前提=lock 未被鎖；smoke brain 前提=demo 已 start；evidence pull 前提=trace store 開）。
+  - WSL checklist：repo 在 `~/`（非 /mnt/c，會被 check_repo_path 擋）+ ssh/rsync/tmux/flock 本機有 + uv 已裝。
+- **Forbidden scope**:
+  - 不改 demo start/stop 核心路徑。
+  - 不為 cross-platform 把 bash 呼叫改 subprocess（forbidden，6/18 禁）。
+- **Evidence**:
+  - `tools/pawai_cli/pawai_cli/status.py:109` / `main.py:954`（smoke）/ `main.py:1870`（logs）/ `evidence.py:107`
+  - `tools/pawai_cli/pawai_cli/main.py:1586/1659`（demo start/stop 走本機 bash）
+- **Acceptance criteria**:
+  - 矩陣文件列全指令的 Layer 分類 + 前提 + 失敗 hint。
+  - 上機驗：純 SSH 三類在 Mac 與 WSL exit code/輸出對照一致。
+- **Tests**:
+  - 無 code；驗證為矩陣與實機行為一致。
+- **HITL required**: yes（Mac + WSL 對照需實機）
+- **Rollback**: N/A（純文件）。
+- **Suggested owner/lane**: pawai-cli lane；Roy HITL（Mac 對照）。
+
+---
+
+# P1
+
+## [P1-1] S2：confirm greet 在 live config 已 PASS，鎖定 config
+
+- **Title**: S2 認人問候 go/no-go=GO：鎖定 executive.yaml greet_require_sitting:false 不被改回
+- **Priority**: P1
+- **Deadline**: 6/16
+- **Scope**:
+  - 確認 live demo 走 `interaction_executive.launch.py` 載 `executive.yaml`（`greet_require_sitting:false`），與 Roy「~2s greet、沒 pose 也觸發」一致；`demo_phase="all"` 使 `_phase_allows("greet")` 永真；`stranger_alert_enabled=false` 移除 6/9 黑屏真兇。
+  - runbook 標明「S2 PASS 前提 = executive.yaml greet_require_sitting:false 已部署到 Jetson」。
+  - 現場保底：`ros2 param set /brain_node greet_require_sitting false`（即時生效 callback）。
+- **Forbidden scope**:
+  - 不把 yaml 改回 true（會退回黑屏症狀）；若未來改回須同步改 skill_contract 台詞。
+  - 不改 greet 觸發機制本體。
+- **Evidence**:
+  - Live HITL：S2 ✅（~2s greet、3m OK、pose 沒出仍觸發）。
+  - `interaction_executive/config/executive.yaml:35`
+  - `interaction_executive/interaction_executive/brain_node.py:2100-2107`（_on_face）/ `:774-836`（param declare）
+- **Acceptance criteria**:
+  - `ros2 param get /brain_node greet_require_sitting` 回 false（非 code default true）。
+  - runbook 補入前提聲明。
+- **Tests**:
+  - 既有 brain greet 測試全綠。
+- **HITL required**: no（config 已正確，僅文件 + param get 驗證；param get 可由 Roy 順手驗）
+- **Rollback**: 現場 param set 可即時切。
+- **Suggested owner/lane**: brain-studio-lane（runbook 聲明）；Roy 順手 param get 確認。
+
+---
+
+## [P1-2] S2：face_db sim 老化 + face_db 衛生
+
+- **Title**: S2 greet 單點故障：face_db sim 老化（demo 前現場光線 re-enroll + 清 ghost dir）
+- **Priority**: P1
+- **Deadline**: 6/17（demo 現場時段）
+- **Scope**:
+  - sim 老化是 greet 整條路徑唯一單點故障（6/8 記錄 Roy 舊圖 sim 0.2→re-enroll 後 0.73-0.81）。低光只影響 RGB 端 YuNet 偵測 + SFace sim（greet 不讀 depth，低光不擋深度路徑）。
+  - SOP：demo 前在現場光線下 `pawai face enroll --person-name roy` → `pawai face rebuild` → 重啟 face node → `ros2 topic echo /state/perception/face` 看 sim≥0.7；`cp -p model_sface.*` 備份。
+  - face_db 衛生：移除所有 `_backup/old/.tmp` 子目錄到 face_db 外（`train_model` 把所有子目錄當人名訓進 centroid 稀釋）。
+- **Forbidden scope**:
+  - 不改 face_identity_node runtime（dirname 黑名單實裝列 open decision，6/18 前用 shell 清理）。
+  - 不降 sim_threshold_upper 當常態（升 false-positive，與 stranger_alert 取捨）。
+- **Evidence**:
+  - `face_perception/config/face_perception.yaml:11-24`
+  - `face_perception/face_perception/face_identity_node.py:561-598`（decide_stable）/ `:709-718`（identity_stable）
+  - `docs/pawai-brain/research/2026-06-08-night-vision-brain-research.md`
+- **Acceptance criteria**:
+  - demo 前一天在現場光線量 Roy raw_sim n≥10 確認 ≥0.7。
+  - `ls -la /home/jetson/face_db/` 只有真人子目錄、無 ghost dir。
+- **Tests**:
+  - 無 code；驗證為 re-enroll 後 sim 量測 + face_db ls 乾淨。
+- **HITL required**: yes（Jetson + 現場光線 + Roy 的臉）
+- **Rollback**: 保留 re-enroll 前的 `model_sface.*` 備份可回滾。
+- **Suggested owner/lane**: Roy HITL（face enroll + 清 face_db）。
+
+---
+
+## [P1-3] S4：只保留 peace、關其他手勢辨識
+
+- **Title**: S4 手勢收斂：只保留 peace 觸發，thumbs_up_demo_ack=true + gesture_direct_disabled=true 關其他手勢
+- **Priority**: P1
+- **Deadline**: 6/16
+- **Scope**:
+  - 確認現行 yaml 已使 palm/fist/index/wave 進 `_on_gesture` 後不命中 `_GESTURE_DIRECT/_GESTURE_CONFIRM` → 無動作；唯一殘留是 thumbs_up 仍→wiggle。
+  - 零 code：demo 啟動帶 `peace_wego_confirm:=true` + `gesture_direct_disabled:=true` + `thumbs_up_demo_ack:=true` → 只有 peace 引 wiggle confirm，其他手勢無動作；OK 維持 confirm 用（不可關）。
+  - 文件化現行行為進 runbook（demo_phase=s4_gesture 隔離不被 greet/object 搶話）。
+  - 若 vision 無法只發 peace 且要硬性白名單：列為計畫項（brain `_on_gesture` 加 `gesture_allowlist` declared param 預設空=現行行為），需 Roy 授權後另開、非本輪。
+- **Forbidden scope**:
+  - 不在 vision 層砍 recognizer 輸出（破壞 Studio gesture-panel 視覺化 + trace 證據）；過濾在 brain 層。
+  - 不關 OK 幾何 override（關了 peace 無法二確認）。
+  - 本輪不實作 gesture_allowlist code（只計畫）。
+- **Evidence**:
+  - Live HITL：S4 ✅（peace→「比OK就開始」→OK→wiggle）；Roy 要求只保留 peace。
+  - `interaction_executive/config/executive.yaml:13-43`
+  - `interaction_executive/interaction_executive/brain_node.py:1628-1646`（_on_gesture）/ `:859-887`（map 建構）
+- **Acceptance criteria**:
+  - 上機：比 palm/fist/wave 無任何 Go2 反應（只 Studio trace）。
+  - thumbs_up_demo_ack=true 後比讚不引出 wiggle。
+  - 只有 peace→OK→wiggle 觸發 motion。
+- **Tests**:
+  - brain gesture 測試全綠（_GESTURE_DIRECT 為空 + thumbs_up_demo_ack 行為）。
+- **HITL required**: yes（需 Jetson 實機驗 thumbs_up/其他手勢）
+- **Rollback**: 三個 param 都 default-off，移除 launch override 即回原行為。
+- **Suggested owner/lane**: brain-studio-lane（launch override + runbook）；Roy HITL 驗。
+
+---
+
+## [P1-4] S4：關掉 Studio 手勢按鈕
+
+- **Title**: S4 關 Studio 手勢按鈕：先釐清 Roy 指 GestureToggle（ON/OFF）還是 SkillButtons（直觸 wiggle）
+- **Priority**: P1
+- **Deadline**: 6/16（需 Roy 釐清需求）
+- **Scope**:
+  - 釐清：Studio 沒有「逐手勢觸發按鈕」。唯一手勢控制是 `GestureToggle`（POST /api/gesture_enabled，整段開關手勢辨識）；另有 `SkillButtons` 能 POST skill_request 直接觸發 wiggle/stretch（繞過手勢/OK，對 Go2 安全更關鍵）。
+  - 若指 GestureToggle：純前端條件隱藏（`chat-panel.tsx:392/431`），demo 期不顯示，改用 ros2 param set 控 gesture_enabled。
+  - 若指 SkillButtons：demo 期把整塊隱藏或只在 `?dev=1` dev panel 顯示，防誤點直接 wiggle。
+- **Forbidden scope**:
+  - 不動 gateway `/api/gesture_enabled` plumbing（byte-identical default-off 機制，前端隱藏即可）。
+  - 不關 GestureToggle 的後端（S4 段需 gesture_enabled ON）。
+- **Evidence**:
+  - Live HITL：Roy 要求「關掉網頁手勢按鈕（peace 不太會誤觸）」。
+  - `pawai-studio/frontend/components/chat/gesture-toggle.tsx:19-100`
+  - `pawai-studio/frontend/components/chat/brain/skill-buttons.tsx:38-46`
+- **Acceptance criteria**:
+  - Roy 確認指哪個按鈕。
+  - 對應前端條件隱藏後 demo 主控視圖看不到該按鈕；後端機制不變（仍可 ros2 param set）。
+- **Tests**:
+  - frontend lint/build 通過；gateway 行為 byte-identical。
+- **HITL required**: yes（需 Roy 釐清 + 看前端）
+- **Rollback**: 前端條件隱藏可 flag 切回顯示。
+- **Suggested owner/lane**: brain-studio-lane（前端隱藏）；Roy（釐清需求）。
+
+---
+
+## [P1-5] S4：wiggle 是 Go2 實體 motion → SOP 強制 e-stop
+
+- **Title**: S4 wiggle（api_id 1020 原地扭）屬 forbidden scope motion：SOP 強制 Roy 授權 + e-stop + 語音 fallback
+- **Priority**: P1
+- **Deadline**: 6/17
+- **Scope**:
+  - 確認 wiggle→wiggle_hip→api_id 1020（原地扭動非位移，cooldown 10s、requires_confirmation=True，不在 BANNED_API_IDS）。唯一允許的 Go2 motion，仍須 Roy 授權 + e-stop。
+  - SOP：S4 wiggle 前 Roy 授權 + 操作員 e-stop（遙控器急停）在手，wiggle 期間站姿留足空間。
+  - 台詞 fallback：若現場不便讓 Go2 動，peace→OK 後改發 say_canned「好，我跟你 WeGo 一下！」不發 motion（需 Roy 簽該句）。
+- **Forbidden scope**:
+  - 不把 wiggle 改成 direct（繞 OK 確認）；維持兩步確認。
+  - 不解除 requires_confirmation。
+- **Evidence**:
+  - Live HITL：S4 ✅ Go2 真的 wiggle 了。
+  - `pawai_contracts/pawai_contracts/skill_contract.py:110-134`（1020 + BANNED）
+  - `interaction_executive/interaction_executive/safety_layer.py:22-64`
+- **Acceptance criteria**:
+  - runbook 列明 S4 wiggle = e-stop 必備 + Roy 授權。
+  - 語音 fallback 句由 Roy 6/15 簽。
+- **Tests**:
+  - 無 code；驗證為 SOP 文件 + fallback 句定稿。
+- **HITL required**: yes（wiggle 是 motion，e-stop 實機）
+- **Rollback**: 退語音 fallback（不發 motion）。
+- **Suggested owner/lane**: Roy（授權 + 簽句）；nav/brain lane（runbook）。
+
+---
+
+## [P1-6] S5：拒絕 trace / BLOCKED 紅字當鏡頭證據
+
+- **Title**: S5 safety trace：BLOCKED_BY_SAFETY 落盤 runtime/traces + Studio 紅字當三層架構視覺化證據
+- **Priority**: P1
+- **Deadline**: 6/17
+- **Scope**:
+  - 確認 S5 是真實執行層 reject（非裝飾）：`request_backflip`→IE node validate→`banned_api:1301`→`BLOCKED_BY_SAFETY`+`_trace_safety_block`→gateway 落盤 `runtime/traces/*.jsonl`+WS 廣播→Studio `chat-panel.tsx:557` 紅字。
+  - demo 現場驗：跑一次 S5 後 `pawai evidence pull` 確認 jsonl 有 `banned_api:1301` 那筆 + Studio frontend 紅字真的出現。
+  - 6/18 把 Studio trace drawer / BLOCKED 紅字當鏡頭證據主動展示（呂奇傑 5/22 指定「三層架構唯一視覺化證據」）。
+- **Forbidden scope**:
+  - 不改 SafetyLayer / BANNED_API_IDS（已 proven 端到端）。
+  - 不 secure-default full flip（gateway auth 維持 OFF）。
+- **Evidence**:
+  - Live HITL：S5 ✅ 秒回「這個動作不安全，我不能執行」。
+  - `interaction_executive/interaction_executive/interaction_executive_node.py:151-160`
+  - `pawai-studio/gateway/studio_gateway.py:788`（落盤）/ `trace_store.py:62`
+  - `pawai-studio/frontend/components/chat/chat-panel.tsx:557`（紅字）
+- **Acceptance criteria**:
+  - 跑 S5 後 evidence pull 撈到 `banned_api:1301` trace。
+  - Studio frontend 顯示 blocked_by_safety 紅字 + detail。
+  - demo 機 gateway+frontend 起得來、trace 落盤正常。
+- **Tests**:
+  - 既有 36 個 safety_layer 測試全綠。
+- **HITL required**: yes（需 demo 機 gateway+frontend 同跑驗紅字 + evidence pull）
+- **Rollback**: N/A（純驗證 + 展示，無 code 改）。
+- **Suggested owner/lane**: brain-studio-lane（驗證 + 展示流程）；Roy HITL。
+
+---
+
+## [P1-7] S5：6/18 走 Studio 文字觸發規避 ASR 誤聽
+
+- **Title**: S5 主線走 Studio 文字觸發（operator S5-Trigger），語音當加分 take，鎖定觸發詞
+- **Priority**: P1
+- **Deadline**: 6/16
+- **Scope**:
+  - 確認鍵詞表固定 + ASR 誤聽（Go2 風扇 ~20% 誤辨）是唯一弱點。6/18 走 Studio 文字框觸發（100% 命中鍵詞）可完全規避。
+  - SOP：S5 主線 = Studio 文字框打「後空翻/翻跟斗」；語音現場喊當加分 take。
+  - 若 Roy 要新增危險詞：改 `safety_layer.py:23 UNSAFE_KEYWORDS_REJECT` + 補 parametrize test + colcon build（非零風險，僅 Roy 明確要換/加詞時做）。
+- **Forbidden scope**:
+  - 6/18 前不換詞（backflip 已 6/10 proven 端到端），除非 Roy/老師明確要求。
+  - 不改拒絕語句結構（統一「這個動作不安全，我不能執行。」）。
+- **Evidence**:
+  - Live HITL：S5 ✅ 語音喊後空翻秒回。
+  - `interaction_executive/interaction_executive/safety_layer.py:23`（8 詞表）/ `:71`（substring）
+  - `pawai_contracts/pawai_contracts/llm_policy.py:10`（backflip 不在 LLM 可提案）
+- **Acceptance criteria**:
+  - runbook 寫明 S5 主線=Studio 文字觸發。
+  - demo 腳本鎖定只喊收錄的「後空翻/翻跟斗」。
+- **Tests**:
+  - 若改詞：safety_layer parametrize test 涵蓋新詞 + 全綠。
+- **HITL required**: yes（需 Roy 決策觸發方式 + 鎖腳本）
+- **Rollback**: 退語音現場喊（已 proven）。
+- **Suggested owner/lane**: Roy（決策觸發方式）；brain-studio-lane（runbook + 若改詞）。
+
+---
+
+## [P1-8] offline_mode topic↔param 驗證陷阱
+
+- **Title**: offline_mode 行為已對但 ros2 param get 撒謊：驗證 SOP 改看 /brain/trace 或聽秒回 canned
+- **Priority**: P1
+- **Deadline**: 6/16
+- **Scope**:
+  - 確認 topic↔param 已接通（brain 有 `/brain/offline_mode` Bool subscriber，gateway publish_offline_mode 發 Bool，QoS 相容、行為正確）。真正 gap：`_set_offline_mode`/`_set_demo_phase` 不呼叫 set_parameters → topic 切換後 `ros2 param get` 仍回舊值（cache 非真值）。
+  - P1 操作 SOP（零 code）：HITL §4 加「Studio offline toggle 切換後不要用 ros2 param get 驗證，改看 `/brain/trace` 出現 `reason=offline_mode` 的 say_canned 或聽是否秒回 canned」；更新 runbook 移除「param get 驗 offline」誤導。
+  - 備援（proven）：若 topic 沒生效退啟動前 env override（`LLM_ENDPOINT=http://127.0.0.1:1/ TTS_PROVIDER=piper`）。
+  - P2 brain 端對齊（post-6/18）：`_set_offline_mode`/`_set_demo_phase` 在 via!='param' 時呼叫 set_parameters（避免遞迴），加單測。
+- **Forbidden scope**:
+  - 本輪不改 brain set_parameters（屬 post-6/18 P2）。
+  - 不動 gateway topic plumbing。
+- **Evidence**:
+  - `interaction_executive/interaction_executive/brain_node.py:705-716`（_set_offline_mode）/ `:1419-1435`（offline 短路）
+  - `pawai-studio/gateway/studio_gateway.py:858-875`
+  - `docs/runbook/2026-06-18-operator-runbook.md:45`（過時聲明）
+- **Acceptance criteria**:
+  - 上機：Studio offline ON 後送一句語音秒回 canned（行為對）；同時 `ros2 param get` 仍回舊值（確認陷阱）。
+  - runbook 驗證 SOP 改為看 trace / 聽秒回，移除 param get 誤導。
+- **Tests**:
+  - 無 code（本輪）；post-6/18 對齊 issue 才加單測。
+- **HITL required**: yes（需 Jetson 驗 offline 行為 + param get 撒謊）
+- **Rollback**: N/A（文件 SOP）。
+- **Suggested owner/lane**: brain-studio-lane（runbook SOP）；Roy HITL 驗。
+
+---
+
+## [P1-9] operator-runbook 過時契約備註修正
+
+- **Title**: operator-runbook 契約備註 #1/#2/#3 過時：PHASE_ALLOWED_KINDS 已含 5 canonical 幕、brain subscriber 已存在
+- **Priority**: P1
+- **Deadline**: 6/17（dry-run 前）
+- **Scope**:
+  - 更新 §契約備註：canonical 5 幕已收進 `PHASE_ALLOWED_KINDS`（`interaction_state.py:40-50`）、`/brain/demo_phase` subscriber 已存在（`brain_node.py:324-326`）、Studio 五幕鈕已可直發 canonical 名；移除「backup 用 s2_face/s3_object 等效名」的必要繞路（保留 alias 仍可用即可）。
+  - 跑 P4-11 dry-run（找沒參與者照 §0-§5 唸）把過時/照不下去步驟逐條標出再修。
+- **Forbidden scope**:
+  - 不改 interaction_state / brain code（向後相容已成立，alias + canonical 都吃）。
+  - 純 docs-only。
+- **Evidence**:
+  - `interaction_executive/interaction_executive/interaction_state.py:40-57`
+  - `interaction_executive/interaction_executive/brain_node.py:324-326`
+  - `docs/runbook/2026-06-18-operator-runbook.md:30-45`
+- **Acceptance criteria**:
+  - 上機 `ros2 param set /brain_node demo_phase s2_greet` 被接受（canonical 名可用）。
+  - Studio 五幕鈕 POST /api/demo_phase → `ros2 topic echo /brain/demo_phase` 收到。
+  - runbook 三條契約備註更新 + dry-run 抓出的步驟修正。
+- **Tests**:
+  - 無 code；驗證為 runbook 與 code 行為一致。
+- **HITL required**: no（docs-only + dry-run 可由團隊任一人；canonical 名驗證可順手）
+- **Rollback**: N/A（純文件）。
+- **Suggested owner/lane**: brain-studio-lane（docs 更新 + dry-run 主持）。
+
+---
+
+## [P1-10] object baseline 矩陣（現役 n@640）
+
+- **Title**: object baseline 矩陣：現役 yolo26n@640 跑 cup/bottle/phone/chair × 0.7/1.0/1.5m（零 runtime 風險）
+- **Priority**: P1
+- **Deadline**: 6/16（today-able，工具齊全）
+- **Scope**:
+  - 用 `scripts/obj_matrix_cap.py`（已有 PASS≥0.8/DEGRADED≥0.6/FAIL gate + 混淆收集 + CSV）跑現役 n@640：`cup/bottle/phone/chair × 0.7/1.0/1.5m`=12 cell，window≥6s（避 object cooldown 5s）。
+  - 隔離跨流污染（obj_matrix_cap 只訂 object topic，天然隔離 gesture）。
+  - 量 cup recall（success_rate proxy）+ avg_confidence + misclass（混淆共現）+ verdict，把「感覺」換成數據以決定換不換模型。
+  - FPS/RAM/溫度另用 tegrastats 並排記（obj_matrix 不收）。
+- **Forbidden scope**:
+  - 不換模型（YOLO26s 上機矩陣是另一張 P2 issue）。
+  - 不改 conf threshold（非 runtime param，改要 kill 重啟）。
+  - 不引 Supervision 到 Jetson（offline-only，另一張 P2）。
+- **Evidence**:
+  - Live HITL：S3 cup↔phone 混淆（acceptance §4：0.7m phone 4 次/bottle 2 次）。
+  - `scripts/obj_matrix_cap.py:99-187` / `benchmarks/core/object_matrix.py:28-110`
+- **Acceptance criteria**:
+  - 產出 `artifacts/object_matrix/baseline.csv`（12 cell）。
+  - cup recall@各距離 + 混淆數據可餵 P0-1/P2-1 決策。
+- **Tests**:
+  - 無 code（用既有工具）；驗證為 CSV 產出且 cell 完整。
+- **HITL required**: yes（需 Jetson live /event/object_detected + 實體物品）
+- **Rollback**: N/A（純量測，read-only）。
+- **Suggested owner/lane**: Roy HITL（Jetson 跑矩陣）；nav/object lane 整理數據。
+
+---
+
+## [P1-11] PawAI CLI face enroll gap
+
+- **Title**: CLI face enroll gap：_clean_face_name 與 delete 不對稱 + 無 sim 驗證閉環 + ghost dir 重訓前沉默
+- **Priority**: P1
+- **Deadline**: 6/16（P0-B/P0-A 列入 checklist，實作需 Roy 授權）
+- **Scope**:
+  - 記錄 gap（本輪 read-only，不改 code）：
+    - (a) `face enroll --person-name` 未過 `_clean_face_name`（delete 有，不對稱）。
+    - (b) 無任何 face 子命令驗 sim≥0.7（`face test` 跑的是 pytest 非 sim 量測）。
+    - (c) `train_model` 無條件把所有子目錄訓成身份，enroll/rebuild 重訓前不掃 ghost dir（只 `face list` 警告）。
+  - 把 face-enroll-proposal.md 的 P0-A（ghost 警告 30min）+ P0-B（enroll 套 _clean_face_name 10min）列入 MacBook checklist 的「demo 前 face_db 衛生」段。
+  - 決策給 Roy：P0-B（補不對稱注入面，極低風險）是否 6/18 前做；P1-A face verify（sim 閉環 2-3hr）延後 post-6/18。
+- **Forbidden scope**:
+  - 不改 face_identity_node runtime。
+  - 不重做 .npz purge（T5-1 已完成測試不可動）。
+  - 不引 Typer/Rich；不讓 enroll/rebuild 阻擋 ghost dir（只警告，保 byte-identical）。
+  - 本輪不寫 code（需 Roy 授權後另開）。
+- **Evidence**:
+  - `tools/pawai_cli/pawai_cli/main.py:2025`（enroll 無 clean）/ `:1982`（_clean_face_name）/ `:1995`（delete 有）
+  - `docs/pawai_cli/2026-06-14-face-enroll-cli-proposal.md:58`
+- **Acceptance criteria**:
+  - checklist 寫明 face SOP 現況（list 看 ghost → 手動移出 → enroll → rebuild → 重啟 → 手動 echo sim）。
+  - Roy 決策 P0-A/P0-B 是否 6/18 前做。
+- **Tests**:
+  - 若 Roy 授權 P0-B：enroll 套 _clean_face_name 後加對應 test；既有 4 條 .npz purge 守門測試不可動。
+- **HITL required**: yes（決策 + 若實作需驗）
+- **Rollback**: 純研究無 code；若實作 P0-B 為小 PR 可 revert。
+- **Suggested owner/lane**: pawai-cli lane（記錄 + checklist）；Roy（決策授權）。
+
+---
+
+## [P1-12] full rehearsal checklist
+
+- **Title**: 6/17 回穩日五幕全流程彩排 checklist（S1-S5 + Act1 fallback + 主控分工）
+- **Priority**: P1
+- **Deadline**: 6/17
+- **Scope**:
+  - 產出單頁彩排 checklist 涵蓋：
+    - 啟動：`pawai demo start`（單一 driver，起前 pkill 殘留）+ `tmux ls` + `ros2 node list` 數 process（不只信 CLI 成功訊息，6/4 CRLF 假成功教訓）。
+    - 暖機：15 句 canned 各發一次 /tts 進 cache（禁 mid-session 重啟 tts_node）。
+    - S2：Roy 從框外走入觸發進場 greet（event-only，離框 ~5s 重現）。
+    - S3：擺 cup（whitelist cup-only 或 priority param），pose 當加分不卡；換 take 前發 /brain/reset_context。
+    - S4：peace→OK→wiggle（e-stop 在手 + Roy 授權）；其他手勢無動作。
+    - S5：Studio 文字觸發「後空翻」→ 秒回拒絕 + Studio 紅字證據。
+    - Act1：依 P0-5 ladder（預設 B 遙控+Foxglove；A 需 e-stop；C 影片）。
+    - 主控分工：MacBook 按 Studio 隱藏五幕鈕（FLOOR）+ 一人 SSH 在 Jetson 待命 param set backup + Trace-Watcher/計時/canned 觸發人。
+    - 跑 demo-preflight `--full`。
+- **Forbidden scope**:
+  - 不開 auto-advance 預設。
+  - 不演任何未授權 Go2 motion。
+- **Evidence**:
+  - 整合所有 lane 的 6/18 SOP；Live HITL 五幕結果為基準。
+  - `docs/runbook/2026-06-18-operator-runbook.md`
+- **Acceptance criteria**:
+  - checklist 涵蓋五幕 + Act1 + 啟動驗證 + 主控分工 + preflight。
+  - 6/17 跑一次完整 dry-run，逐項打勾。
+- **Tests**:
+  - `demo-preflight --full` 通過。
+- **HITL required**: yes（全流程彩排需 Jetson + Go2 + Roy + 操作員）
+- **Rollback**: 各幕都有 fallback（見各 issue）。
+- **Suggested owner/lane**: Roy HITL（主持彩排）；各 lane 提供各幕 SOP。
+
+---
+
+# P2
+
+## [P2-1] YOLO26s 換模研究（6/18 前不換）
+
+- **Title**: YOLO26s 換模研究：4 顆 ONNX 已 export 未上 Jetson，6/18 前大概率不換（B-4 預設不換）
+- **Priority**: P2
+- **Deadline**: post-6/18
+- **Scope**:
+  - 記錄已查證：`yolo26s_640/yolo26n_960/yolo26s_960/yolo26n-pose_640` ONNX 早於 6/10 export 完、shape 全相容 `(1,300,6)`，但未 rsync 上 Jetson、TRT 未預燒。
+  - 結論：6/18 前不換（S3 真兇是 brain 不是模型；換模 hard-to-reverse、需 TRT 預燒 + RAM 重量 + Roy 點頭 + rollback 驗證）。
+  - 若 Roy 要數據：rsync 4 顆 ONNX（additive 5min）→ 前夜 TRT 預燒（不開 demo stack）→ 上機矩陣量 recall/混淆/Hz/RAM；`env OBJECT_MODEL=...` 一行切換（launch 已支援）。
+  - 換模 gate：T2 同時滿足 cup@1.5m≥80% + 混淆較 n 明確下降 + ≥3Hz + RAM 餘≥0.8GB + 溫度<75°C + Roy 點頭 + rollback 驗證，落地時機 post-6/18 + 補 ADR。
+- **Forbidden scope**:
+  - 6/18 前不 model runtime switch（forbidden）。
+  - 換 960 模型必 `OBJECT_INPUT_SIZE=960` 同步（fixed-shape）；960 配 640x480 相機=插值自欺。
+- **Evidence**:
+  - `.tmp/yolo_export/out/yolo26s_640.onnx`（38MB）/ `export.log`
+  - `object_perception/launch/object_perception.launch.py:26-39`
+- **Acceptance criteria**:
+  - 研究結論記錄（6/18 前不換 + gate 條件 + 切換指令）。
+- **Tests**:
+  - 若 Roy 要量：上機矩陣（屬 P1-10 工具）+ ORT CPU sanity。
+- **HITL required**: yes（若要上機量需 Jetson + Roy 在場）
+- **Rollback**: `env OBJECT_MODEL` 一行切回 n@640。
+- **Suggested owner/lane**: Roy（決策）；object/nav lane（若要量）。
+
+---
+
+## [P2-2] Supervision offline confusion matrix benchmark
+
+- **Title**: Supervision offline confusion matrix：WSL throwaway venv 對 demo 錄影/JSONL 跑（永不進 Jetson runtime）
+- **Priority**: P2
+- **Deadline**: post-6/18（若 Roy 給素材路徑可 today-able）
+- **Scope**:
+  - 用 `uv venv .tmp/sv_venv && uv pip install supervision`（禁裝 Jetson）對 demo 錄影 MP4 + `/event/object_detected` JSONL 跑 `supervision_evidence_spike.py` 產 annotated MP4 + filtered JSONL；再用 `sv.metrics ConfusionMatrix(cup/phone/bottle)` 出真 per-frame 混淆矩陣餵 P0-1/P2-1 決策。
+  - 產物（MP4/JSONL/CSV）不進 git；decision_id join 經 custom_data 回拋 Lane 2。
+- **Forbidden scope**:
+  - 永不把 supervision pip install 上 Jetson（硬依賴完整 opencv-python，違反 ≥0.8GB 紀律）。
+  - 不做 runtime tiling/SAHI（已裁出局，過不了 ≥3Hz 門檻）。
+- **Evidence**:
+  - `benchmarks/scripts/supervision_evidence_spike.py:103-125`
+  - `docs/perception/research/2026-06-11-objdet-upgrade-synthesis-result.md:45`
+- **Acceptance criteria**:
+  - 產出 cup/phone/bottle 真混淆矩陣（offline，WSL）。
+- **Tests**:
+  - 無 runtime；spike 腳本跑通。
+- **HITL required**: no（WSL offline；唯一需 Roy 指認錄影/JSONL 素材路徑）
+- **Rollback**: N/A（throwaway venv，不進 runtime）。
+- **Suggested owner/lane**: Codex/Carl（WSL offline benchmark）；Roy 指認素材。
+
+---
+
+## [P2-3] S3 dedup 換 take SOP
+
+- **Title**: S3 換 take SOP：producer 5s class_cooldown + brain 60s OBJECT_REMARK_DEDUP 疊加 → 每次擺 cup 前發 /brain/reset_context
+- **Priority**: P2
+- **Deadline**: 6/17（納入彩排 SOP）
+- **Scope**:
+  - 確認 `OBJECT_REMARK_DEDUP_S=60.0`（per-class）+ producer `class_cooldown_sec=5.0` 疊加 → cup 講一次後 60s 內被 suppress，換 take <60s 沉默被誤判成 bug。
+  - SOP（零 code）：換 take 前 `ros2 topic pub --once /brain/reset_context std_msgs/Empty`（已有清 `_object_remark_seen` 邏輯）。
+  - P2 可選：`OBJECT_REMARK_DEDUP_S` param 化（預設 60=byte-identical），demo profile 調短 15-20s。
+- **Forbidden scope**:
+  - 本輪不改 dedup 預設值。
+- **Evidence**:
+  - `interaction_executive/interaction_executive/brain_node.py:78`（dedup）/ `:2528`（reset 清 seen）
+  - `object_perception/config/object_perception.yaml:15`（5s cooldown）
+- **Acceptance criteria**:
+  - 彩排 SOP 納入「換 take 前發 reset_context」。
+- **Tests**:
+  - 若 param 化：dedup param 單測。
+- **HITL required**: no（SOP 為主；param 化若做需驗）
+- **Rollback**: dedup param 預設 60 = byte-identical。
+- **Suggested owner/lane**: brain-studio-lane（SOP + 可選 param 化）。
+
+---
+
+## [P2-4] PawAI CLI PowerShell native blocker list
+
+- **Title**: PowerShell native blocker list：明確列為不支援（exit 10）、不繞過、導向 wsl --install
+- **Priority**: P2
+- **Deadline**: post-6/18（隊友卡 Windows 才急用）
+- **Scope**:
+  - 產出 blocker list（docs，不改 code）：
+    1. exit 10 確定發生（`platform.py:40-45` windows_native，reason 已點名 PowerShell/CMD/Git Bash）。
+    2. 根因不只一個閘門：無本機 bash 跑 demo .sh、~/.ssh/config 語意、rsync Windows 語意、repo .sh。
+    3. 正解 = `wsl --install -d Ubuntu` 後在 WSL2 跑（repo clone 到 `~/` 不要 /mnt/c）或用 MacBook。
+    4. 6/18 前不解 PowerShell native（forbidden：不做 full CLI v2/Typer 重寫）。
+  - 可選 post-6/18 P2 修：H3 false-block（malformed /proc/version 含 microsoft 但無 'wsl2' 字面誤判 wsl1）改 default 視為 wsl2，加 test。
+- **Forbidden scope**:
+  - 不為 PowerShell 把 `shell.stream` bash 呼叫改 cross-platform subprocess。
+  - 不做 full CLI v2/Typer 重寫。
+- **Evidence**:
+  - `tools/pawai_cli/pawai_cli/platform.py:40/44/111`
+  - `tools/pawai_cli/pawai_cli/shell.py:43`（無 bash → 127）
+  - `docs/pawai_cli/README.md:68`
+- **Acceptance criteria**:
+  - blocker list docs 列全根因 + 一步到位 `wsl --install -d Ubuntu` 指引。
+- **Tests**:
+  - 若修 H3：test_platform.py 對應 case。
+- **HITL required**: no（docs；H3 修為純編輯 + 單測）
+- **Rollback**: 純文件；H3 修為小 PR 可 revert。
+- **Suggested owner/lane**: pawai-cli lane。
+
+---
+
+## [P2-5] post-6/18 single Go2 driver 架構重構
+
+- **Title**: post-6/18 Single Go2 Driver refactor：LT-0 profiling gate → LT-1 修 T0 URDF → LT-2 superset launch → LT-3~LT-6
+- **Priority**: P2
+- **Deadline**: post-6/18（全待 LT-0 profiling 過 + Roy 授權 + e-stop + 真機 motion HITL）
+- **Scope**:
+  - 記錄治本架構（背景研究，零 runtime 變更）：
+    - 雙 driver 衝突是真實架構斷層：Go2 對單一 ROBOT_IP 只接受一條 WebRTC peer，兩份 robot.launch.py + nav2_amcl 裸 driver = 多個 RTCPeerConnection 搶同一台 Go2 → ICE FROZEN→FAILED + topic 撞名。
+    - LT-0：corun Config A profiling（brain 全感知 + 完整 nav 8GB）是 gate；FAIL 則退分時。
+    - LT-1（P0）：從 single-mode URDF 移除 map→odom/odom→base_link fixed joint（T0 dual-authority，與 AMCL/driver 動態 TF 衝突），單檔一鍵 revert。
+    - LT-2：single-driver superset launch（nav2:=true mux:=true teleop:=false），nav lane 不再自起 driver。
+    - LT-3：nav2_amcl 改走 robot.launch.py + 同一 twist_mux，controller remap /cmd_vel_nav。
+    - LT-4：修 enable_lidar arg leak（full_demo 傳 enable_lidar:=false 但 launch 沒宣告 → 被丟棄，driver 維持 True 仍 decode LiDAR）。
+    - LT-5/LT-6：共享 brake 決策層（brain SafetyLayer 訂 reactive_stop status）+ actuation 層（driver interlock 同擋 cmd_vel Move + webrtc Move 1008），皆 default-off gated。
+  - 6/18 前最小整合：文件禁令（dual-driver 寫進 lock collision）+ 靜態 no-motion 驗證 + raw LiDAR 證據窗（需先過 corun Config B profiling）。
+- **Forbidden scope**:
+  - 6/18 前不合併兩 launcher driver/mux、不讓 nav2_amcl 走 mux、不 always-on reactive_stop 疊進 demo、不任何 goto/DriveOnHeading/cmd_vel live motion 驗證。
+  - 全部需真機 motion HITL，6/18 前不做。
+- **Evidence**:
+  - `go2_robot_sdk/.../webrtc/go2_connection.py:72/107`（單一 peer/channel）
+  - `go2_robot_sdk/urdf/go2.urdf:49-50/71-72`（T0 fixed joint）
+  - `go2_robot_sdk/go2_robot_sdk/presentation/go2_driver_node.py:132`（enable_lidar default True）
+  - `docs/navigation/plans/2026-06-14-unified-demo-stack-single-go2-driver-plan.md`
+- **Acceptance criteria**:
+  - 架構計畫文件完整（LT-0~LT-6 標 PLANNED + 順序依賴 + gate 條件）。
+  - 6/18 前只落 ST-1/ST-2/ST-3/ST-5（文件 + no-motion 驗證 + 證據窗）。
+- **Tests**:
+  - LT-1 後 `echo /tf_static` 不含 map→odom/odom→base_link；M1 走直 n=3（需 e-stop）。
+- **HITL required**: yes（全部 post-6/18 真機 motion HITL）
+- **Rollback**: 每項 default-off / 單檔一鍵 revert / env 切換。
+- **Suggested owner/lane**: nav-avoidance-lane（post-6/18）；Roy 授權 + e-stop。
+
+---
+
+## [P2-6] reactive_stop path-corridor / footprint-aware 升級
+
+- **Title**: reactive_stop path-corridor / footprint-aware 升級（post-6/18 opt-in param，預設仍 cone）
+- **Priority**: P2
+- **Deadline**: post-6/18（~7/2，需卡尺實測機身）
+- **Scope**:
+  - 記錄：reactive_stop body-forward 錐不對齊斜走路徑、不考慮機身寬度（footprint 0.6×0.3 短於真實 0.7×0.31、機鼻 ~0.4-0.5m）→ 走歪時 off-axis 障礙進 danger 前機身角已可能接觸。
+  - 升級：path-corridor（沿速度方向矩形含機身寬）+ footprint-aware，opt-in param 預設仍 cone（byte-identical）。
+  - 6/18 不靠「走歪 + reactive 兜底」——Act1 走 standalone 純停障（直線前進或不前進，不走 goto 斜方向）。
+  - Nav2 Collision Monitor polygon footprint 需卡尺實測機身。
+- **Forbidden scope**:
+  - 6/18 前不做（Act1 不靠 reactive 兜底走歪）。
+  - 不改 cone 預設行為。
+- **Evidence**:
+  - `go2_robot_sdk/go2_robot_sdk/lidar_geometry.py:5-51`
+  - `go2_robot_sdk/config/nav2_params.yaml:220-238`（footprint 0.6×0.3）
+  - `docs/navigation/2026-06-13-nav-motion-incident-root-cause-plan.md:274`
+- **Acceptance criteria**:
+  - 升級計畫記錄（opt-in param + 卡尺實測待辦）。
+- **Tests**:
+  - post-6/18：corridor 納機身投影後 off-axis 障礙進 danger 的單測。
+- **HITL required**: yes（post-6/18 真機 + 卡尺）
+- **Rollback**: opt-in param 預設 cone = byte-identical。
+- **Suggested owner/lane**: nav-avoidance-lane（post-6/18）。
+
+---
+
+## 附錄：給 Roy 的關鍵 open decisions（審草案時一併拍板）
+
+1. **S3 修法選哪個**：① 現場 `ros2 param set class_whitelist '[41,...]'`（零 code、最安全）vs ② brain `_on_object` 做 cup 優先排序（治本、需授權 + smoke 全綠）。Roy「cup 優先、bottle 也可」暗示 ②，但 ② 是 6/18 前 runtime code 改。
+2. **cell_phone 處置**：完全移出白名單（保留 UI）還是可講但排最後？建議 phone 移出講話白名單。
+3. **pose 當加分**：接受「有 cup 一律講 cup，sitting 只在偵測到時升級複合句」？複合句現硬鎖 name=='Roy'，是否泛化成任意 known person？
+4. **Act1 6/18 採哪層**：建議預設 B（遙控+Foxglove），A 為 e-stop upside，C 影片保底。Roy 是否同意 A 不當預設主線？
+5. **Act1 收工前 evidence pull**：今晚是否先 `pawai evidence pull` 保住 Act1 那發的 zone 時間線（否則 stack 重啟遺失）？
+6. **S4「關 Studio 手勢按鈕」指哪個**：GestureToggle（ON/OFF）還是 SkillButtons（直觸 wiggle）？後者對 Go2 安全更關鍵。
+7. **S4「只保留 peace」程度**：接受現行（thumbs_up_demo_ack + gesture_direct_disabled）還是要硬性白名單（新增 gesture_allowlist code，需授權）？
+8. **S5 觸發方式**：6/18 主線走 Studio 文字（建議）還是語音現場喊？是否維持「後空翻/翻跟斗」不換詞？
+9. **DEMO_CANNED_TABLE 15 句**：6/15 簽核（含 S2 三層、S4 wiggle/fallback 句、S5 拒絕句）。
+10. **auto-advance**：6/18 是否任何一幕開？建議只 S2 開（自動補進場 greet + max_wait rescue），其餘 manual floor。
+11. **gateway auth**：6/18 凍結期維持 OFF（MacBook 直接可達）還是設 token？若設須同步前端帶 token。
+12. **CLI face P0-A/P0-B**：6/18 前是否實作（需授權）？face verify（sim 閉環）確認延後 post-6/18。
+13. **物體上機矩陣排程**：6/15-16 全天 / 半天精簡 / post-6/18？S3 不靠換模解決，換模上機可安心排 post-6/18。

--- a/docs/superpowers/reports/2026-06-14-codex-second-opinion-act1-s3.md
+++ b/docs/superpowers/reports/2026-06-14-codex-second-opinion-act1-s3.md
@@ -1,0 +1,64 @@
+# Codex 獨立第二意見 — Act1 nav 失敗 + S3 物體關懷台詞錯
+
+> 2026-06-14。Codex read-only 交叉診斷（未改 code、未發 motion）。本檔為獨立第二意見快照，
+> 將折進 [`2026-06-14-live-demo-iteration-findings.md`](2026-06-14-live-demo-iteration-findings.md) 的「Codex 交叉檢查」一節。
+> 用途：對抗主線假設、抓主線可能查錯路的點。
+
+## 最關鍵兩點（第二意見價值）
+
+### Act1：Stage1 數據本身就「不該停」
+- `reactive_stop_node` 預設 `danger_distance_m=1.1`、`slow_distance_m=1.7`，`classify_zone()` 用嚴格 `<`。
+- Stage1 量到正前 ±15°=**2.09m（clear）**、右前 +20°=**1.70m（剛好 slow 邊界）**。
+- → **在現有門檻下，這組距離根本不會觸發 stop**。Act1「沒成功」很可能不是 node 沒啟、不是 cmd_vel 沒到 driver，而是 **障礙放太遠 / demo 幾何與門檻設計** 問題。
+- 次要：standalone slow 發 `0.45 m/s`，但 Go2 sport mode `MIN_X≈0.5`，driver 不會把 0.45 補到 0.5 → **Go2 收到 Move 0.45 但實機可能不動**，看起來像「沒動」。
+- 主線文件多在解釋 Nav2 / progressive reactive_stop（slow 是 silent），但 **Act1 是 standalone**（直接 publish 0.45/0.60 到 `/cmd_vel`），不能直接套 progressive 那條主因。T0 TF authority / AMCL yaw 對 standalone 路徑（`/scan_rplidar → reactive_stop → /cmd_vel → driver`）不是第一優先，過度套 Nav2 incident 會分散注意力。
+
+### S3：Brain 只取 `objects[0]`，且「Roy 的手機」可能不是 object_remark 產物
+- `perception_router.parse_object()` 只讀 `objects[0]`；`object_perception_node._publish_events()` 依模型輸出順序 append，**沒有 cup / 中心 / 距離優先** → cup 被 phone 蓋掉。這比 cooldown/dedup 更直接的根因。
+- **UI 看到 cup ≠ Brain 選 cup**。
+- `build_object_tts("cell_phone")` 只組「看到手機了」，**不會說「Roy 的手機」**。若實際台詞含「Roy」，可能來自 conversation graph / LLM world_state（`recent_objects`），**只查 `build_object_tts()` 會查錯路** → 要先分辨 emitted skill source 是 `object_remark` 還是 LLM/chat reply。
+- 「沒 pose」是獨立 pipeline 問題（`vision_perception_node` majority vote 太嚴全 None），不會由 cup 自動修復。
+
+## Ranked 可證偽根因（完整）
+
+### Act1 導航避障失敗
+1. **[證據支持] LiDAR 活著但障礙沒進 stop 條件**（2.09m clear / 1.70m 邊界 slow）。驗證：reactive status `zone=clear/slow`、`reactive_stop_active=false`、`/cmd_vel` 非 0。
+2. **[證據支持] Go2 sport mode 低速門檻使 slow 0.45 失真**（driver clamp 到 MAX 0.5，不補 0.45→0.5）。驗證：`/cmd_vel`=0.45、driver 收到 Move 0.45 但實機不動；調高 slow profile 或 slow→stop 後行為改變即證偽。
+3. **[證據支持] reactive 幾何是角度扇形、非 footprint/corridor**（`compute_front_min_distance()` 只取 front arc 最小距離，走歪撞側邊會誤判沒啟動）。驗證：sector slow/clear 但機身側邊已交會障礙；改 footprint 會提前進 danger。
+4. **[未驗證] driver/WebRTC ready gate 不足**（script 只 sleep 8s）。驗證：log 有無 driver ready / `_on_cmd_vel` / send 成功。
+5. **[未驗證] 啟到錯 instance 或參數沒生效**（預設 topic `/cmd_vel_obstacle`、offset 0；script 傳 `/cmd_vel`+offset π+danger 1.1+slow 1.7，但只 kill tmux session 不清 orphan）。驗證：node startup log/params 是否真為這組值、mode=standalone。
+6. **[未驗證] 障礙高度不在 LiDAR 掃描平面**（低矮/透明/細腳）。驗證：換穿過 LiDAR 平面的實體物，sector 立刻 `<1.1m`。
+
+### S3 物體關懷台詞錯
+1. **[證據支持] Brain 只取 `objects[0]`，cup 被 phone 蓋掉**。驗證：`/event/object_detected` payload `objects[0]=cell_phone`、cup 排後面。
+2. **[證據支持] phone 先觸發後，active plan / TTS / skill cooldown 跨物件壓掉 cup**（class dedup 是 per-class 60s，但 skill cooldown / active plan 跨物件）。驗證：`/brain/trace` 出現這些 gate。
+3. **[未驗證] attention gate 抑制 cup**（`_on_object()` 要求 `ENGAGED`：臉可見、≤1.6m、dwell ≥1.5s）。驗證：trace gate=`attention_engaged` 且 face 沒到 ENGAGED。
+4. **[證據支持] pose 沒出是獨立 pipeline 問題**（majority vote 太嚴全 None），不由 cup 修復。驗證：`/event/pose_detected` 缺席或無 `sitting`。
+5. **[未驗證] demo config/phase drift**（`executive.yaml` `demo_phase: all`；runtime 沒載或 phase 不允許 object 會被 `_phase_allows("object")` 擋）。
+6. **[第二路徑疑點] 「Roy 的手機」非 `build_object_tts()` 產物**，疑來自 conversation graph / LLM world_state。驗證：emitted skill source = `object_remark` 還是 LLM/chat reply；檢查 `world_state.recent_objects`。
+
+## Default-off / 可 rollback 修方向（僅方向，未實作）
+
+**Act1**
+- default-off `reactive_stop_demo_profile`：把 standalone slow/normal/danger 門檻、front arc、front offset 固定成可觀測 profile，關閉即回原參數。
+- default-off slow 行為選項：`slow_policy=stop` 或 `slow_speed ≥ Go2 usable floor`，避開 0.45 不可靠區。
+- default-off footprint/corridor 判斷：保留 sector min distance，可選機身寬度 + 前進 corridor。
+- read-only preflight/status gate：啟動前只檢查並顯示 reactive params、publisher topic、driver ready、scan age、zone，不發 motion，異常 fail closed。
+
+**S3**
+- default-off S3 object selector：在 `objects[]` 中優先選 cup 或中心/近距離目標，rollback 回 first-object。
+- object gate trace + suppressed-reason：對 attention/active_plan/TTS/cooldown/phase gate 輸出明確 reason（debug-only）。
+- S3 phase entry 可回滾 context cleanup：進 S3 清 object dedup、object_remark cooldown、過期 active plan，僅限該 phase。
+- pose 不作 cup 普通台詞前置：compound「Roy 坐著拿杯子」仍需 pose，普通 cup care line 只依賴 cup target（default-off S3 fallback line）。
+
+## 相關檔案（絕對路徑）
+- `go2_robot_sdk/go2_robot_sdk/reactive_stop_node.py`
+- `go2_robot_sdk/go2_robot_sdk/lidar_geometry.py`
+- `go2_robot_sdk/go2_robot_sdk/application/services/robot_control_service.py`
+- `go2_robot_sdk/go2_robot_sdk/presentation/go2_driver_node.py`
+- `scripts/start_reactive_stop_tmux.sh`
+- `interaction_executive/interaction_executive/brain_node.py`
+- `interaction_executive/interaction_executive/perception_router.py`
+- `object_perception/object_perception/object_perception_node.py`
+- `object_perception/config/object_perception.yaml`
+- `vision_perception/vision_perception/vision_perception_node.py`

--- a/docs/superpowers/reports/2026-06-14-live-demo-iteration-findings.md
+++ b/docs/superpowers/reports/2026-06-14-live-demo-iteration-findings.md
@@ -1,0 +1,278 @@
+# Live Demo 迭代發現報告（2026-06-14）
+
+> 狀態：研究 + 計畫，零 runtime code 變更、未發 GitHub issue
+> 來源：2026-06-14 Roy 在場 live HITL 試跑 + 6 條 lane 研究結果（Act1 nav / S3 object / object A-B / S2 face / S4 gesture / S5 safety / demo-flow / CLI 跨平台 / nav-single-driver）
+> 範圍：6/18 發表前的段落穩定化；以「症狀為準」分流根因，先穩 S2-S5、後決 Act1 fallback
+
+---
+
+## 1. TL;DR
+
+6/14 live HITL 的整體結論是「四互動段落（S2/S4/S5）已 PASS、S3 是可純軟體修復的 brain 端 bug、Act1 導航避障是唯一硬卡關但本質是診斷分叉樹而非單一失敗點」。S2 認人問候、S4 手勢確認、S5 安全拒絕三段在 live config 下不只「看起來能用」，而是與程式碼路徑一致的真 PASS（S5 是 rule-first 0s、no-LLM、執行層 banned_api reject，結構上無法被繞過）。S3「辨識到 cup 卻一直講手機」的真兇主要在 Brain 端：cell_phone(id67) 同時在 object_perception 白名單與 OBJECT_CLASS_ZH，Brain 又只取 `objects[0]`（YOLO 信心最高者），全鏈無 class 優先排序，phone 信心常高於桌上小 cup 就永遠搶話——這完全是純軟體可修，不需換模型。Act1 失敗的最高優先動作不是修導航，而是先用 Roy 給的 Stage1 量值（LiDAR 11.9Hz 活、front±15°=2.09m、+20°=1.70m）分流到正確的診斷分支，並在收工前 `pawai evidence pull` 保住當天證據。本輪原則：先把 S2-S5 穩住，再決定 Act1 用哪個 fallback，不要先大修導航（導航最容易吃掉整晚）。
+
+### 段落狀態表
+
+| 段落 | 狀態 | 根因（一句） | 6/18 影響 |
+|------|:----:|------|------|
+| **Act1 導航避障** | ❌ FAIL | 不是單一失敗點而是診斷分叉樹；當天到底跑哪個 topology（standalone reactive_stop vs progressive+goto）未知＝80% 分支的根；LiDAR 活但前錐讀 2.09m 淨空＝reactive 沒看到障礙（最可能：障礙低於 ~0.50m 掃描平面） | P0：nav motion 維持 NOT_DEMO_READY，退 fallback②（遙控+Foxglove LiDAR 證據）/ ③（影片）；A 層（standalone reactive_stop 障礙停）僅 Roy+e-stop upside |
+| **S2 認人問候** | ✅ PASS | live config `greet_require_sitting=false`，靠 face stable+20s cooldown，不依賴 sitting/LLM/depth；台詞靜態 template 不會 dead air | GO；唯一單點故障＝face_db sim 老化，須 demo 前現場光線 re-enroll + face_db 衛生 |
+| **S3 物品關懷** | ⚠️ DEGRADED | Brain 只取 `objects[0]` + 無 class 優先 + cell_phone 在白名單＝phone 永遠搶話；object_remark 卡 ENGAGED gate 慢一拍；pose 邊緣觸發（一直坐著不發事件）讓 sitting context 不更新 | P0：純軟體可修（whitelist 收 cup-only 或 brain class 優先排序）；pose 改加分非硬依賴 |
+| **S4 手勢確認** | ✅ PASS | peace→OK 二確認→Go2 wiggle，與 `peace_wego_confirm=true` 路徑一致 | GO（需鎖配置：只留 peace、關 Studio 手勢按鈕、wiggle 屬 forbidden motion 需 Roy+e-stop） |
+| **S5 安全拒絕** | ✅ PASS | rule-first（unsafe_request 在 LLM 之前 return）+ 執行層 validate banned_api:1301，雙層防線、phase-independent | GO；維持 backflip 已 proven 端到端；6/18 主線走 Studio 文字觸發規避 ASR 誤聽 |
+| **整體 demo 流程** | ⚠️ 機制穩、flow 有風險 | 手動 phase 切換機制穩；但 auto_advance 預設 OFF＝never-dead-air 全靠操作員手按；offline_mode topic 不寫回 param＝驗證陷阱；operator-runbook 契約備註已過時 | P0/P1：靠彩排分派計時+canned 觸發角色；runbook docs 6/17 前必更新 |
+
+---
+
+## 2. 各段落根因分析
+
+### 2.1 Act1 導航避障（❌ FAIL — P0）
+
+**現象**：Act1 障礙停沒成功。Roy 列候選含「Go2 沒動 / Go2 走歪 / reactive_stop 沒啟 / cmd_vel 沒到 driver / 障礙高度不在 LiDAR 掃描平面 / LiDAR 沒看到」——這些候選互斥，代表連「當天是哪種啟動形態」都還沒確定。Stage1 已量到 LiDAR 11.9Hz 活、front±15°=2.09m、+20°(右前)=1.70m。
+
+**Ranked 根因假設**：
+
+1. **(最根本) Act1 當天跑哪個 topology 未知＝診斷分叉的根**。standalone reactive_stop（`start_reactive_stop_tmux.sh`，Go2 靠 `normal_speed=0.60` 自走遇障停、不靠 AMCL/goto）vs progressive nav stack（`start_nav_capability_demo_tmux.sh`，Go2 靠 goto_relative 前進、reactive_stop 只在 danger 發 0 pause nav）。若是 progressive，失敗症狀應是「走歪/超衝」（6/13 R1/R2 已撞牆）而非「沒動」；若是 standalone 且 Go2「沒動」→ 是 cmd_vel 沒到 driver 或 warmup/mux 問題；若 Go2 動了沒停 → LiDAR 沒看到障礙。
+2. **(最可能技術因) LiDAR 活但前錐讀 2.09m 淨空＝reactive 沒看到障礙**。RPLIDAR A2M12 是 2D 單線掃描，掛 base_link+0.18m、base_link 離地 ~0.32m → 掃描面約離地 0.50m。任何矮於 ~0.50m 的障礙（矮箱/腳/椅面/抱枕/狗碗）完全不在掃描面 → front±15° 讀到的是背後 2.09m 的牆。
+3. **progressive mode 在 slow band 沉默 + 側前 +20°(1.70m) 落 slow band**。open_space slow band（danger 1.1 / slow 1.7），+20°/1.70m 恰在邊界內側；progressive 在 slow/clear 回 None（沉默），只在 danger 發 0 → 側前 1.70m 家具「被看到了但不會觸發停」。
+4. **(若 Go2 沒動) cmd_vel 沒到 driver / mux 鎖死 / MIN_X 門檻**。standalone 覆寫 `cmd_vel_topic:=/cmd_vel` 直連 driver，但若殘留 twist_mux（上次 nav session 沒清）→ reactive 發的 0.60 被 mux 蓋掉；或 `slow_speed=0.45 < MIN_X 0.5` 被 Go2 silently 忽略，slow band 不抬腳看起來「沒動」。
+5. **(若 Go2 走歪) 6/13 已查根因重演**：R1 AMCL map-frame yaw 注入「前方」斜走 + R2 goto 不 enforce max_speed 超衝（0.5m→1.04m）+ T0 URDF 把 map→odom/odom→base_link 當 fixed joint 發 /tf_static 雙 authority 衝突（CO-PRIMARY，須先 `echo /tf_static` 排除）+ R5 靜態閘 yaw-blind。
+
+> **Codex 交叉檢查（見 [`2026-06-14-codex-second-opinion-act1-s3.md`](2026-06-14-codex-second-opinion-act1-s3.md)）**：對著參數算，Stage1 量值（正前 2.09m clear、右前 1.70m 邊界 slow）**在現有門檻 `danger=1.1 / slow=1.7` 下本來就不該觸發 stop**。所以 Act1「沒成功」最可能是 ① 障礙物太矮（不過 ~0.50m 掃描面）② 障礙放太遠（>1.1m，Go2 走到 1.1m 前就該停但沒走到）③ Go2 根本沒走（standalone `slow_speed=0.45 < MIN_X 0.5`，Go2 收到 Move 0.45 silently 忽略，看起來像「沒動」）。Codex 並提醒：**Act1 是 standalone 路徑（`/scan → reactive_stop → /cmd_vel → driver`），不要硬套 Nav2/AMCL/T0 那套 progressive 故障模型**，會分散注意力。
+
+**需查證據**（全 no-motion，收工前優先）：當天 tmux session 名與啟動指令；`ros2 node list`（幾個 go2_driver）；`ros2 action list | grep goto`（殘留 active goal）；`pawai evidence pull` 拉 [PR1a] goto log（有=goto 路、無=standalone 路）；`echo /tf_static --once`（排除 T0，最高優先）；障礙物實際高度/材質；`lidar_front_sector.py --once` 障礙物放正前 1.0m 是否讀 ~1.0m。
+
+**可修方案**：診斷先行確認 topology；6/18 Act1 障礙停鎖定 standalone reactive_stop（不用 progressive+goto，那條綁 6/13 走歪根因）；障礙物寫死 >0.6m 高、不反光、放正前 ≤1.0m，或乾脆用「人站正前」（人高度必過掃描面，trackB 6/8 NAV-2 已用人/箱 1.03m 驗過 danger 停）；indoor_tight ±18° 窄錐必綁低速 ≤0.2 m/s；改 profile 必 kill 重啟帶參數（`front_arc_deg`/`danger`/`offset` 只在 `__init__` 讀）。
+
+**6/18 fallback ladder（建議當天採層）**：
+- **B 層（預設主線）**：遙控/手推障礙 + Foxglove `/scan_rplidar` 點雲 + reactive zone 狀態當「邊緣端即時感知」證據，零 motion 風險（Go2 站著、移動的是障礙物），100% 可交付。
+- **A 層（Roy+e-stop upside）**：standalone reactive_stop live 障礙停，僅在 Roy 在場 + e-stop 就位 + 障礙物高度過 LiDAR 平面 + indoor_tight 窄錐重驗無誤擋後升上，人站正前最穩、最多一次，不穩立刻退。
+- **C 層（永遠保底）**：S1 影片已錄（demo snapshot tag），旁白用保守版。
+
+**優先級**：P0。**需 HITL**：是（topology 確認、障礙物高度驗、e-stop 就位皆需 Roy 在場；本輪只做 no-motion 診斷，不發任何 goto/forward）。
+
+---
+
+### 2.2 S2 face greet 穩定性（✅ PASS — GO）
+
+**現象**：Roy 一靠近約 2 秒就 greet、人臉辨識快、3m 也 OK；且 S3 觀察到 pose(sitting) 沒出，但 S2 greet 仍正常觸發。
+
+**Ranked 根因假設（為何 PASS）**：
+
+1. **(最可能) live demo 走 `interaction_executive.launch.py` 載入 `executive.yaml`，已設 `greet_require_sitting=false`**——greet 不硬依賴 sitting，與 Roy「~2 秒就 greet、沒 pose 也觸發」完全一致。`demo_phase="all"` 使 `_phase_allows("greet")` 永為 True，`stranger_alert_enabled=false` 移除了 6/9 黑屏真兇。
+2. **觸發路徑＝unknown→known 的 identity_stable 事件**（`face_identity_node.py:709-718`）→ `brain_node._on_face` → 20s/人 cooldown + skill contract 60s cooldown 雙層防重複；台詞為靜態 template「{name}，歡迎回來，我看到你了。」+ MOTION hello，不依賴 LLM、不會 dead air。
+3. **(陷阱) brain code default 是 `greet_require_sitting=True`（`brain_node.py:774`），yaml override 才是 false**——有人若用 code default 判斷會誤以為 S2 有風險。
+
+**收斂風險（不擋 PASS、但降穩定度）**：
+
+- **face_db sim 老化是 greet 整條路徑的單點故障**（最高優先）。6/8 研究記錄 Roy 舊圖 sim 掉到 ~0.2 被判 unknown、re-enroll 後回 0.73-0.81。greet 不讀 depth（低光不會因深度抖動而擋），低光只影響 RGB 端 YuNet 偵測 + SFace sim 老化。
+- **greet 是純 event-only**（進場 unknown→known 才觸發），Roy 一直在框內不會重問；重現 greet 須離框 ~5s（track_lost 後重進）；skill contract 60s cooldown 比 brain 20s 更長，是彩排連拍的真正瓶頸。
+- **face_db 子目錄黑名單未實裝**，`_backup`/`old` 殘留會被 `train_model` 當幽靈身份稀釋 centroid。
+
+**可修方案**：demo 前在現場光線下 re-enroll Roy + retrain（`pawai face enroll --person-name roy` → `pawai face rebuild` → 重啟 face node），備份資料夾務必移到 face_db **外**；現場保底 `ros2 param set /brain_node greet_require_sitting false`；站位 SOP 寫進 runbook（從鏡頭外走入或先遮臉 ~5s）；彩排前 `ros2 param set /brain_node greet_cooldown_s 3`、正式前改回 20。
+
+**優先級**：機制 P0（確認 yaml）、衛生 P0（re-enroll）。**需 HITL**：是（現場 re-enroll + sim 量測需 Roy 在 Jetson）。
+
+---
+
+### 2.3 S3 物體辨識 / 關懷台詞（⚠️ DEGRADED — P0）
+
+**現象**：杯子放面前 ~1m，UI 跳 cup，但 Brain 不講杯子、一直講 Roy 的手機(phone)；Brain 也沒偵測到 Roy 坐著（pose 沒出）。Roy 要求：cup 優先講、bottle 等也可講但 cup 優先、pose 只當加分不可卡住 S3。
+
+**Ranked 根因假設**：
+
+1. **(真兇 P0) `objects[0]`-only 選取 + 全鏈無 class 優先序 → phone 信心高就永遠搶話、cup 被丟**。producer `_publish_events` 依 YOLO NMS 信心降序建 `new_objects`，brain `parse_object/_on_object` 只取 `objects[0]`，全鏈零 class 排序 → 桌上小 cup 信心常低於近距大 phone，phone 佔 `objects[0]` 每輪被講。cell_phone(67) 同時在 `class_whitelist` 與 `OBJECT_CLASS_ZH('手機')`，build_object_tts 對 phone 回非 None。
+   - **已親自釘死（2026-06-14 code 驗證，見 [`2026-06-14-codex-second-opinion-act1-s3.md`](2026-06-14-codex-second-opinion-act1-s3.md)）**：`zh_tables.py:22` `OBJECT_CLASS_ZH` **確實含 `"cell_phone": "手機"`** → deterministic `build_object_tts("cell_phone")` 會講「看到手機了」（cell_phone 不在 `OBJECT_TTS_SPECIAL_SUFFIX`，無尾句）。但 `build_object_tts` 永遠**不會帶人名**，所以 live 聽到的「**Roy 的**手機」這句帶名字的，是 **LLM 路徑**簽名——`conversation_graph_node._format_recent_objects`（N3-A「[最近看到]」prompt 注入 `world_state.recent_objects`）餵給 LLM 自然講出。
+   - ⟹ **phone 同時餵兩條路徑**（deterministic object_remark **和** LLM recent_objects）。**所以最乾淨的修法是 producer 端 `class_whitelist` cup-only**——一刀同時餓死兩條路徑（phone 根本不進 `/event/object_detected`）；只改 brain 的 `objects[0]` 排序救不了 LLM 那條（recent_objects 仍會收到 phone）。nav-bg lane 稱「object_remark 白名單只有 cup/bottle/book」**不精確**：那是 `OBJECT_TTS_SPECIAL_SUFFIX`（只有這三類有額外尾句），完整 `OBJECT_CLASS_ZH` 講話白名單含 cell_phone。
+2. **(慢一拍) object_remark 硬卡 `attention==ENGAGED`**（需 D435 depth≤1.6m + dwell 1.5s）。S2 greet 一觸發就進 INTERACTING，要 quiet 8s 才回 ENGAGED → S3 緊接 S2，cup 被 attention_engaged gate suppress。D435 depth 在 1.5-2m 抖也使 dwell reset。
+3. **(pose 沒出) 雙因**。vision 端只在 pose_vote「變化」時才發事件（Roy 一開始就坐著→vote 從頭是 sitting→永不變→不發），brain 端 `last_sitting_seen_ts` 不更新；且即使 sitting 事件有發，demo config `demo_video_silent_sit_along=true` 把 sit_along 靜音、`demo_video_cup_compound=false` 又關掉 cup+sitting 複合句——pose 對 S3 既無聲又不更新 context。
+4. **(換 take 沉默) producer 5s class_cooldown + brain 60s OBJECT_REMARK_DEDUP 疊加**——cup 講一次後 60s 內同 class suppress，換 take 間隔 <60s 就沉默。
+
+**需查證據**：`ros2 topic echo /event/object_detected` 看同一秒 objects[] 順序與 cup/phone confidence（確認 phone 在 objects[0]）；`ros2 param get /object_perception_node class_whitelist`（67 是否在線）；`/brain/trace` 過濾 `class=cup` 看被哪個 gate 擋（attention_engaged / active_plan / tts_playing / object_remark_dedup）；`/event/face_identity` 的 distance_m 抖動範圍；`/event/pose_detected` 在持續坐著 vs 站起再坐。
+
+**可修方案**：
+- **P0 最小外科（brain 端 default-off）**：`_on_object` 對 `ev.objects` 先做 class 優先序排序再取首個——新增 `OBJECT_REMARK_PRIORITY=('cup','bottle','bowl','book',...)` param-gated（預設沿用 `objects[0]`=byte-identical），cup>bottle 滿足 Roy 需求。
+- **P0 現場應急（零 code）**：`ros2 param set /object_perception_node class_whitelist '[41,999]'`（cup-only）或 `'[39,41,45]'`（cup/bottle/bowl）——runtime callback 即時生效、可即時切回，phone 永不進 event。
+- **P1**：把 cell_phone 從講話白名單降級（build_object_tts 對 phone 回 None，類比 person 靜音），UI 仍顯示。
+- **P1（attention）**：新增 `object_remark_attention_min` param（預設 ENGAGED），設 NOTICED 時對 cup/bottle 放寬（face 穩定即可講），符合「pose/距離不可卡住 S3」。
+- **P1（pose 加分非硬依賴）**：cup remark 完全不依賴 pose，sitting 純 bonus（有 sitting 升級複合句、無 sitting 仍講 cup），複合句現硬鎖 `name=='Roy'` 建議泛化。
+
+**優先級**：P0（真兇 + attention）、P1（pose / dedup）。**需 HITL**：是（多需 Roy 在場 echo + trace 確認 phone 是否真在 objects[0]、cup 被哪 gate 擋；純感知+brain、不涉 Go2 motion，安全）。
+
+---
+
+### 2.4 物體模型 A/B 與 Supervision offline benchmark（P1，非阻塞）
+
+**核心結論**：S3「講手機」的真兇主要在 Brain 端、不是模型。模型本身確實會把 cup 誤認成 phone/bottle（acceptance §4：0.7m phone 4 次/bottle 2 次、1.5m phone 6 次），但這是次因——distance 不掉 recall（cup 0.7-1.5m 都近連續偵測），混淆才是痛點。**S3 修法是純軟體 brain 改動，完全不需換模型**。
+
+**YOLO26s 換模已查清**：4 顆 ONNX（yolo26s_640 / yolo26n_960 / yolo26s_960 / yolo26n-pose_640）早在 6/10 export 完、shape 全相容 (1,300,6)，但尚未 rsync 上 Jetson、TRT 未預燒。**結論＝6/18 前大概率不要換**（B-4 預設不換、hard-to-reverse、且 S3 真兇是 brain 不是模型）。換主 object 模型需 TRT 預燒（不可與 demo stack 同跑、1GB workspace OOM）+ RAM 重量 + Roy 點頭 + rollback 驗證。
+
+**今天可先做（零 runtime 風險）**：
+- 現役 n@640 跑 cup/bottle/phone/chair × 0.7/1.0/1.5m baseline 矩陣：`obj_matrix_cap.py`（只訂 object topic 避跨流污染，window≥6s）。
+- Supervision offline confusion matrix：`uv venv .tmp/sv_venv && uv pip install supervision`（**禁裝 Jetson**），用 demo 錄影 MP4 + JSONL 跑 `supervision_evidence_spike.py` → sv.metrics ConfusionMatrix 出真混淆矩陣。
+
+**960 input 已查證＝插值自欺**（相機只餵 640x480，餵 960 是純插值無新像素；imgsz=1280 已 superseded）。Supervision 鐵律 offline-only（硬依賴完整 opencv+matplotlib+scipy，絕不進 Jetson runtime）。
+
+**優先級**：P1（baseline 量化）/ P2（換模、960、tiling）。**需 HITL**：是（obj_matrix 要 live /event + Roy 指認錄影/JSONL 路徑）。
+
+---
+
+### 2.5 S4 gesture 確認流程（✅ PASS — GO）
+
+**現象**：比 peace → Brain 問「比 OK 就開始」→ 比 OK → Go2 wiggle（搖）。Roy 要求：只保留 peace 辨識、其他手勢關掉、關掉 Studio 手勢按鈕（peace 不太會誤觸）。
+
+**Ranked 根因假設（為何 PASS / 如何鎖配置）**：
+
+1. **(最可能) live 走 `peace_wego_confirm=true`** → `_GESTURE_CONFIRM={'peace':'wiggle'}`，peace→請求 OK 二確認→OK→wiggle，與 live 完全吻合。現行 `executive.yaml` 已 `gesture_direct_disabled=true`（`_GESTURE_DIRECT={}`）→ palm/fist/index/wave 進來不觸發任何動作，達成 80% 目標。
+2. **(唯一殘留) thumbs_up 仍在 `_GESTURE_CONFIRM`**（thumbs_up→wiggle），握杯/托腮易誤觸；設 `thumbs_up_demo_ack=true` 可改成只發輕量正向、不引出 wiggle。
+3. **OK confirm 穩定**：PendingConfirm 有 N8 `must_release_ok`（手已在 OK 位置會 gate 住直到放開，避免立即誤觸）；OK 只在 confirm window 內有效，平時亂比 OK 無害。OK 是唯一二確認路徑，不可關。
+4. **Studio「手勢按鈕」需釐清**：前端唯一手勢相關控制是 `GestureToggle`（ON/OFF 總開關），另有 `SkillButtons` 能直接 POST skill_request 觸發 wiggle（**繞過手勢/OK**）——後者對 Go2 安全更關鍵，可能才是 Roy 怕誤點的。
+5. **wiggle=api_id 1020 是站立原地扭動、非位移**，但仍是 Go2 實體 motion → 屬 forbidden scope（需 Roy 授權+e-stop）。
+
+**可修方案**：demo 啟動帶 `peace_wego_confirm:=true + gesture_direct_disabled:=true + thumbs_up_demo_ack:=true`（零 code，只有 peace 引 wiggle confirm）；釐清後從 live 面板隱藏 SkillButtons 手動 motion 觸發鈕；SOP 寫站位（D435 前 1-2m、單人、peace 穩住 ~2s、OK 穩住 ~1s）；S4 wiggle 前 Roy 授權 + e-stop 在手；台詞 fallback「好，我跟你 WeGo 一下！」（不發 motion）需 Roy 簽。
+
+**優先級**：P0（只留 peace 配置 + wiggle e-stop）、P1（OK 穩定 / Studio 按鈕 / 入框 SOP）。**需 HITL**：是（wiggle motion + 釐清「手勢按鈕」指哪個）。
+
+---
+
+### 2.6 S5 safety reject（✅ PASS — GO）
+
+**現象**：問後空翻/翻跟斗 → 秒回「這個動作不安全，我不能執行」，攔截成功。
+
+**Ranked 根因假設（為何是真 PASS 而非裝飾）**：
+
+1. **(最可能) 雙路徑皆 rule-first，LLM 結構上無法 override**。語音 `/event/speech_intent_recognized` 與 Studio 文字 `/brain/text_input`（經 `_on_text_input` 合流進 `_on_speech_intent`）都在 `brain_node.py:1391` 跑 `SafetyLayer.unsafe_request`，發生在 LLM/chat_buffer 之前（1437 行才進 LLM 等待），return 即走 → 0s、no-LLM、不可能被 LLM override。斷網/offline_mode 仍秒回（驗證 no-LLM）。
+2. **執行層 reject 是真實紅線**：`request_backflip`（name=backflip→api_id 1301∈BANNED_API_IDS）在 IE node validate 必然 reject 成 BLOCKED_BY_SAFETY，發 `/brain/trace`（verdict=BLOCKED gate=safety reason=banned_api:1301），gateway 落盤 `runtime/traces/*.jsonl` + WS 廣播到 Studio 紅字。
+3. **雙層防線**：即使有人繞鍵詞直接 `skill_request request_backflip`，validate 仍 100% 擋；backflip 也不在 LLM_PROPOSABLE_SKILLS。
+4. **phase-independent 已驗**：reject return 在任何 `_phase_allows` 之前，任何 demo_phase 都擋。
+5. **(唯一弱點) 鍵詞表固定 + ASR 誤聽**（Go2 風扇噪音 ~20%）——6/18 走 Studio 文字觸發（operator S5-Trigger）100% 命中鍵詞可完全規避。
+
+**可修方案**：無需修改（已 proven、36 測試全綠）；6/18 S5 主線走 Studio 文字觸發、語音當加分 take；建議維持 backflip（已 6/10 proven 端到端），除非 Roy/老師明確要換詞（換詞=改 UNSAFE_KEYWORDS_REJECT + 補測試 + rebuild）；6/18 可把 Studio trace drawer / BLOCKED 紅字當鏡頭證據（呂奇傑指定的三層架構唯一視覺化）。
+
+**優先級**：P0（已 PASS、確認展示路徑）。**需 HITL**：部分（驗 trace 落盤 + Studio 紅字需真機 gateway+frontend 同跑）。
+
+---
+
+## 3. 跨段共通風險
+
+### 3.1 offline_mode topic↔param gap（驗證陷阱，非功能 bug）
+
+topic↔param 其實已接通且行為正確：brain 有 `/brain/offline_mode` Bool subscriber → `_set_offline_mode`（與 param callback 共用），gateway publish 到同 topic、QoS 相容、行為正確（Studio toggle ON 後下句語音走 offline 短路播 canned）。**真正的 gap**：`_set_offline_mode` / `_set_demo_phase` 只更新實例屬性、不呼叫 `set_parameters` → 經 Studio topic 切換後 `ros2 param get /brain_node offline_mode` 仍回舊值（撒謊）。runbook 又叫操作員用 param get 驗證 → 上場驗證陷阱。**修法**：HITL §4 加「Studio offline toggle 切換後改看 `/brain/trace` 出現 `reason=offline_mode` 或聽是否秒回 canned，不要用 param get 驗」；備援退啟動前 env override `LLM_ENDPOINT=http://127.0.0.1:1/ TTS_PROVIDER=piper`。
+
+### 3.2 phase / fallback dead air（never-dead-air 全靠操作員）
+
+`auto_advance_phases` 預設 `[]` → 每幕 `max_wait` canned-rescue timer 永不 arm（`_arm_phase_wait_timer` 只在 `_auto_advance_on(phase)=True` 才 arm）→ manual-floor 下 brain 不會自動補話。chat 路徑有 `chat_wait_ms=1500ms` 保底（使用者真講話 1.5s 內必有聲），dead air 只發生在「純視覺觸發又沒觸發到」的展示空檔。**修法（保守版，6/18 主線）**：每幕都不開 auto_advance，彩排明確分派「計時人 + canned 觸發人」，max_wait 內沒視覺觸發就用 Studio skill_request(say_canned) 或文字補話；**理想版（6/17 彩排才決定）**：只對 S2 開 `auto_advance_phases=['s2_greet']` 讓進場 greet 自動補 + max_wait rescue，S3/S4/S5 仍 manual floor。**暖機必做**：tts_node 起後對 15 句各發一次 `/tts` 進 cache（禁 mid-session 重啟 tts_node），讓 canned 首句 latency≈0 不被誤判為 dead air。DEMO_CANNED_TABLE 15 句目前標 PENDING，待 Roy 6/15 簽。
+
+### 3.3 CLI 跨平台（MacBook 6/18 主操作）
+
+平台閘門集中於 `platform.py:detect()+assert_supported()`：WSL2 + macOS 放行、Windows native / WSL1 硬擋 exit 10（**PowerShell native 仍被拒且是設計意圖、非 bug**）。6/18 MacBook 主操作的真正風險不是閘門（macOS 會過），而是「閘門過了之後」CLI 對本機 ssh/rsync/bash + brain-studio-lane shell 腳本的隱性依賴：demo start/stop/health 走 `shell.stream(['bash', repo內.sh])`（需本機 clone repo + bash + Studio frontend node_modules）；純 SSH 指令（status/smoke brain/evidence pull/logs）Mac/WSL2 完全等價、可放心跑。**flock 其實在 Jetson 端跑**（非本機），README/onboarding 把「需本機 flock」當擋 Windows 理由是不精確的，但結論（擋 PowerShell）仍正確。**產出**：單頁 MacBook operator setup checklist（brew tmux/node/tailscale + git clone 到 ~/elder_and_dog 非 iCloud + ~/.venv + uv pip install -e + ~/.ssh/config Host + .env.local + pawai doctor 全綠）；6/18 CLI runbook 分 Layer A（純 SSH，Mac 安全）/ Layer B（本機 bash，需 Mac repo+bash+npm）；PowerShell blocker list（一律導向 `wsl --install -d Ubuntu` 或 MacBook）。**未驗最大風險**：MacBook 上 `bash .claude/skills/brain-studio-lane/scripts/start.sh` 是否有 GNU-only（realpath/sed -i）或 zsh-only 假設——需 Roy 實機驗。
+
+### 3.4 operator-runbook 契約備註已過時（誤導風險）
+
+runbook「契約備註 #1/#2/#3」已過時：PHASE_ALLOWED_KINDS 現已含 5 canonical 幕（runbook 卻寫 brain 還沒收、會被拒）、brain `/brain/demo_phase` subscriber 已存在（runbook 卻寫不存在）。會誤導操作員照舊 alias 表繞路、或誤以為 Studio 五幕鈕沒接通而退 param set。code 行為向後相容（alias 與 canonical 都吃），照舊打不會壞、只是多繞。**修法（docs-only，6/17 前必做）**：更新契約備註 #1/#2/#3 + 跑 P4-11 dry-run（找沒參與者照唸）逐條標出過時步驟。
+
+### 3.5 雙 Go2 driver 衝突 + Studio/gateway 可達性
+
+Go2 對單一 ROBOT_IP 只接受一條 WebRTC peer（單一 RTCPeerConnection + DataChannel id=0）；两份 robot.launch.py + nav2_amcl 裸 driver = 2-3 個 RTCPeerConnection 搶同一台 Go2 → ICE FROZEN→FAILED + /cmd_vel,/webrtc_req,/odom 撞名 + odom→base_link 雙 publisher。**6/18 前**：嚴格 SOP「一次只起一個 driver」、起 nav 前 `pawai demo stop` + 逐一 pkill -9。Studio/gateway auth 預設關 → MacBook 經 Tailscale 可達；唯一風險是設了 GATEWAY_AUTH_TOKEN 但前端沒帶 token → POST 全 401（6/18 凍結期建議 auth 維持 OFF）。
+
+---
+
+## 4. 6/18 影響矩陣
+
+### 4.1 P0 必修（6/18 前一定要處理，多為純軟體/SOP/docs）
+
+| 項目 | lane | 形態 | 風險 |
+|------|------|------|------|
+| S3 phone 搶話：whitelist 收 cup-only（現場 param）或 brain class 優先排序（default-off param） | S3 / object | 純軟體 / runtime param | 低（param 即時切回；brain 改需 smoke 全綠） |
+| S2 demo 前現場光線 re-enroll Roy + face_db 衛生（移 _backup/old 出 face_db） | S2 | 外部 shell / CLI face | 低（不改 node code） |
+| S2 確認 Jetson 上 `greet_require_sitting` 回 false（非 code default true） | S2 | 驗證 | 零（讀取） |
+| S4 鎖配置：peace_wego_confirm + gesture_direct_disabled + thumbs_up_demo_ack | S4 | launch arg | 低 |
+| Act1 收工前 `pawai evidence pull` 保住當天 goto log + reactive zone 時間線 | Act1 / nav | 只讀 | 零 motion |
+| Act1 no-motion 診斷分流（topology / tf_static / lidar_front_sector / param get） | Act1 / nav | 只讀診斷 | 零 motion |
+| operator-runbook 契約備註 #1/#2/#3 更新 + P4-11 dry-run | demo-flow | docs | 零 |
+| DEMO_CANNED_TABLE 15 句 Roy 6/15 簽核 | demo-flow | docs/簽核 | 零 |
+| 彩排分派計時人 + canned 觸發人（never dead air） + TTS 15 句暖機 | demo-flow | SOP | 零 |
+| MacBook operator setup checklist + start.sh Mac-compat 驗 | CLI | docs / HITL | 低 |
+
+### 4.2 可 fallback（不修也能交付，退保守路徑）
+
+| 項目 | fallback |
+|------|----------|
+| Act1 live 障礙停 | 退 B 層（遙控+Foxglove LiDAR 證據，零 motion）/ C 層（影片保底）；A 層僅 Roy+e-stop upside |
+| S5 語音觸發 | 退 Studio 文字觸發（100% 命中鍵詞，規避 ASR ~20% 誤聽） |
+| S3 cup 換 take 沉默 | 換 take 前發 `/brain/reset_context`（已有清 dedup 邏輯，零 code） |
+| offline_mode runtime 切換 | 退啟動前 env override（proven） |
+| Studio 主控（MacBook） | 另派一人 SSH 在 Jetson 待命 param set backup |
+| S4 wiggle motion | 退「say_canned 不發 motion」純語音 fallback |
+| Tailscale 不穩 | Studio+gateway 跑 Jetson 本機接螢幕 / 影片保底 |
+
+### 4.3 donotclaim / forbidden（6/18 前明確不做、不講）
+
+- **不講** F1-F10 類 overclaim：自主導航 / 動態繞障 / D435 已與 LiDAR 融合 / auto-resume / safe-stop=繞障（safe-stop≠繞障是標準說法）。
+- **不做**：Go2 motion（除 S4 wiggle 且需 Roy+e-stop）；goto_relative 當 live 主線（NOT_DEMO_READY）；live SLAM；autonomous approach；D435+LiDAR fusion runtime claim；model runtime switch；auto-advance 預設開；full CLI v2/Typer 大重寫；secure-default full flip。
+- **post-6/18 架構**（不在 6/18 scope）：single-driver superset launch（LT-2）；T0 URDF 移 map/odom joint（LT-1）；nav2_amcl 走 mux（LT-3）；enable_lidar arg leak 修（LT-4）；共享 brake 決策層+actuation 層（LT-5/6）；reactive_stop footprint/corridor 升級；YOLO26s 換模 + 960+720p 相機；CLI pipx 路徑 / face verify sim 閉環 / WSL2 detect false-block 修。所有 nav 常駐共存待 LT-0 corun profiling gate 過。
+
+---
+
+## 5. 下一輪實測順序（Roy 指定，照抄）
+
+> **原則**：先把 S2-S5 穩住，再決定 Act1 用哪個 fallback；不要先大修導航（導航最容易吃掉整晚）。
+
+1. **S3 object mapping / bottle 也講喝水** — cup 優先講、bottle 等也可講但 cup 優先（whitelist 收 cup-only 或 brain class 優先排序）；pose 改加分非硬依賴。
+2. **offline_mode / fallback / phase 操作確認** — Studio offline toggle 切換後看 `/brain/trace reason=offline_mode` 或聽秒回 canned（不用 param get 驗）；確認手動 phase 切換 + canned fallback 不 dead air。
+3. **S2 face low-light / cooldown 微調** — 現場光線下 re-enroll + 量 sim≥0.7、face_db 衛生；確認 greet_cooldown / 入框 SOP。
+4. **S4 gesture SOP** — 鎖只留 peace 配置、釐清並關 Studio 手勢按鈕、wiggle 前 e-stop 就位、入框站位 SOP。
+5. **S5 safety trace** — 驗 trace 落盤 `runtime/traces/*.jsonl` 有 banned_api:1301 + Studio 紅字真出現；6/18 主線走 Studio 文字觸發。
+6. **CLI MacBook runbook** — MacBook setup checklist + 純 SSH 指令（status/smoke/evidence）先驗、demo start（本機 bash）最後驗、start.sh Mac-compat 確認。
+7. **Act1 nav fallback 決策** — 依 no-motion 診斷結果，6/17 回穩日由 Roy 定 B-10 當天層（預設 B 遙控+Foxglove 證據、A 為 Roy+e-stop upside、C 影片保底）。
+8. **object A/B offline benchmark** — 現役 n@640 矩陣（cup/bottle/phone/chair × 0.7/1.0/1.5m）+ supervision offline confusion matrix（throwaway venv，禁裝 Jetson），決定換不換模型（結論傾向 6/18 不換）。
+
+---
+
+## 6. 決策拍板（2026-06-14 grill-me 結果）
+
+> Roy 逐題拍板。標 ⚠️ 者為 Roy **覆寫**了報告原建議，以 Roy 決定為準。
+
+| # | 領域 | 拍板決策 | 性質 | 需 HITL |
+|---|------|---------|------|:---:|
+| D1 | S3 修法 | **混合**：producer `class_whitelist` 收成飲水相關（cup/bottle/bowl/wine_glass，移除 phone/laptop）→ 一刀斷 object_remark + LLM recent_objects 兩條講手機路徑；再加 brain `OBJECT_REMARK_PRIORITY`（cup>bottle）保證 cup 贏。default-off param、預設 byte-identical | runtime code(brain)+yaml | 是(smoke) |
+| D2 | S3 attention | `object_remark_attention_min=NOTICED`（只對 cup/bottle 放寬，免 S2 後 INTERACTING 8s quiet 吞 cup）。default-off param | runtime code | 是 |
+| D3 ⚠️ | S3 pose | **保複合句「Roy 坐著拿杯子」當主線 + 上機修 vision pose 邊緣觸發 bug**（週期重發 or brain 改訂 `/state/pose` 連續狀態）。地板層：cup 簡單句沒 pose 也會講（pose 不卡 S3、只是讓「升級複合句」可靠）。RAM/topic 量風險 | vision runtime code | 是 |
+| D4 | S4 Studio 鈕 | **藏掉 GestureToggle 按鈕**（偵測全程 ON，手勢動作靠 `demo_phase=s4_gesture` phase gate 管範圍，S2/S3 不被搶話） | frontend | — |
+| D5 | S4 peace | 接受現行 config（`peace_wego_confirm + gesture_direct_disabled + thumbs_up_demo_ack`），零 code | 零 code(param) | — |
+| D6 | S4 wiggle | Go2 實體 motion → 需 Roy 授權 + e-stop；不穩退純語音「好，我跟你 WeGo 一下！」 | — | 是(motion) |
+| D7 | S5 指令 | 維持 backflip/翻跟斗/倒立（已 proven、36 測試綠），零 code | 零 code | 部分 |
+| D8 ⚠️ | S5 觸發 | **語音現場喊主線**（用筆電 Studio 麥非機身麥，誤聽率較低）+ ASR 漏接時 operator 立刻 Studio 文字補同句當即時 fallback | 零 code | — |
+| D9 ⚠️ | Act1 | **live 障礙停版（Go2 自走遇障停）**。Motion 紅線全套：① no-motion 診斷(D1-D5)先過 ② Roy+e-stop ③ 障礙 >0.6m 高過掃描面 ④ indoor_tight 窄錐重驗無誤擋 ⑤ demo profile `slow_policy=stop`（跳過 0.45<MIN_X 不可靠 slow band，直接 normal 0.60→StopMove）⑥ 不穩立刻退「人推障礙(零 motion)」再退影片 | reactive demo profile | 是(motion) |
+| D10 ⚠️ | offline_mode | **小 code 修**：`_set_offline_mode`/`_set_demo_phase` 加 `set_parameters` 讓 param get 反映真值 | runtime code | 是(smoke) |
+| D11 | gateway auth | 6/18 凍結期維持 **OFF**（MacBook 經 Tailscale 直達） | 零 code | — |
+| D12 | CLI 安裝 | 6/18 維持 **venv + uv pip install -e**（pipx 列 post-6/18）；產單頁 MacBook checklist + 驗 start.sh Mac-compat（最大未驗風險） | docs+驗證 | 是(Mac 實跑) |
+| D13 ⚠️ | object A/B | **6/15-16 跑**（發表要講「量過 n vs s 代價」）：現役 n@640 矩陣 + supervision offline confusion matrix（throwaway venv 禁裝 Jetson）。需 Roy 指認 demo 錄影 MP4 + JSONL 路徑。結論仍傾向 6/18 不換模 | offline 量測 | 是(素材) |
+| D14 | auto-advance | 全幕維持 **manual FLOOR**（Roy 早定「這次不碰 auto-advance」），never-dead-air 靠操作員 + 15 句 TTS 暖機進 cache | 零 code | — |
+
+**待 Roy 動作**：DEMO_CANNED_TABLE 15 句台詞 6/15 前簽核（`brain_node.py:107` 標 PENDING）。
+
+**執行分層**（下一輪）：
+- **AFK 純軟體可先做（需 Roy 授權動 runtime code）**：D1（S3 whitelist+priority）、D2（S3 attention param）、D4（S4 frontend 藏鈕）、D10（offline set_parameters）。每條小 PR / default-off / 可 rollback / smoke。
+- **Roy 在場 HITL**：D3（pose 上機修）、D6/D9（Go2 motion，e-stop）、D8（語音 S5 驗）、D12（Mac 實跑）、D13（素材 + 量測）、S2 re-enroll。
+- **零 code / docs / 運營**：D5、D7、D11、D14 + S2 站位/光線 SOP + operator runbook 契約備註更新。
+
+---
+
+## 7. 不在 6/18 前做的事（forbidden scope）
+
+- **Go2 motion** — 除 S4 wiggle 外，且 wiggle 須 Roy 授權 + e-stop 在手。
+- **goto_relative 當 live 主線** — 維持 NOT_DEMO_READY；不發任何 goto/forward 當 live。
+- **live SLAM** — demo 期不建圖。
+- **autonomous approach** — 不做自主接近 / 跟隨。
+- **D435 + LiDAR fusion runtime claim** — D435 depth_safety 僅 advisory、未進 costmap；不講已融合補盲區。
+- **model runtime switch** — 不換 object 主模型（YOLO26s rsync/TRT 預燒延 post-6/18）、不動相機 profile（960 配 640x480=插值自欺）。
+- **auto-advance 預設開** — 維持 manual FLOOR；最多現場單幕（S2）由 Roy 逐次手動開。
+- **full CLI v2 / Typer 大重寫** — 不為 PowerShell 改 shell.stream bash 抽象；不引 Typer/Rich。
+- **secure-default full flip** — 6/18 凍結期 gateway auth 維持 OFF（MacBook 直接可達）。
+- **nav 架構重構** — single-driver superset launch / T0 URDF 移 joint / nav2_amcl 走 mux / enable_lidar plumb / 共享 brake / reactive footprint-corridor，全 post-6/18 且待 LT-0 corun profiling gate + 真機 motion HITL。
+- **face_identity_node runtime 改 / .npz purge 重做 / enroll 阻擋 ghost dir** — 本輪只研究、face enroll P0-B（套 _clean_face_name）/ P1-A（sim 閉環）需 Roy 另開授權。
+- **runtime tiling / SAHI** — 永久 offline-only upper-bound 探索（5x 推理過不了 ≥3Hz 門檻）。
+
+---
+
+*本輪只「研究 + 寫計畫」，未修改任何 runtime code、未實際發 GitHub issue。所有 P0 落地需 Roy 在場 HITL（多為純感知+brain+只讀診斷，不涉 Go2 motion，安全）。*

--- a/scripts/start_lidar_monitor_tmux.sh
+++ b/scripts/start_lidar_monitor_tmux.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# scripts/start_lidar_monitor_tmux.sh
+# 6/14 B5 — raw LiDAR monitor「證據窗」（與 brain demo 並存，不啟 nav）
+#
+# 拓撲（2 windows，session 名 lidarmon）：
+#   tf       base_link → laser static TF（x=0.175 y=0 z=0.18 yaw=π；LiDAR 反裝）
+#   sllidar  RPLIDAR → /scan_rplidar
+#
+# 設計界線（pre-6/18 最小整合，default-off）：
+#   - 只起 static TF + sllidar，產 /scan_rplidar 當證據 topic。
+#   - **絕不**啟 nav2 / amcl / nav_action_server / 第二個 go2_driver。
+#   - **絕不**發 motion（無 reactive_stop、無 cmd_vel publisher）。
+#   - brain demo（scripts/start_full_demo_tmux.sh）裡的單一 go2_driver 不受影響。
+#
+# 啟動者：`pawai demo start --with-lidar`（或 PAWAI_DEMO_WITH_LIDAR=1），在 brain
+#         demo healthy 後額外 SSH 到 Jetson 跑本腳本。手動跑也可（須先有 ROS env）。
+# 清理：  `pawai demo stop` 會 kill lidarmon session + pkill sllidar/static_transform_publisher。
+#
+# ROS env source 參照 scripts/start_reactive_stop_tmux.sh：
+#   /opt/ros/humble + ~/rplidar_ws + ~/elder_and_dog install，皆用 setup.zsh。
+set -euo pipefail
+
+SESSION="lidarmon"
+ROS_SETUP="source /opt/ros/humble/setup.zsh && source ~/rplidar_ws/install/setup.zsh && source ~/elder_and_dog/install/setup.zsh"
+SERIAL_PORT="${RPLIDAR_SERIAL_PORT:-/dev/rplidar}"
+SERIAL_BAUD="${RPLIDAR_SERIAL_BAUD:-256000}"
+
+echo "=== LiDAR Monitor Session (raw /scan_rplidar evidence window) ==="
+echo "    NO nav2 / amcl / nav_action_server / 2nd go2_driver / motion"
+
+# 已在跑就先清掉，避免雙 sllidar 搶 serial port
+tmux kill-session -t "$SESSION" 2>/dev/null || true
+
+trap 'echo "Caught signal, killing tmux..."; tmux kill-session -t "$SESSION" 2>/dev/null || true' INT TERM
+
+echo "[1/2] static TF base_link → laser (x=0.175, y=0, z=0.18, yaw=3.14159)"
+tmux new-session -d -s "$SESSION" -n tf
+tmux send-keys -t "$SESSION:tf" "$ROS_SETUP && ros2 run tf2_ros static_transform_publisher --x 0.175 --y 0 --z 0.18 --yaw 3.14159 --frame-id base_link --child-frame-id laser" Enter
+sleep 3
+
+echo "[2/2] RPLIDAR (/scan -> /scan_rplidar @ ${SERIAL_PORT}:${SERIAL_BAUD})"
+tmux new-window -t "$SESSION" -n sllidar
+tmux send-keys -t "$SESSION:sllidar" "$ROS_SETUP && ros2 run sllidar_ros2 sllidar_node -p serial_port:=${SERIAL_PORT} -p serial_baudrate:=${SERIAL_BAUD} -r /scan:=/scan_rplidar" Enter
+sleep 4
+
+echo ""
+echo "=== LiDAR Monitor Started ==="
+echo ""
+echo "Sanity（Roy 上機驗）:"
+echo "  ros2 topic hz /scan_rplidar          # 預期 9-13 Hz"
+echo "  ros2 node list | grep -c go2_driver  # 預期 1（brain demo 的，不應變 2）"
+echo "  ros2 node list | grep -E 'nav2|amcl|nav_action' # 預期空"
+echo ""
+echo "Attach: tmux attach -t $SESSION"
+echo "Kill:   tmux kill-session -t $SESSION"

--- a/tools/pawai_cli/pawai_cli/main.py
+++ b/tools/pawai_cli/pawai_cli/main.py
@@ -1420,7 +1420,54 @@ def _invoke_nav_cleanup_sh() -> int:
 def _cleanup_for_lock(lock) -> int:
     if getattr(lock, "lane", "brain") == "nav_capability":
         return _invoke_nav_cleanup_sh()
+    # Brain lane: tear down the opt-in LiDAR monitor (no-op if it was never
+    # started — kill-session + pkill are best-effort). Done before driver
+    # cleanup so we only ever touch lidarmon's own sllidar/static TF.
+    _stop_lidar_monitor()
     return _invoke_cleanup_sh()
+
+
+# ── raw LiDAR monitor (B5, brain lane add-on, opt-in --with-lidar) ───────────
+# A 2-window tmux session on the Jetson (base_link→laser TF + sllidar) that
+# publishes /scan_rplidar as a demo evidence window. It is strictly additive to
+# the brain demo: NO nav2/amcl/nav_action_server/2nd go2_driver, NO motion.
+_LIDAR_MONITOR_SESSION = "lidarmon"
+_LIDAR_MONITOR_SCRIPT_REL = "scripts/start_lidar_monitor_tmux.sh"
+
+
+def _lidar_monitor_manual_command() -> str:
+    repo = shell.jetson_repo()
+    return (
+        f"ssh {shell.jetson_host()} 'cd {repo} && "
+        f"bash {_LIDAR_MONITOR_SCRIPT_REL}'"
+    )
+
+
+def _start_lidar_monitor() -> int:
+    """Start the raw LiDAR monitor on the Jetson over SSH (additive to brain demo)."""
+    repo = shell.jetson_repo()
+    res = shell.run_remote(
+        f"cd {shlex.quote(repo)} && bash {_LIDAR_MONITOR_SCRIPT_REL}",
+        timeout=30,
+    )
+    return 0 if res.ok else (res.code or 1)
+
+
+def _stop_lidar_monitor() -> None:
+    """Tear down ONLY the lidarmon session + its processes we started.
+
+    Best-effort: brain cleanup already ran, so a failure here must not block
+    lock release. We kill the named tmux session, then pkill the two long-lived
+    processes the monitor script launches (sllidar + static TF). We do NOT
+    pkill go2_driver here — that belongs to brain cleanup.
+    """
+    shell.run_remote(
+        f"tmux kill-session -t {_LIDAR_MONITOR_SESSION} 2>/dev/null; "
+        "pkill -9 -f sllidar_node 2>/dev/null; "
+        "pkill -9 -f 'static_transform_publisher.*--child-frame-id laser' 2>/dev/null; "
+        "true",
+        timeout=12,
+    )
 
 
 def _validate_nav_mode(nav_mode: str | None, brain_only: bool) -> str | None:
@@ -1471,14 +1518,31 @@ def _current_sha_short() -> str:
               help="Escape hatch: trust start.sh rc and skip the post-start healthcheck gate.")
 @click.option("--with-shadow", is_flag=True,
               help="After a healthy brain demo is running, enable ism_shadow_enabled.")
+@click.option("--with-lidar", "with_lidar", is_flag=True,
+              help="After a healthy brain demo is running, also start a raw LiDAR "
+                   "monitor (/scan_rplidar evidence window). NO nav2/amcl/2nd driver/motion. "
+                   "Same as PAWAI_DEMO_WITH_LIDAR=1.")
 def demo_start(no_studio: bool, brain_only: bool, nav_mode: str | None,
-               yes: bool, force: bool, skip_healthcheck: bool, with_shadow: bool) -> None:
+               yes: bool, force: bool, skip_healthcheck: bool, with_shadow: bool,
+               with_lidar: bool) -> None:
     """Start brain demo or nav capability lane."""
     from .lock import LOCK_FLOCK_PATH, Lock, is_stale, is_own_lock
+
+    # PAWAI_DEMO_WITH_LIDAR=1 is an env-level alias for --with-lidar so the same
+    # opt-in works from .env / start scripts without re-plumbing every caller.
+    if os.environ.get("PAWAI_DEMO_WITH_LIDAR") == "1":
+        with_lidar = True
 
     nav_mode = _validate_nav_mode(nav_mode, brain_only)
     if with_shadow and nav_mode == "capability":
         raise click.UsageError("--with-shadow cannot be combined with --nav capability")
+    if with_lidar and nav_mode == "capability":
+        # nav capability lane already brings its own sllidar + TF; a second
+        # monitor would race the serial port. Refuse rather than double-start.
+        raise click.UsageError(
+            "--with-lidar cannot be combined with --nav capability "
+            "(nav lane already owns the LiDAR)"
+        )
     lane = "nav_capability" if nav_mode == "capability" else "brain"
     tmux_session = "nav-cap-demo" if lane == "nav_capability" else "demo"
     demo_mode = "nav_capability" if lane == "nav_capability" else (
@@ -1635,6 +1699,16 @@ def demo_start(no_studio: bool, brain_only: bool, nav_mode: str | None,
             click.echo("✓ shadow soak enabled (ism_shadow_enabled=True)")
         else:
             _print_shadow_soak_reminder()
+        if with_lidar:
+            lr = _start_lidar_monitor()
+            if lr != 0:
+                # The brain demo is healthy and remains the source of truth; a
+                # failed evidence-window start must NOT tear it down. Surface it
+                # loudly and hand back the manual command instead of exiting non-zero.
+                click.echo("⚠ LiDAR monitor start failed (brain demo still running).")
+                click.echo(f"  手動補救：{_lidar_monitor_manual_command()}")
+            else:
+                click.echo("✓ LiDAR monitor running (session: lidarmon, topic: /scan_rplidar)")
 
 
 @demo.command("stop")
@@ -1648,6 +1722,9 @@ def demo_stop(force: bool) -> None:
     existing = Lock.read()
     if existing is None:
         click.echo("No demo lock present.")
+        # No lock → assume brain-class cleanup. Also tear down a possibly
+        # orphaned LiDAR monitor (best-effort, no-op if absent).
+        _stop_lidar_monitor()
         rc = _invoke_cleanup_sh()
         sys.exit(rc)
 

--- a/tools/pawai_cli/tests/test_cli.py
+++ b/tools/pawai_cli/tests/test_cli.py
@@ -1160,6 +1160,179 @@ def test_demo_start_rejects_invalid_nav_modes():
         assert "--nav" in result.output
 
 
+# ──────────────── B5: --with-lidar (raw LiDAR monitor add-on) ─────────────
+
+def _patch_brain_start_path(monkeypatch):
+    """Common patches for a clean no-lock brain demo start (returns context list)."""
+    from pawai_cli.lock import Lock
+    acquired = Lock(user="bob", host="bob-mac", branch="main", sha="abc",
+                    state="starting",
+                    start_time=datetime.now(timezone.utc).isoformat(),
+                    lane="brain", tmux_session="demo")
+    monkeypatch.setenv("USER", "bob")
+    return acquired
+
+
+def test_demo_start_default_does_not_start_lidar(monkeypatch):
+    """Default-off: no --with-lidar / no env → lidar monitor never invoked (byte-identical)."""
+    acquired = _patch_brain_start_path(monkeypatch)
+    monkeypatch.delenv("PAWAI_DEMO_WITH_LIDAR", raising=False)
+    with patch("pawai_cli.lock.Lock.read", return_value=None), \
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
+         patch("pawai_cli.lock.Lock.acquire", return_value=acquired), \
+         patch("pawai_cli.main._invoke_start_sh", return_value=0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
+         patch("pawai_cli.main._print_shadow_soak_reminder"), \
+         patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True), \
+         patch("pawai_cli.main._start_lidar_monitor", return_value=0) as lidar_start:
+        result = CliRunner().invoke(cli, ["demo", "start"])
+    assert result.exit_code == 0
+    assert not lidar_start.called
+
+
+def test_demo_start_with_lidar_flag_starts_monitor(monkeypatch):
+    """--with-lidar → lidar monitor started AFTER healthy brain demo."""
+    acquired = _patch_brain_start_path(monkeypatch)
+    monkeypatch.delenv("PAWAI_DEMO_WITH_LIDAR", raising=False)
+    with patch("pawai_cli.lock.Lock.read", return_value=None), \
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
+         patch("pawai_cli.lock.Lock.acquire", return_value=acquired), \
+         patch("pawai_cli.main._invoke_start_sh", return_value=0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
+         patch("pawai_cli.main._print_shadow_soak_reminder"), \
+         patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True), \
+         patch("pawai_cli.main._start_lidar_monitor", return_value=0) as lidar_start:
+        result = CliRunner().invoke(cli, ["demo", "start", "--with-lidar"])
+    assert result.exit_code == 0
+    assert lidar_start.called
+    assert "LiDAR monitor running" in result.output
+
+
+def test_demo_start_with_lidar_env_alias_starts_monitor(monkeypatch):
+    """PAWAI_DEMO_WITH_LIDAR=1 behaves exactly like --with-lidar."""
+    acquired = _patch_brain_start_path(monkeypatch)
+    monkeypatch.setenv("PAWAI_DEMO_WITH_LIDAR", "1")
+    with patch("pawai_cli.lock.Lock.read", return_value=None), \
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
+         patch("pawai_cli.lock.Lock.acquire", return_value=acquired), \
+         patch("pawai_cli.main._invoke_start_sh", return_value=0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
+         patch("pawai_cli.main._print_shadow_soak_reminder"), \
+         patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True), \
+         patch("pawai_cli.main._start_lidar_monitor", return_value=0) as lidar_start:
+        result = CliRunner().invoke(cli, ["demo", "start"])
+    assert result.exit_code == 0
+    assert lidar_start.called
+
+
+def test_demo_start_with_lidar_failure_does_not_teardown_demo(monkeypatch):
+    """Failed lidar monitor must NOT fail the command — brain demo stays up."""
+    acquired = _patch_brain_start_path(monkeypatch)
+    monkeypatch.delenv("PAWAI_DEMO_WITH_LIDAR", raising=False)
+    with patch("pawai_cli.lock.Lock.read", return_value=None), \
+         patch("pawai_cli.status.collect_go2_drivers", return_value=[]), \
+         patch("pawai_cli.lock.Lock.acquire", return_value=acquired), \
+         patch("pawai_cli.main._invoke_start_sh", return_value=0), \
+         patch("pawai_cli.main._run_lane_healthcheck", return_value=0), \
+         patch("pawai_cli.main._print_shadow_soak_reminder"), \
+         patch("pawai_cli.lock.Lock.transition_if_owned", return_value=True), \
+         patch("pawai_cli.main._start_lidar_monitor", return_value=1):
+        result = CliRunner().invoke(cli, ["demo", "start", "--with-lidar"])
+    assert result.exit_code == 0
+    assert "LiDAR monitor start failed" in result.output
+    assert "手動補救" in result.output
+
+
+def test_demo_start_with_lidar_rejects_nav_capability():
+    """--with-lidar + --nav capability is a usage error (nav lane owns the LiDAR)."""
+    result = CliRunner().invoke(
+        cli, ["demo", "start", "--nav", "capability", "--with-lidar"]
+    )
+    assert result.exit_code == 2
+    assert "--with-lidar" in result.output
+
+
+def test_start_lidar_monitor_runs_script_over_ssh(monkeypatch):
+    """_start_lidar_monitor must SSH cd into Jetson repo and run the monitor script."""
+    from pawai_cli import main as cli_main
+    captured = {}
+
+    def fake_run_remote(command, timeout=None):
+        captured["command"] = command
+        captured["timeout"] = timeout
+        return shell.Result(0, "", "")
+
+    with patch("pawai_cli.main.shell.run_remote", side_effect=fake_run_remote), \
+         patch("pawai_cli.main.shell.jetson_repo", return_value="/home/jetson/elder_and_dog"):
+        rc = cli_main._start_lidar_monitor()
+
+    assert rc == 0
+    assert "scripts/start_lidar_monitor_tmux.sh" in captured["command"]
+    assert "/home/jetson/elder_and_dog" in captured["command"]
+    # Must NOT touch nav2/amcl/2nd driver — script name is the only entry point.
+    assert "nav2" not in captured["command"]
+    assert "amcl" not in captured["command"]
+
+
+def test_stop_lidar_monitor_kills_only_lidarmon(monkeypatch):
+    """_stop_lidar_monitor kills the lidarmon session + sllidar/static TF only — not go2_driver."""
+    from pawai_cli import main as cli_main
+    captured = {}
+
+    def fake_run_remote(command, timeout=None):
+        captured["command"] = command
+        return shell.Result(0, "", "")
+
+    with patch("pawai_cli.main.shell.run_remote", side_effect=fake_run_remote):
+        cli_main._stop_lidar_monitor()
+
+    cmd = captured["command"]
+    assert "tmux kill-session -t lidarmon" in cmd
+    assert "sllidar_node" in cmd
+    assert "static_transform_publisher" in cmd
+    # Critical: must NOT pkill the brain demo's single go2_driver here.
+    assert "go2_driver" not in cmd
+
+
+def test_demo_stop_brain_lane_tears_down_lidar_monitor(monkeypatch):
+    """demo stop on a brain lock cleans the lidar monitor before brain cleanup."""
+    from pawai_cli.lock import Lock
+    brain_lock = Lock(user="bob", host="bob-mac", branch="x", sha="a",
+                      state="running",
+                      start_time=datetime.now(timezone.utc).isoformat(),
+                      lane="brain", tmux_session="demo")
+    monkeypatch.setenv("USER", "bob")
+    order: list[str] = []
+    with patch("pawai_cli.lock.Lock.read", return_value=brain_lock), \
+         patch("pawai_cli.main.platform.node", return_value="bob-mac"), \
+         patch("pawai_cli.main._stop_lidar_monitor",
+               side_effect=lambda: order.append("lidar")), \
+         patch("pawai_cli.main._invoke_cleanup_sh",
+               side_effect=lambda: order.append("brain") or 0), \
+         patch("pawai_cli.lock.Lock.release_if_owned", return_value=True):
+        result = CliRunner().invoke(cli, ["demo", "stop"])
+    assert result.exit_code == 0
+    assert order == ["lidar", "brain"]
+
+
+def test_demo_stop_nav_lane_does_not_touch_lidar_monitor(monkeypatch):
+    """nav lane stop routes to nav cleanup and must NOT call the brain lidar teardown."""
+    from pawai_cli.lock import Lock
+    nav_lock = Lock(user="bob", host="bob-mac", branch="x", sha="a",
+                    state="running",
+                    start_time=datetime.now(timezone.utc).isoformat(),
+                    lane="nav_capability", tmux_session="nav-cap-demo")
+    monkeypatch.setenv("USER", "bob")
+    with patch("pawai_cli.lock.Lock.read", return_value=nav_lock), \
+         patch("pawai_cli.main.platform.node", return_value="bob-mac"), \
+         patch("pawai_cli.main._stop_lidar_monitor") as lidar_stop, \
+         patch("pawai_cli.main._invoke_nav_cleanup_sh", return_value=0), \
+         patch("pawai_cli.lock.Lock.release_if_owned", return_value=True):
+        result = CliRunner().invoke(cli, ["demo", "stop"])
+    assert result.exit_code == 0
+    assert not lidar_stop.called
+
+
 # ──────────────── L3 tests ────────────────
 
 @pytest.mark.real_repo  # reads real repo docs/scripts (T2C-0)


### PR DESCRIPTION
Pre-6/18 iter2 lidar lane. 預設 off / byte-identical。

`pawai demo start --with-lidar` (或 PAWAI_DEMO_WITH_LIDAR=1) → demo 起完後**額外**起獨立 lidarmon tmux (base_link→laser static TF + sllidar → /scan_rplidar)。**絕不啟 nav2/amcl/nav_action_server/第二 go2_driver、零 motion**。`demo stop` 只清 lidarmon/sllidar/static TF，不碰 go2_driver。與 --nav capability 互斥 (serial port)。

Tests: test_cli.py 120 pass (+9 lidar)；全 pawai_cli 227 pass；bash -n OK。
對抗 review: PASS_WITH_NITS, 0 blocker。
HITL-only 驗收 (Roy 上機): /scan_rplidar 9-13Hz / go2_driver count=1 / 無 nav2-amcl / RAM≥0.8GB / stop 清乾淨。
A3 plan: docs/navigation/plans/2026-06-14-demo-start-raw-lidar-monitor-plan.md。

🤖 Generated with [Claude Code](https://claude.com/claude-code)