### PR TITLE
feat(cli-v2): Typer/Rich parallel skeleton 'pawai2' (compat wrapper, legacy untouched)

### DIFF
--- a/tools/pawai_cli/pawai_cli/v2/__init__.py
+++ b/tools/pawai_cli/pawai_cli/v2/__init__.py
@@ -1,0 +1,26 @@
+"""PawAI CLI v2 — parallel Typer + Rich front-end (entry point: ``pawai2``).
+
+This is an ADDITIVE, parallel skeleton. The legacy Click CLI
+(``pawai_cli.main:cli`` → console_script ``pawai``) is the authoritative,
+byte-identical implementation kept as the rollback path. v2 NEVER reimplements
+lock / deploy / cleanup core logic — every command here delegates to the proven
+Click implementation in ``pawai_cli.main`` (and ``pawai_cli.evidence``).
+
+The only NEW surface area v2 adds is presentation (Rich console framing, a
+distinct ``pawai2`` help tree) and the platform gate re-use. Behaviour of the
+underlying commands is unchanged because we call their original callbacks.
+"""
+
+from __future__ import annotations
+
+__all__ = ["app"]
+
+
+def __getattr__(name: str):  # pragma: no cover - thin lazy import
+    # Lazy so that `import pawai_cli.v2` does not force-import typer when a
+    # caller only wants the docstring / metadata.
+    if name == "app":
+        from .app import app
+
+        return app
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tools/pawai_cli/pawai_cli/v2/app.py
+++ b/tools/pawai_cli/pawai_cli/v2/app.py
@@ -1,0 +1,260 @@
+"""PawAI CLI v2 Typer application (entry point: ``pawai2``).
+
+Parity contract
+---------------
+Every command below is a THIN wrapper. It collects options, then delegates to
+the *exact* legacy implementation by calling the original Click command's
+``.callback`` (the undecorated function) with explicit keyword arguments. We do
+NOT reimplement lock / deploy / cleanup / smoke / evidence logic — those live
+once, in ``pawai_cli.main`` and ``pawai_cli.evidence``, and the legacy ``pawai``
+binary keeps running them byte-identically.
+
+Because the legacy callbacks signal completion with ``sys.exit()`` /
+``raise SystemExit`` and surface failures with ``click.ClickException``, the
+delegation boundary (:func:`_delegate`) translates those into the same process
+exit codes Click itself would produce, so ``pawai2 X`` exits the same way
+``pawai X`` does.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+import click
+import typer
+
+from .. import __version__, shell
+from .. import platform as _plat
+from ..main import _load_env
+from . import console as c
+
+app = typer.Typer(
+    name="pawai2",
+    help=(
+        "PawAI CLI v2 (Typer + Rich) — parallel front-end. "
+        "Delegates to the proven `pawai` implementation; the legacy `pawai` "
+        "binary remains the byte-identical rollback path."
+    ),
+    add_completion=True,
+    no_args_is_help=True,
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+
+smoke_app = typer.Typer(name="smoke", help="End-to-end smoke runs (wraps existing scripts).",
+                        no_args_is_help=True)
+evidence_app = typer.Typer(name="evidence", help="Evidence Center artifacts (read-only).",
+                           no_args_is_help=True)
+demo_app = typer.Typer(name="demo", help="Demo lane controls (lock-aware; delegates to legacy).",
+                       no_args_is_help=True)
+app.add_typer(smoke_app, name="smoke")
+app.add_typer(evidence_app, name="evidence")
+app.add_typer(demo_app, name="demo")
+
+
+# ── delegation boundary ──────────────────────────────────────────────────────
+
+def _delegate(callback: Callable, **kwargs) -> None:
+    """Run a legacy Click command's raw callback and mirror Click's exit codes.
+
+    The legacy callbacks either return normally, ``sys.exit(code)`` /
+    ``raise SystemExit(code)``, or ``raise click.ClickException``. Map each to
+    the process exit Click would have produced so ``pawai2`` parity holds:
+
+      * normal return        → exit 0
+      * SystemExit(code)     → exit code (None/str handled like CPython)
+      * ClickException       → render to stderr + exit ``exc.exit_code`` (1)
+      * click.Abort          → "Aborted!" + exit 1 (Click's convention)
+    """
+    try:
+        callback(**kwargs)
+    except SystemExit as exc:
+        code = exc.code
+        if code is None:
+            raise typer.Exit(code=0) from None
+        if isinstance(code, int):
+            raise typer.Exit(code=code) from None
+        # Non-int exit payload (a message): print + exit 1, mirroring CPython.
+        c.error(str(code))
+        raise typer.Exit(code=1) from None
+    except click.exceptions.Abort:
+        c.error("Aborted!")
+        raise typer.Exit(code=1) from None
+    except click.ClickException as exc:
+        # Click prints "Error: <message>" to stderr; keep that wording so logs
+        # and muscle-memory match the legacy binary.
+        c.err_console.print(f"Error: {exc.format_message()}")
+        raise typer.Exit(code=exc.exit_code) from None
+    else:
+        raise typer.Exit(code=0)
+
+
+def _legacy_callback(name: str) -> Callable:
+    """Resolve a top-level legacy Click command's raw callback by command name."""
+    from ..main import cli as _legacy_cli
+
+    return _legacy_cli.commands[name].callback
+
+
+def _legacy_group_callback(group: str, sub: str) -> Callable:
+    """Resolve a legacy Click sub-command callback (e.g. smoke→brain)."""
+    from ..main import cli as _legacy_cli
+
+    return _legacy_cli.commands[group].commands[sub].callback
+
+
+# ── root callback: platform gate + env load (parity with legacy cli()) ───────
+
+def _version_callback(value: bool) -> None:
+    if value:
+        c.info(f"pawai2 {__version__}")
+        raise typer.Exit(code=0)
+
+
+@app.callback()
+def main(
+    version: Optional[bool] = typer.Option(
+        None, "--version", callback=_version_callback, is_eager=True,
+        help="Show pawai2 version and exit.",
+    ),
+) -> None:
+    """Root: enforce the same platform gate the legacy ``pawai`` enforces.
+
+    ``platform.assert_supported`` exits 10 on Windows-native / WSL1 / a repo
+    under /mnt/c — identical gate to ``pawai_cli.main.cli``. On Windows native
+    the gate's own message already points users at WSL2 (``wsl --install``); we
+    do not "soft-support" PowerShell here.
+    """
+    root = shell.repo_root()
+    _plat.assert_supported(root)
+    _load_env(root)
+
+
+# ── doctor / status / logs (top-level legacy commands) ───────────────────────
+
+@app.command()
+def doctor(
+    verbose: bool = typer.Option(False, "--verbose", help="Print SSH stderr details on failure."),
+    expect_demo: bool = typer.Option(False, "--expect-demo",
+                                     help="Treat Gateway 8080 down as FAIL (default: SKIP)."),
+    fix: bool = typer.Option(False, "--fix",
+                             help="Prompt to write detected Tailscale IP into .env.local."),
+    deep: bool = typer.Option(False, "--deep", help="Run live OpenRouter API call."),
+    cache: int = typer.Option(0, "--cache", help="Cache result for N seconds."),
+) -> None:
+    """Validate local environment and Jetson reachability (delegates to legacy)."""
+    _delegate(_legacy_callback("doctor"), verbose=verbose, expect_demo=expect_demo,
+              fix=fix, deep=deep, cache_seconds=cache)
+
+
+@app.command()
+def status(
+    short: bool = typer.Option(False, "--short", help="Skip ROS node detail."),
+) -> None:
+    """Show Jetson tmux/ROS/git state (delegates to legacy)."""
+    _delegate(_legacy_callback("status"), short=short)
+
+
+@app.command()
+def logs(
+    module: str = typer.Argument(..., help="Module name, or 'all'."),
+    lines: int = typer.Option(500, "--lines", help="Lines to capture from tmux pane."),
+) -> None:
+    """Capture Jetson tmux logs for a module (delegates to legacy)."""
+    _delegate(_legacy_callback("logs"), module=module, lines=lines)
+
+
+# ── smoke brain / object / nav-static (subset; vision/full deferred) ─────────
+
+@smoke_app.command("brain")
+def smoke_brain(
+    rounds: int = typer.Option(5, "--rounds", min=1, max=30,
+                               help="E2E rounds (smoke_test_e2e.sh argument)."),
+) -> None:
+    """Run the speech E2E smoke on the Jetson (delegates to legacy)."""
+    _delegate(_legacy_group_callback("smoke", "brain"), rounds=rounds)
+
+
+@smoke_app.command("object")
+def smoke_object(
+    with_cup: bool = typer.Option(False, "--with-cup",
+                                  help="After static checks, wait up to 60s for a cup event."),
+) -> None:
+    """Run the object smoke on the Jetson (delegates to legacy)."""
+    _delegate(_legacy_group_callback("smoke", "object"), with_cup=with_cup)
+
+
+@smoke_app.command("nav-static")
+def smoke_nav_static() -> None:
+    """Run the nav STATIC smoke on the Jetson (read-only; delegates to legacy).
+
+    Hard-wires the legacy ``smoke nav --static`` contract: motion regression is
+    HITL and intentionally never exposed through v2.
+    """
+    _delegate(_legacy_group_callback("smoke", "nav"), static_only=True)
+
+
+# ── evidence pull (read-only) ────────────────────────────────────────────────
+
+@evidence_app.command("pull")
+def evidence_pull(
+    dest: Optional[str] = typer.Option(
+        None, "--dest",
+        help="Local destination dir (default: artifacts/evidence/traces)."),
+) -> None:
+    """Pull runtime/traces/*.jsonl from the Jetson gateway store (delegates)."""
+    from ..evidence import evidence as _evidence_group
+
+    _delegate(_evidence_group.commands["pull"].callback, dest_str=dest)
+
+
+# ── demo start / stop (lock/deploy/cleanup core untouched — delegated) ───────
+
+@demo_app.command("start")
+def demo_start(
+    no_studio: bool = typer.Option(False, "--no-studio",
+                                   help="Start full mode without local Studio overlay."),
+    brain_only: bool = typer.Option(False, "--brain-only",
+                                    help="Start minimal brain stack only."),
+    nav: Optional[str] = typer.Option(None, "--nav", metavar="MODE",
+                                      help="Start nav capability lane. First version: capability."),
+    yes: bool = typer.Option(False, "-y", "--yes",
+                             help="Skip ordinary prompts (does NOT override another user's lock)."),
+    force: bool = typer.Option(False, "--force", help="Take over another user's demo lock."),
+    skip_healthcheck: bool = typer.Option(False, "--skip-healthcheck",
+                                          help="Escape hatch: skip the post-start healthcheck."),
+    with_shadow: bool = typer.Option(False, "--with-shadow",
+                                     help="After a healthy brain demo, enable ism_shadow_enabled."),
+) -> None:
+    """Start brain demo or nav capability lane (delegates to legacy demo start).
+
+    The lock acquisition, start.sh invocation, post-start healthcheck gate, and
+    shadow-soak handling all run inside the legacy callback — v2 adds nothing.
+    """
+    _delegate(_legacy_group_callback("demo", "start"),
+              no_studio=no_studio, brain_only=brain_only, nav_mode=nav,
+              yes=yes, force=force, skip_healthcheck=skip_healthcheck,
+              with_shadow=with_shadow)
+
+
+@demo_app.command("stop")
+def demo_stop(
+    force: bool = typer.Option(False, "--force",
+                               help="Stop another user's demo and release their lock."),
+) -> None:
+    """Stop the running lane (lock-lane-routed cleanup; delegates to legacy)."""
+    _delegate(_legacy_group_callback("demo", "stop"), force=force)
+
+
+# Pre-resolve the demo-start parameter name set once, for the parity test to
+# assert v2's kwargs are a faithful 1:1 of the legacy callback signature.
+def _legacy_demo_start_params() -> set[str]:
+    import inspect
+
+    from ..main import cli as _legacy_cli
+
+    sig = inspect.signature(_legacy_cli.commands["demo"].commands["start"].callback)
+    return set(sig.parameters)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/tools/pawai_cli/pawai_cli/v2/console.py
+++ b/tools/pawai_cli/pawai_cli/v2/console.py
@@ -1,0 +1,48 @@
+"""Rich console base for PawAI CLI v2.
+
+A single shared :class:`rich.console.Console` plus a thin set of output helpers
+so every v2 command frames messages consistently. Stdout vs stderr is kept
+honest: status/info/success go to stdout, warnings/errors go to stderr.
+
+These helpers are deliberately small. v2 commands DELEGATE their real work to
+the legacy Click implementation, which prints its own ``click.echo`` output;
+these helpers are only for v2's own framing (banners, the platform-gate notice,
+PowerShell guidance, and command-level headers).
+"""
+
+from __future__ import annotations
+
+import os
+
+from rich.console import Console
+
+# NO_COLOR / non-tty CI: Rich auto-detects, but make it explicit and testable.
+_FORCE_NO_COLOR = bool(os.environ.get("NO_COLOR"))
+
+console = Console(stderr=False, no_color=_FORCE_NO_COLOR, highlight=False)
+err_console = Console(stderr=True, no_color=_FORCE_NO_COLOR, highlight=False)
+
+
+def info(message: str) -> None:
+    """Neutral informational line (stdout)."""
+    console.print(message)
+
+
+def success(message: str) -> None:
+    """Success line (stdout)."""
+    console.print(f"[bold green]✓[/] {message}")
+
+
+def warn(message: str) -> None:
+    """Warning line (stderr)."""
+    err_console.print(f"[bold yellow]⚠[/] {message}")
+
+
+def error(message: str) -> None:
+    """Error line (stderr)."""
+    err_console.print(f"[bold red]✗[/] {message}")
+
+
+def header(title: str) -> None:
+    """Section header used at the top of a v2 command's own framing."""
+    console.print(f"[bold cyan]{title}[/]")

--- a/tools/pawai_cli/pyproject.toml
+++ b/tools/pawai_cli/pyproject.toml
@@ -8,8 +8,20 @@ dependencies = [
     "python-dotenv>=1.0",
 ]
 
+[project.optional-dependencies]
+# v2 (Typer + Rich) parallel front-end. Kept optional so the legacy `pawai`
+# binary has ZERO new runtime dependencies — install with
+# `pip install -e 'tools/pawai_cli[v2]'` to get `pawai2`.
+v2 = [
+    "typer>=0.12",
+    "rich>=13.0",
+]
+
 [project.scripts]
 pawai = "pawai_cli.main:cli"
+# v2 parallel binary. Additive: does NOT replace `pawai`. Requires the [v2]
+# extra (typer/rich). Legacy `pawai` stays byte-identical and is the rollback.
+pawai2 = "pawai_cli.v2.app:app"
 
 [build-system]
 requires = ["setuptools>=68"]

--- a/tools/pawai_cli/tests/test_v2_app.py
+++ b/tools/pawai_cli/tests/test_v2_app.py
@@ -14,13 +14,14 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-pytest.importorskip("typer")  # v2 deps are an optional [v2] extra; skip when absent (CI base install)
+# v2 deps are an optional [v2] extra; skip when absent (CI base install).
+pytest.importorskip("typer")
 
-from typer.testing import CliRunner
+from typer.testing import CliRunner  # noqa: E402
 
-from pawai_cli import platform as plat
-from pawai_cli.shell import Result
-from pawai_cli.v2.app import app
+from pawai_cli import platform as plat  # noqa: E402
+from pawai_cli.shell import Result  # noqa: E402
+from pawai_cli.v2.app import app  # noqa: E402
 
 runner = CliRunner()
 

--- a/tools/pawai_cli/tests/test_v2_app.py
+++ b/tools/pawai_cli/tests/test_v2_app.py
@@ -12,6 +12,10 @@ import inspect
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+import pytest
+
+pytest.importorskip("typer")  # v2 deps are an optional [v2] extra; skip when absent (CI base install)
+
 from typer.testing import CliRunner
 
 from pawai_cli import platform as plat

--- a/tools/pawai_cli/tests/test_v2_app.py
+++ b/tools/pawai_cli/tests/test_v2_app.py
@@ -1,0 +1,397 @@
+"""PawAI CLI v2 (Typer + Rich) parallel skeleton — tests (first batch).
+
+Everything is mocked: conftest T2C-0 pins PAWAI_REPO_ROOT / JETSON_HOST and
+refuses un-mocked ssh/rsync, so this suite never touches the network. The key
+guarantee these tests enforce is PARITY: v2 commands must delegate to the exact
+legacy Click callbacks with the exact kwargs the legacy binary uses — v2 must
+NOT reimplement lock / deploy / cleanup / smoke / evidence logic.
+"""
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from typer.testing import CliRunner
+
+from pawai_cli import platform as plat
+from pawai_cli.shell import Result
+from pawai_cli.v2.app import app
+
+runner = CliRunner()
+
+
+def _invoke(args):
+    return runner.invoke(app, args)
+
+
+# ── help snapshot ────────────────────────────────────────────────────────────
+
+def test_v2_help_lists_first_batch_commands():
+    result = _invoke(["--help"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Top-level commands wired in the first batch.
+    for cmd in ("doctor", "status", "logs", "smoke", "evidence", "demo"):
+        assert cmd in out, f"missing {cmd} in help:\n{out}"
+
+
+def test_v2_version_flag():
+    result = _invoke(["--version"])
+    assert result.exit_code == 0, result.output
+    assert "pawai2" in result.output
+
+
+def test_v2_smoke_help_lists_subset():
+    result = _invoke(["smoke", "--help"])
+    assert result.exit_code == 0, result.output
+    for sub in ("brain", "object", "nav-static"):
+        assert sub in result.output
+    # vision / full are intentionally deferred to a later batch.
+    assert "vision" not in result.output
+    assert "full" not in result.output
+
+
+# ── platform gate (Windows native → exit 10, parity with legacy) ─────────────
+
+def test_v2_platform_gate_windows_native_exits_10():
+    info = plat.PlatformInfo(kind="windows_native", supported=False,
+                             reason="Windows native unsupported")
+    with patch("pawai_cli.platform.detect", return_value=info):
+        result = _invoke(["doctor"])
+    assert result.exit_code == 10
+    # Gate's own message steers users to WSL2 — v2 does NOT soft-support PS.
+    assert "wsl --install" in result.output
+
+
+def test_v2_platform_gate_mnt_c_exits_10():
+    info = plat.PlatformInfo(kind="wsl2", supported=True, reason="")
+    with patch("pawai_cli.platform.detect", return_value=info), \
+         patch("pawai_cli.v2.app.shell.repo_root",
+               return_value=__import__("pathlib").Path("/mnt/c/Users/foo/repo")):
+        result = _invoke(["status"])
+    assert result.exit_code == 10
+    assert "/mnt/c" in result.output
+
+
+# ── doctor (mocked) ──────────────────────────────────────────────────────────
+
+def test_v2_doctor_delegates_to_legacy_callback():
+    """doctor must call the legacy `doctor` callback with mapped kwargs."""
+    captured = {}
+
+    def fake_doctor(**kwargs):
+        captured.update(kwargs)
+        raise SystemExit(0)
+
+    legacy = SimpleNamespace(callback=fake_doctor)
+    legacy_cli = SimpleNamespace(commands={"doctor": legacy})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["doctor", "--deep", "--cache", "7"])
+    assert result.exit_code == 0, result.output
+    # `--cache N` maps to the legacy `cache_seconds` parameter name.
+    assert captured == {"verbose": False, "expect_demo": False, "fix": False,
+                        "deep": True, "cache_seconds": 7}
+
+
+def test_v2_doctor_blocking_exit_code_propagates():
+    """Legacy doctor SystemExit(2) (blocking findings) must surface as exit 2."""
+    def fake_doctor(**kwargs):
+        raise SystemExit(2)
+
+    legacy = SimpleNamespace(callback=fake_doctor)
+    legacy_cli = SimpleNamespace(commands={"doctor": legacy})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["doctor"])
+    assert result.exit_code == 2
+
+
+# ── status (mocked) ──────────────────────────────────────────────────────────
+
+def test_v2_status_delegates_and_passes_short():
+    captured = {}
+
+    def fake_status(**kwargs):
+        captured.update(kwargs)
+        # legacy `status` returns normally (no SystemExit) → v2 exits 0
+
+    legacy = SimpleNamespace(callback=fake_status)
+    legacy_cli = SimpleNamespace(commands={"status": legacy})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["status", "--short"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"short": True}
+
+
+def test_v2_status_real_collect_mocked_unreachable():
+    """End-to-end through the real legacy status, with the SSH probe mocked
+    unreachable (conftest would otherwise refuse the ssh)."""
+    with patch("pawai_cli.status.shell.run_remote",
+               return_value=Result(255, "", "ssh failed")):
+        result = _invoke(["status", "--short"])
+    assert result.exit_code == 0, result.output
+    assert "unreachable" in result.output.lower()
+
+
+# ── logs (mocked) ────────────────────────────────────────────────────────────
+
+def test_v2_logs_delegates_with_module_and_lines():
+    captured = {}
+
+    def fake_logs(**kwargs):
+        captured.update(kwargs)
+
+    legacy = SimpleNamespace(callback=fake_logs)
+    legacy_cli = SimpleNamespace(commands={"logs": legacy})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["logs", "brain", "--lines", "200"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"module": "brain", "lines": 200}
+
+
+# ── smoke command-construction (real legacy callbacks, SSH mocked) ───────────
+
+def test_v2_smoke_brain_builds_correct_ssh_command():
+    calls = {}
+
+    def fake_run_remote(cmd, timeout=None):
+        calls["probe"] = cmd
+        return Result(0, "", "")
+
+    def fake_stream_remote(cmd):
+        calls["stream"] = cmd
+        return 0
+
+    with patch("pawai_cli.main.shell.run_remote", side_effect=fake_run_remote), \
+         patch("pawai_cli.main.shell.stream_remote", side_effect=fake_stream_remote):
+        result = _invoke(["smoke", "brain", "--rounds", "3"])
+
+    assert result.exit_code == 0, result.output
+    assert "scripts/smoke_test_e2e.sh" in calls["probe"]
+    assert "cd /home/jetson/elder_and_dog" in calls["stream"]
+    assert "source /opt/ros/humble/setup.zsh" in calls["stream"]
+    assert "bash scripts/smoke_test_e2e.sh 3" in calls["stream"]
+
+
+def test_v2_smoke_brain_default_rounds_is_5():
+    calls = {}
+    with patch("pawai_cli.main.shell.run_remote", return_value=Result(0, "", "")), \
+         patch("pawai_cli.main.shell.stream_remote",
+               side_effect=lambda cmd: calls.setdefault("stream", cmd) and 0):
+        result = _invoke(["smoke", "brain"])
+    assert result.exit_code == 0, result.output
+    assert "bash scripts/smoke_test_e2e.sh 5" in calls["stream"]
+
+
+def test_v2_smoke_brain_ssh_unreachable_names_doctor():
+    with patch("pawai_cli.main.shell.run_remote",
+               return_value=Result(255, "", "ssh: timed out")):
+        result = _invoke(["smoke", "brain"])
+    assert result.exit_code != 0
+    assert "pawai doctor" in result.output
+
+
+def test_v2_smoke_object_builds_correct_ssh_command():
+    calls = {}
+    with patch("pawai_cli.main.shell.run_remote", return_value=Result(0, "", "")), \
+         patch("pawai_cli.main.shell.stream_remote",
+               side_effect=lambda cmd: calls.setdefault("stream", cmd) and 0):
+        result = _invoke(["smoke", "object", "--with-cup"])
+    assert result.exit_code == 0, result.output
+    assert "scripts/smoke_test_object.sh" in calls["stream"]
+    assert "--with-cup" in calls["stream"]
+
+
+def test_v2_smoke_nav_static_hardwires_static_flag():
+    """`smoke nav-static` must pass static_only=True to the legacy nav smoke —
+    motion regression stays HITL and is never exposed in v2."""
+    calls = {}
+    with patch("pawai_cli.main.Lock.read", return_value=None), \
+         patch("pawai_cli.main.shell.run_remote", return_value=Result(0, "", "")), \
+         patch("pawai_cli.main.shell.stream_remote",
+               side_effect=lambda cmd: calls.setdefault("stream", cmd) and 0):
+        result = _invoke(["smoke", "nav-static"])
+    assert result.exit_code == 0, result.output
+    assert "scripts/smoke_test_nav_static.sh" in calls["stream"]
+
+
+def test_v2_smoke_nav_static_blocked_by_brain_lock():
+    """Parity with legacy `smoke nav --static`: a brain lock blocks before SSH."""
+    run_remote = Mock(return_value=Result(0, "", ""))
+    stream_remote = Mock(return_value=0)
+    with patch("pawai_cli.main.Lock.read", return_value=SimpleNamespace(lane="brain")), \
+         patch("pawai_cli.main.shell.run_remote", run_remote), \
+         patch("pawai_cli.main.shell.stream_remote", stream_remote):
+        result = _invoke(["smoke", "nav-static"])
+    assert result.exit_code != 0
+    assert "互斥" in result.output
+    run_remote.assert_not_called()
+    stream_remote.assert_not_called()
+
+
+# ── evidence pull command-construction (read-only) ───────────────────────────
+
+def test_v2_evidence_pull_rsync_is_read_only():
+    seen = []
+
+    def fake_stream(argv, cwd=None, env=None):
+        seen.append(list(argv))
+        return 0
+
+    with patch("pawai_cli.evidence.shell.stream", side_effect=fake_stream):
+        result = _invoke(["evidence", "pull"])
+    assert result.exit_code == 0, result.output
+    sources = [argv[-2] for argv in seen]
+    assert any(s.endswith("runtime/traces/") for s in sources)
+    for argv in seen:
+        assert argv[0] == "rsync"
+        assert "--delete" not in argv          # pull NEVER deletes
+
+
+def test_v2_evidence_pull_custom_dest(tmp_path):
+    seen = {}
+
+    def fake_stream(argv, cwd=None, env=None):
+        seen["argv"] = list(argv)
+        return 0
+
+    dest = tmp_path / "my-evidence"
+    with patch("pawai_cli.evidence.shell.stream", side_effect=fake_stream):
+        result = _invoke(["evidence", "pull", "--dest", str(dest)])
+    assert result.exit_code == 0, result.output
+    assert seen["argv"][-1] == f"{dest}/"
+
+
+def test_v2_evidence_pull_rsync_missing_names_install_fix():
+    with patch("pawai_cli.evidence.shell.stream", return_value=127):
+        result = _invoke(["evidence", "pull"])
+    assert result.exit_code != 0
+    assert "rsync" in result.output
+    assert "install" in result.output
+
+
+# ── demo start / stop PARITY (the rollback-critical guarantee) ───────────────
+
+def test_v2_demo_start_kwargs_match_legacy_signature():
+    """v2 demo start must call the legacy callback with EXACTLY the legacy
+    parameter set — no extra, no missing. This is the core parity contract:
+    lock/deploy/cleanup core is the legacy callback, v2 only forwards args."""
+    from pawai_cli.v2.app import _legacy_demo_start_params
+
+    legacy_params = _legacy_demo_start_params()
+    captured = {}
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+
+    legacy_start = SimpleNamespace(callback=fake_start)
+    legacy_demo = SimpleNamespace(commands={"start": legacy_start})
+    legacy_cli = SimpleNamespace(commands={"demo": legacy_demo})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["demo", "start", "--brain-only", "-y"])
+    assert result.exit_code == 0, result.output
+    # Exact 1:1 parameter parity with the legacy demo-start callback.
+    assert set(captured) == legacy_params
+    # And the forwarded values reflect the CLI flags faithfully.
+    assert captured["brain_only"] is True
+    assert captured["yes"] is True
+    assert captured["force"] is False
+    assert captured["nav_mode"] is None
+
+
+def test_v2_demo_start_nav_capability_forwarded():
+    captured = {}
+
+    def fake_start(**kwargs):
+        captured.update(kwargs)
+
+    legacy_start = SimpleNamespace(callback=fake_start)
+    legacy_demo = SimpleNamespace(commands={"start": legacy_start})
+    legacy_cli = SimpleNamespace(commands={"demo": legacy_demo})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["demo", "start", "--nav", "capability", "--force"])
+    assert result.exit_code == 0, result.output
+    assert captured["nav_mode"] == "capability"
+    assert captured["force"] is True
+
+
+def test_v2_demo_start_lock_collision_exit_code_propagates():
+    """When legacy demo start SystemExit(2)s on a `-y` lock collision, v2 must
+    surface exit 2 — it does not swallow or remap the lock semantics."""
+    def fake_start(**kwargs):
+        raise SystemExit(2)
+
+    legacy_start = SimpleNamespace(callback=fake_start)
+    legacy_demo = SimpleNamespace(commands={"start": legacy_start})
+    legacy_cli = SimpleNamespace(commands={"demo": legacy_demo})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["demo", "start", "-y"])
+    assert result.exit_code == 2
+
+
+def test_v2_demo_stop_delegates_force_flag():
+    captured = {}
+
+    def fake_stop(**kwargs):
+        captured.update(kwargs)
+        raise SystemExit(0)
+
+    legacy_stop = SimpleNamespace(callback=fake_stop)
+    legacy_demo = SimpleNamespace(commands={"stop": legacy_stop})
+    legacy_cli = SimpleNamespace(commands={"demo": legacy_demo})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["demo", "stop", "--force"])
+    assert result.exit_code == 0, result.output
+    assert captured == {"force": True}
+
+    # Parity: the legacy stop callback only takes `force`.
+    from pawai_cli.main import cli as real_cli
+    real_params = set(inspect.signature(
+        real_cli.commands["demo"].commands["stop"].callback).parameters)
+    assert set(captured) == real_params
+
+
+# ── ClickException rendering through the delegation boundary ──────────────────
+
+def test_v2_click_exception_renders_and_exits_1():
+    import click
+
+    def fake_logs(**kwargs):
+        raise click.ClickException("module unknown: bogus")
+
+    legacy = SimpleNamespace(callback=fake_logs)
+    legacy_cli = SimpleNamespace(commands={"logs": legacy})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["logs", "bogus"])
+    assert result.exit_code == 1
+    assert "module unknown: bogus" in result.output
+
+
+def test_v2_abort_renders_and_exits_1():
+    import click
+
+    def fake_stop(**kwargs):
+        raise click.exceptions.Abort()
+
+    legacy_stop = SimpleNamespace(callback=fake_stop)
+    legacy_demo = SimpleNamespace(commands={"stop": legacy_stop})
+    legacy_cli = SimpleNamespace(commands={"demo": legacy_demo})
+    with patch("pawai_cli.main.cli", legacy_cli):
+        result = _invoke(["demo", "stop"])
+    assert result.exit_code == 1
+    assert "Aborted" in result.output
+
+
+# ── legacy `pawai` remains byte-identical (additive guarantee) ───────────────
+
+def test_legacy_pawai_entry_unchanged_and_lacks_v2_commands():
+    """The legacy Click `pawai` must NOT have grown a `nav-static` smoke or any
+    v2-only surface — v2 is a separate binary, not a mutation of legacy."""
+    from pawai_cli.main import cli as legacy_cli
+
+    smoke = legacy_cli.commands["smoke"]
+    # Legacy keeps `nav` (with --static), NOT a renamed `nav-static`.
+    assert "nav" in smoke.commands
+    assert "nav-static" not in smoke.commands
+    # Legacy entry callback is still the original group.
+    assert legacy_cli.name == "cli" or legacy_cli.name is None


### PR DESCRIPTION
Pre-6/18 CLI v2 第一批。**舊 `pawai` byte-identical**(只動 pyproject 加 pawai2 entry + [v2] optional extra)。

新 `pawai2`: doctor/status/logs/smoke(brain/object/nav-static)/evidence pull/demo start-stop，全走 _delegate() 呼叫既有 Click callback，**不重寫 lock/deploy/cleanup**。PowerShell native→WSL2 導流。
Tests: 26 v2 + parity(demo start/stop kwargs 與 legacy 1:1)；typer 用 importorskip guard(CI 無 typer 則 skip，base install 零新依賴)。
**非 demo 載重**(demo 仍走舊 CLI)，rollback=舊 pawai 永遠在。

🤖 Generated with [Claude Code](https://claude.com/claude-code)