### PR TITLE
fix(brain): object_remark_priority dynamic_typing so runtime STRING_ARRAY set works

### DIFF
--- a/interaction_executive/interaction_executive/brain_node.py
+++ b/interaction_executive/interaction_executive/brain_node.py
@@ -862,9 +862,14 @@ class BrainNode(Node):
         # [cup,bottle,bowl,wine_glass] so the drink remark wins over background
         # clutter (cell_phone/chair). Empty [] needs the same explicit
         # STRING_ARRAY descriptor.
+        # dynamic_typing: an empty-list default `[]` makes rclpy infer BYTE_ARRAY
+        # and silently defeats a fixed STRING_ARRAY descriptor (runtime `param set`
+        # then fails "expected BYTE_ARRAY"; 2026-06-14 HITL). dynamic_typing=True
+        # keeps the initialized `[]` default (startup read stays exception-free =
+        # off) yet allows setting a string array at runtime.
         self.declare_parameter(
             "object_remark_priority", [],
-            ParameterDescriptor(type=_RclParameter.Type.STRING_ARRAY.value),
+            ParameterDescriptor(dynamic_typing=True),
         )
         # B2 (2026-06-14): minimum attention level that lets object_remark speak.
         # "ENGAGED" (default) = byte-identical (gate stays "only when ENGAGED").


### PR DESCRIPTION
**Live HITL 2026-06-14 抓到的 #183 bug。** merged #183 用空 list 預設 `[]` + STRING_ARRAY descriptor 宣告 object_remark_priority,但 rclpy 從 `[]` 值推 BYTE_ARRAY、蓋過 descriptor → runtime `ros2 param set` 失敗「expected BYTE_ARRAY」→ S3 cup 優先序根本開不起來。

修：`dynamic_typing=True`(保留初始化的 `[]` 預設 → 啟動讀取不 raise = off;但允許 runtime 設成 string array)。試過 declare-by-type 但 rclpy NOT_SET param 的 get_parameter().value 會 raise ParameterUninitializedException,故用 dynamic_typing。

**已實機驗證**(Jetson deploy + restart):`ros2 param set /brain_node object_remark_priority "['cup','bottle','bowl','wine_glass']"` → param get 回 String values ✅。
Tests: test_brain_node.py 45 pass、pre-commit 156 pass。default 仍 `[]` = byte-identical。

🤖 Generated with [Claude Code](https://claude.com/claude-code)